### PR TITLE
hostd metrics remember user-selected datum modes

### DIFF
--- a/.changeset/long-bugs-add.md
+++ b/.changeset/long-bugs-add.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Metrics datum modes (average, latest, total) selected by the user are now remembered.

--- a/apps/hostd/components/Home/HomeBandwidth.tsx
+++ b/apps/hostd/components/Home/HomeBandwidth.tsx
@@ -15,6 +15,7 @@ export function HomeBandwidth() {
       <Heading>Bandwidth</Heading>
       <DatumScrollArea>
         <DatumCardConfigurable
+          category="bandwidth"
           label="ingress"
           color={bandwidth.config.data['ingress'].color}
           value={bandwidth.stats['ingress']}
@@ -23,6 +24,7 @@ export function HomeBandwidth() {
           format={humanBytes}
         />
         <DatumCardConfigurable
+          category="bandwidth"
           label="egress"
           color={bandwidth.config.data['egress'].color}
           value={bandwidth.stats['egress']}

--- a/apps/hostd/components/Home/HomeCollateral.tsx
+++ b/apps/hostd/components/Home/HomeCollateral.tsx
@@ -15,6 +15,7 @@ export function HomeCollateral() {
       <Heading>Collateral</Heading>
       <DatumScrollArea bleed>
         <DatumCardConfigurable
+          category="collateral"
           label="Locked collateral"
           color={collateral.config.data['locked'].color}
           sc={collateral.stats['locked']}
@@ -23,6 +24,7 @@ export function HomeCollateral() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="collateral"
           label="Risked collateral"
           color={collateral.config.data['risked'].color}
           sc={collateral.stats['risked']}

--- a/apps/hostd/components/Home/HomeContracts.tsx
+++ b/apps/hostd/components/Home/HomeContracts.tsx
@@ -15,6 +15,7 @@ export function HomeContracts() {
       <Heading>Contracts</Heading>
       <DatumScrollArea bleed>
         <DatumCardConfigurable
+          category="contracts"
           label="Active contracts"
           color={contracts.config.data['active'].color}
           value={contracts.stats['active']}
@@ -24,6 +25,7 @@ export function HomeContracts() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="contracts"
           label="Successful contracts"
           color={contracts.config.data['successful'].color}
           value={contracts.stats['successful']}
@@ -33,6 +35,7 @@ export function HomeContracts() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="contracts"
           label="Failed contracts"
           color={contracts.config.data['failed'].color}
           value={contracts.stats['failed']}

--- a/apps/hostd/components/Home/HomeOperations.tsx
+++ b/apps/hostd/components/Home/HomeOperations.tsx
@@ -16,6 +16,7 @@ export function HomeOperations() {
         <Heading>Operations</Heading>
         <DatumScrollArea>
           <DatumCardConfigurable
+            category="operations"
             label="storage reads"
             color={operations.config.data['storageReads'].color}
             value={operations.stats['storageReads']}
@@ -25,6 +26,7 @@ export function HomeOperations() {
             format={humanNumber}
           />
           <DatumCardConfigurable
+            category="operations"
             label="storage writes"
             color={operations.config.data['storageWrites'].color}
             value={operations.stats['storageWrites']}
@@ -34,6 +36,7 @@ export function HomeOperations() {
             format={humanNumber}
           />
           <DatumCardConfigurable
+            category="operations"
             label="registry reads"
             color={operations.config.data['registryReads'].color}
             value={operations.stats['registryReads']}
@@ -43,6 +46,7 @@ export function HomeOperations() {
             format={humanNumber}
           />
           <DatumCardConfigurable
+            category="operations"
             label="registry writes"
             color={operations.config.data['registryWrites'].color}
             value={operations.stats['registryWrites']}

--- a/apps/hostd/components/Home/HomePricing.tsx
+++ b/apps/hostd/components/Home/HomePricing.tsx
@@ -23,6 +23,7 @@ export function HomePricing() {
       <Heading>Pricing</Heading>
       <DatumScrollArea bleed>
         <DatumCardConfigurable
+          category="pricing"
           label="storage"
           color={pricing.config.data['storage'].color}
           sc={pricing.stats['storage']}
@@ -32,6 +33,7 @@ export function HomePricing() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="pricing"
           label="ingress"
           color={pricing.config.data['ingress'].color}
           sc={pricing.stats['ingress']}
@@ -41,6 +43,7 @@ export function HomePricing() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="pricing"
           label="egress"
           color={pricing.config.data['egress'].color}
           sc={pricing.stats['egress']}
@@ -50,6 +53,7 @@ export function HomePricing() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="pricing"
           label="collateral"
           color={pricing.config.data['collateral'].color}
           sc={pricing.stats['collateral']}
@@ -59,6 +63,7 @@ export function HomePricing() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="pricing"
           label="contract"
           color={pricing.config.data['contract'].color}
           sc={pricing.stats['contract']}
@@ -67,6 +72,7 @@ export function HomePricing() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="pricing"
           label="sector access"
           color={pricing.config.data['sectorAccess'].color}
           sc={pricing.stats['sectorAccess']}
@@ -76,6 +82,7 @@ export function HomePricing() {
           enabledModes={['latest', 'average']}
         />
         <DatumCardConfigurable
+          category="pricing"
           label="base RPC"
           color={pricing.config.data['baseRPC'].color}
           sc={pricing.stats['baseRPC']}

--- a/apps/hostd/components/Home/HomeRevenue.tsx
+++ b/apps/hostd/components/Home/HomeRevenue.tsx
@@ -15,6 +15,7 @@ export function HomeRevenue() {
       <Heading>Revenue</Heading>
       <DatumScrollArea bleed>
         <DatumCardConfigurable
+          category="revenue"
           label="earned revenue"
           color={revenue.config.data['earned'].color}
           sc={revenue.stats['earned']}
@@ -22,6 +23,7 @@ export function HomeRevenue() {
           isLoading={revenue.isLoading}
         />
         <DatumCardConfigurable
+          category="revenue"
           label="potential revenue"
           color={revenue.config.data['potential'].color}
           sc={revenue.stats['potential']}
@@ -30,6 +32,7 @@ export function HomeRevenue() {
           showChange={false}
         />
         <DatumCardConfigurable
+          category="revenue"
           label="storage"
           color={revenue.config.data['storage'].color}
           sc={revenue.stats['storage']}
@@ -37,6 +40,7 @@ export function HomeRevenue() {
           isLoading={revenue.isLoading}
         />
         <DatumCardConfigurable
+          category="revenue"
           label="egress"
           color={revenue.config.data['egress'].color}
           sc={revenue.stats['egress']}
@@ -44,6 +48,7 @@ export function HomeRevenue() {
           isLoading={revenue.isLoading}
         />
         <DatumCardConfigurable
+          category="revenue"
           label="ingress"
           color={revenue.config.data['ingress'].color}
           sc={revenue.stats['ingress']}
@@ -51,6 +56,7 @@ export function HomeRevenue() {
           isLoading={revenue.isLoading}
         />
         <DatumCardConfigurable
+          category="revenue"
           label="registry read"
           color={revenue.config.data['registryRead'].color}
           sc={revenue.stats['registryRead']}
@@ -58,6 +64,7 @@ export function HomeRevenue() {
           isLoading={revenue.isLoading}
         />
         <DatumCardConfigurable
+          category="revenue"
           label="registry write"
           color={revenue.config.data['registryWrite'].color}
           sc={revenue.stats['registryWrite']}

--- a/apps/hostd/components/Home/HomeStorage.tsx
+++ b/apps/hostd/components/Home/HomeStorage.tsx
@@ -15,6 +15,7 @@ export function HomeStorage() {
       <Heading>Storage</Heading>
       <DatumScrollArea>
         <DatumCardConfigurable
+          category="storage"
           label="storage (physical)"
           color={storage.config.data['physicalSectors'].color}
           value={storage.stats['physicalSectors']}
@@ -24,6 +25,7 @@ export function HomeStorage() {
           format={humanBytes}
         />
         <DatumCardConfigurable
+          category="storage"
           label="registry"
           color={storage.config.data['registryEntries'].color}
           value={storage.stats['registryEntries']}

--- a/libs/design-system/src/app/DatumCardConfigurable.tsx
+++ b/libs/design-system/src/app/DatumCardConfigurable.tsx
@@ -5,12 +5,13 @@ import { ValueNum } from '../components/ValueNum'
 import { ValueSc } from '../components/ValueSc'
 import { DataLabel } from './DataLabel'
 import BigNumber from 'bignumber.js'
-import { useState } from 'react'
 import { Tooltip } from '../core/Tooltip'
+import useLocalStorageState from 'use-local-storage-state'
 
 type Mode = 'total' | 'average' | 'latest'
 
 type Props = {
+  category: string
   label: string
   color?: string
   sc?: {
@@ -42,6 +43,7 @@ const modeMap = {
 }
 
 export function DatumCardConfigurable({
+  category,
   label,
   color,
   sc,
@@ -53,7 +55,12 @@ export function DatumCardConfigurable({
   isLoading,
   showChange = true,
 }: Props) {
-  const [mode, setMode] = useState<Mode>(defaultMode)
+  const [mode, setMode] = useLocalStorageState<Mode>(
+    `v0/datum/${category}/${label}`,
+    {
+      defaultValue: defaultMode,
+    }
+  )
   return (
     <DatumCard
       isLoading={isLoading}


### PR DESCRIPTION
- Metrics datum modes (average, latest, total) selected by the user are now remembered. https://github.com/SiaFoundation/hostd/issues/118