### PR TITLE
fix sync contractset autopilot config

### DIFF
--- a/.changeset/late-shirts-hug.md
+++ b/.changeset/late-shirts-hug.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed an issue with automatically updating the default contract set when configuring autopilot before setting the default contract set.

--- a/apps/renterd/components/Autopilot/index.tsx
+++ b/apps/renterd/components/Autopilot/index.tsx
@@ -43,6 +43,7 @@ export function Autopilot() {
     config: {
       swr: {
         revalidateOnFocus: false,
+        errorRetryCount: 0,
       },
     },
   })

--- a/apps/renterd/components/Autopilot/useSyncContractSet.tsx
+++ b/apps/renterd/components/Autopilot/useSyncContractSet.tsx
@@ -15,12 +15,18 @@ export function useSyncContractSet() {
     useLocalStorageState<boolean>('v0/autopilot/syncDefaultContractSet', {
       defaultValue: true,
     })
-  const contractSet = useContractSetSettings()
+  const contractSet = useContractSetSettings({
+    config: {
+      swr: {
+        errorRetryCount: 0,
+      },
+    },
+  })
   const settingUpdate = useSettingUpdate()
 
   const syncDefaultContractSet = useCallback(
     async (autopilotContractSet: string) => {
-      const csd = contractSet.data
+      const csd = contractSet.data || { default: '' }
       try {
         if (
           shouldSyncDefaultContractSet &&

--- a/libs/design-system/src/data/webLinks.ts
+++ b/libs/design-system/src/data/webLinks.ts
@@ -20,9 +20,9 @@ export const webLinks = {
   },
   design: 'https://design.sia.tech',
   apiDocs: {
-    siad: 'https://api.sia.tech',
     renterd: 'https://api.sia.tech/renterd',
     hostd: 'https://api.sia.tech/hostd',
+    walletd: 'https://api.sia.tech/walletd',
   },
   // forum: 'https://forum.sia.tech',
   github: {


### PR DESCRIPTION
- Fixed an issue with automatically updating the default contract set when configuring autopilot before setting the default contract set. https://github.com/SiaFoundation/renterd/issues/503