### PR TITLE
renterd upload packing, host explorer fix, host egress usage

### DIFF
--- a/.changeset/few-pans-pump.md
+++ b/.changeset/few-pans-pump.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The host explorer now works before autopilot is configured, the table shows the autopilot columns with empty values and tooltips explaining that autopilot is not configured.

--- a/.changeset/giant-lamps-accept.md
+++ b/.changeset/giant-lamps-accept.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Upload packing can now be enabled from the configuration tab.

--- a/.changeset/metal-poems-smoke.md
+++ b/.changeset/metal-poems-smoke.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The contracts table now has an egress usage column.

--- a/.changeset/serious-poems-drum.md
+++ b/.changeset/serious-poems-drum.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The file stats do not show redundancy factor or health until there is at least 1 byte of data.

--- a/.changeset/sour-pugs-fetch.md
+++ b/.changeset/sour-pugs-fetch.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed a crash issue when loading the hosts explorer.

--- a/.changeset/weak-books-exercise.md
+++ b/.changeset/weak-books-exercise.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Wallet balance is now more accurately calculated as spendable + unconfirmed.

--- a/apps/hostd/contexts/contracts/columns.tsx
+++ b/apps/hostd/contexts/contracts/columns.tsx
@@ -248,6 +248,15 @@ export const columns: ContractsTableColumn[] = (
       ),
     },
     {
+      id: 'usageEgress',
+      label: 'egress usage',
+      category: 'financial',
+      contentClassName: 'w-[120px] justify-end',
+      render: ({ data: { usage } }) => (
+        <ValueSc size="12" value={usage.egress} />
+      ),
+    },
+    {
       id: 'usageAccountFunding',
       label: 'account funding usage',
       category: 'financial',

--- a/apps/renterd/components/Config/fields.tsx
+++ b/apps/renterd/components/Config/fields.tsx
@@ -17,6 +17,10 @@ export const defaultContractSet = {
   contractSet: '',
 }
 
+export const defaultUploadPacking = {
+  uploadPackingEnabled: false,
+}
+
 export const defaultConfigApp = {
   includeRedundancyMaxStoragePrice: true,
   includeRedundancyMaxUploadPrice: true,
@@ -43,6 +47,8 @@ export const defaultRedundancy = {
 export const defaultValues = {
   // contract set
   ...defaultContractSet,
+  // upload packing
+  ...defaultUploadPacking,
   // gouging
   ...defaultGouging,
   // redundancy
@@ -52,12 +58,13 @@ export const defaultValues = {
 }
 
 export type ContractSetData = typeof defaultContractSet
+export type UploadPackingData = typeof defaultUploadPacking
 export type ConfigAppData = typeof defaultConfigApp
 export type GougingData = typeof defaultGouging
 export type RedundancyData = typeof defaultRedundancy
 export type SettingsData = typeof defaultValues
 
-type Categories = 'contractset' | 'gouging' | 'redundancy'
+type Categories = 'contractset' | 'uploadpacking' | 'gouging' | 'redundancy'
 
 type GetFields = {
   redundancyMultiplier: BigNumber
@@ -98,6 +105,25 @@ export function getFields({
       validation: {
         required: 'required',
       },
+    },
+    uploadPackingEnabled: {
+      category: 'uploadpacking',
+      type: 'boolean',
+      title: 'Upload packing',
+      description: (
+        <>
+          Data on the Sia network is stored in 40MiB sectors so by default
+          uploaded files are divided and padded into these 40MiB peices. This
+          means that storage is wasted on padding but more importantly files
+          smaller than 40MiB still use 40MiB of space. Upload packing avoids
+          this waste by buffering files and packing them together before they
+          are uploaded to the network. This trades some performance for storage
+          efficiency. It is also important to note that because buffered files
+          are temporarily stored on disk they must be considered when backing up
+          your renterd data.
+        </>
+      ),
+      validation: {},
     },
     // gouging
     maxStoragePrice: {
@@ -348,6 +374,7 @@ export function getFields({
         },
       },
     },
+    // hidden fields used by other config options
     includeRedundancyMaxStoragePrice: {
       type: 'boolean',
       title: 'Include redundancy',

--- a/apps/renterd/components/Config/transform.spec.ts
+++ b/apps/renterd/components/Config/transform.spec.ts
@@ -11,6 +11,7 @@ describe('data transforms', () => {
     expect(
       transformDown(
         { default: 'myset' },
+        { enabled: true },
         {
           hostBlockHeightLeeway: 4,
           maxContractPrice: '20000000000000000000000000',
@@ -34,6 +35,7 @@ describe('data transforms', () => {
       )
     ).toEqual({
       contractSet: 'myset',
+      uploadPackingEnabled: true,
       hostBlockHeightLeeway: new BigNumber(4),
       maxContractPrice: new BigNumber('20'),
       maxDownloadPrice: new BigNumber('1004.31'),
@@ -55,6 +57,7 @@ describe('data transforms', () => {
     expect(
       transformDown(
         { default: 'myset' },
+        { enabled: true },
         {
           hostBlockHeightLeeway: 4,
           maxContractPrice: '20000000000000000000000000',
@@ -78,6 +81,7 @@ describe('data transforms', () => {
       )
     ).toEqual({
       contractSet: 'myset',
+      uploadPackingEnabled: true,
       hostBlockHeightLeeway: new BigNumber(4),
       maxContractPrice: new BigNumber('20'),
       maxDownloadPrice: new BigNumber('1004.31'),
@@ -117,6 +121,7 @@ describe('data transforms', () => {
       transformUpGouging(
         {
           contractSet: 'myset',
+          uploadPackingEnabled: false,
           hostBlockHeightLeeway: new BigNumber(4),
           maxContractPrice: new BigNumber('20'),
           maxDownloadPrice: new BigNumber('1004.31'),
@@ -157,6 +162,7 @@ describe('data transforms', () => {
       transformUpGouging(
         {
           contractSet: 'myset',
+          uploadPackingEnabled: false,
           hostBlockHeightLeeway: new BigNumber(4),
           maxContractPrice: new BigNumber('20'),
           maxDownloadPrice: new BigNumber('1004.31'),

--- a/apps/renterd/components/Config/transform.ts
+++ b/apps/renterd/components/Config/transform.ts
@@ -10,6 +10,7 @@ import {
   ContractSetSettings,
   GougingSettings,
   RedundancySettings,
+  UploadPackingSettings,
 } from '@siafoundation/react-renterd'
 import { toHastings, toSiacoins } from '@siafoundation/sia-js'
 import { ConfigDisplayOptions } from '../../hooks/useConfigDisplayOptions'
@@ -23,6 +24,7 @@ import {
   RedundancyData,
   scDecimalPlaces,
   SettingsData,
+  UploadPackingData,
 } from './fields'
 
 // up
@@ -34,6 +36,16 @@ export function transformUpContractSet(
   return {
     ...existingValues,
     default: values.contractSet,
+  }
+}
+
+export function transformUpUploadPacking(
+  values: UploadPackingData,
+  existingValues: Record<string, unknown>
+): UploadPackingSettings {
+  return {
+    ...existingValues,
+    enabled: values.uploadPackingEnabled,
   }
 }
 
@@ -116,6 +128,14 @@ export function transformDownContractSet(
   }
 }
 
+export function transformDownUploadPacking(
+  u: UploadPackingSettings
+): UploadPackingData {
+  return {
+    uploadPackingEnabled: u.enabled,
+  }
+}
+
 export function transformDownConfigApp(
   ca?: ConfigDisplayOptions
 ): ConfigAppData {
@@ -182,6 +202,7 @@ export function transformDownRedundancy(r: RedundancySettings): RedundancyData {
 
 export function transformDown(
   c: ContractSetSettings | undefined,
+  u: UploadPackingSettings,
   g: GougingSettings,
   r: RedundancySettings,
   ca: ConfigDisplayOptions | undefined
@@ -191,6 +212,8 @@ export function transformDown(
   return {
     // contractset
     ...transformDownContractSet(c),
+    // uploadpacking
+    ...transformDownUploadPacking(u),
     // gouging
     ...transformDownGouging(g, redundancy, configApp),
     // redundancy

--- a/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuHealth.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuHealth.tsx
@@ -30,6 +30,10 @@ export function FilesStatsMenuHealth() {
     isDirectory: true,
   })
 
+  if (!obj.data?.entries || obj.data.entries.length === 0) {
+    return null
+  }
+
   return (
     <Tooltip
       align="end"

--- a/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuSize.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuSize.tsx
@@ -18,6 +18,10 @@ export function FilesStatsMenuSize() {
     return null
   }
 
+  const averageRedundancyFactor = stats.data.totalObjectsSize
+    ? stats.data.totalSectorsSize / stats.data.totalObjectsSize
+    : 0
+
   return (
     <Tooltip
       side="bottom"
@@ -30,9 +34,11 @@ export function FilesStatsMenuSize() {
             <Text size="12" color="subtle">
               with redundancy
             </Text>
-            <Text size="12" color="subtle">
-              average redundancy factor
-            </Text>
+            {!!averageRedundancyFactor && (
+              <Text size="12" color="subtle">
+                average redundancy factor
+              </Text>
+            )}
             <Separator className="w-full my-1" />
             <Text size="12" color="subtle">
               reclaimable space
@@ -44,12 +50,11 @@ export function FilesStatsMenuSize() {
           <Text className="flex flex-col gap-1 items-end">
             <Text size="12">{humanBytes(stats.data.totalObjectsSize)}</Text>
             <Text size="12">{humanBytes(stats.data.totalSectorsSize)}</Text>
-            <Text size="12" font="mono">
-              {(
-                stats.data.totalSectorsSize / stats.data.totalObjectsSize
-              ).toFixed(1)}
-              x
-            </Text>
+            {!!averageRedundancyFactor && (
+              <Text size="12" font="mono">
+                {averageRedundancyFactor.toFixed(1)}x
+              </Text>
+            )}
             <Separator className="w-full my-1" />
             <Text size="12">
               {humanBytes(
@@ -62,9 +67,11 @@ export function FilesStatsMenuSize() {
       }
     >
       <Text size="12" font="mono">
-        {humanBytes(stats.data.totalObjectsSize)} @{' '}
-        {(stats.data.totalSectorsSize / stats.data.totalObjectsSize).toFixed(1)}
-        x
+        {`${humanBytes(stats.data.totalObjectsSize)}${
+          averageRedundancyFactor
+            ? ` @ ${averageRedundancyFactor.toFixed(1)}x`
+            : ''
+        }`}
       </Text>
     </Tooltip>
   )

--- a/apps/renterd/components/Hosts/StateEmpty.tsx
+++ b/apps/renterd/components/Hosts/StateEmpty.tsx
@@ -4,34 +4,13 @@ import {
   HardDriveIcon,
   LinkButton,
   MisuseOutline32,
-  PlaneIcon,
   Text,
 } from '@siafoundation/design-system'
-import { useApp } from '../../contexts/app'
 import { routes } from '../../config/routes'
 import { useHosts } from '../../contexts/hosts'
 
 export function StateEmpty() {
-  const { autopilot } = useApp()
   const { dataState } = useHosts()
-
-  if (autopilot.state === 'on' && !autopilot.status.data?.configured) {
-    return (
-      <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
-        <Text>
-          <PlaneIcon className="scale-[200%]" />
-        </Text>
-        <div className="flex flex-col gap-3 items-center">
-          <Text color="subtle" className="text-center max-w-[500px]">
-            Autopilot must be configured before using the hosts explorer.
-          </Text>
-          <LinkButton href={routes.autopilot.index}>
-            Configure autopilot
-          </LinkButton>
-        </div>
-      </div>
-    )
-  }
 
   if (dataState === 'error') {
     return (

--- a/apps/renterd/components/Hosts/index.tsx
+++ b/apps/renterd/components/Hosts/index.tsx
@@ -10,7 +10,7 @@ import { HostsFilterBar } from './HostsFilterBar'
 
 export function Hosts() {
   const { openDialog } = useDialog()
-  const { dataset, columns, limit, dataState } = useHosts()
+  const { dataset, columns, limit, dataState, tableContext } = useHosts()
 
   return (
     <RenterdAuthedLayout
@@ -26,6 +26,7 @@ export function Hosts() {
         <Table
           isLoading={dataState === 'loading'}
           emptyState={<StateEmpty />}
+          context={tableContext}
           pageSize={limit}
           data={dataset}
           columns={columns}

--- a/apps/renterd/components/RenterdAuthedLayout.tsx
+++ b/apps/renterd/components/RenterdAuthedLayout.tsx
@@ -24,7 +24,9 @@ export function RenterdAuthedLayout(
       connectivityRoute={connectivityRoute}
       isSynced={isSynced}
       walletBalance={
-        wallet.data ? new BigNumber(wallet.data.confirmed) : undefined
+        wallet.data
+          ? new BigNumber(wallet.data.spendable).plus(wallet.data.unconfirmed)
+          : undefined
       }
       {...props}
     />

--- a/apps/renterd/components/Wallet/index.tsx
+++ b/apps/renterd/components/Wallet/index.tsx
@@ -112,7 +112,13 @@ export function Wallet() {
           isWalletSynced={isWalletSynced}
           syncPercent={syncPercent}
           walletScanPercent={walletScanPercent}
-          sc={wallet.data ? new BigNumber(wallet.data.confirmed) : undefined}
+          sc={
+            wallet.data
+              ? new BigNumber(wallet.data.spendable).plus(
+                  wallet.data.unconfirmed
+                )
+              : undefined
+          }
           receiveSiacoin={() => openDialog('addressDetails')}
           sendSiacoin={() => openDialog('sendSiacoin')}
         />

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -27,7 +27,11 @@ import {
 import BigNumber from 'bignumber.js'
 import React from 'react'
 
-type HostsTableColumn = TableColumn<TableColumnId, HostData, void> & {
+type HostsTableColumn = TableColumn<
+  TableColumnId,
+  HostData,
+  { isAutopilotConfigured: boolean }
+> & {
   fixed?: boolean
   category: string
 }
@@ -118,37 +122,61 @@ export const columns: HostsTableColumn[] = (
       id: 'ap_usable',
       label: 'usable',
       category: 'autopilot',
-      render: ({ data }) => (
-        <Tooltip
-          side="right"
-          content={data.usable ? 'Host is usable' : 'Host is not usable'}
-        >
-          <div className="flex gap-2 items-center">
-            <div className="mt-[5px]">
-              <Text color={data.usable ? 'green' : 'red'}>
-                {data.usable ? (
-                  <CheckboxCheckedFilled16 />
-                ) : (
-                  <WarningSquareFilled16 />
-                )}
-              </Text>
-            </div>
-            <div className="flex flex-col">
-              {data.unusableReasons.map((reason) => (
-                <Text key={reason} size="10" noWrap>
-                  {reason}
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip side="right" content="Autopilot is not configured">
+              <div className="mt-[5px]">
+                <Text color="subtle">
+                  <UndefinedFilled16 />
                 </Text>
-              ))}
+              </div>
+            </Tooltip>
+          )
+        }
+        return (
+          <Tooltip
+            side="right"
+            content={data.usable ? 'Host is usable' : 'Host is not usable'}
+          >
+            <div className="flex gap-2 items-center">
+              <div className="mt-[5px]">
+                <Text color={data.usable ? 'green' : 'red'}>
+                  {data.usable ? (
+                    <CheckboxCheckedFilled16 />
+                  ) : (
+                    <WarningSquareFilled16 />
+                  )}
+                </Text>
+              </div>
+              <div className="flex flex-col">
+                {data.unusableReasons.map((reason) => (
+                  <Text key={reason} size="10" noWrap>
+                    {reason}
+                  </Text>
+                ))}
+              </div>
             </div>
-          </div>
-        </Tooltip>
-      ),
+          </Tooltip>
+        )
+      },
     },
     {
       id: 'ap_gouging',
       label: 'gouging',
       category: 'autopilot',
-      render: ({ data }) => {
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip side="right" content="Autopilot is not configured">
+              <div className="mt-[5px]">
+                <Text color="subtle">
+                  <UndefinedFilled16 />
+                </Text>
+              </div>
+            </Tooltip>
+          )
+        }
         return (
           <Tooltip
             side="right"
@@ -428,112 +456,186 @@ export const columns: HostsTableColumn[] = (
       label: 'overall score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.score}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.score}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scoreAge',
       label: 'age score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.age}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.age}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scoreCollateral',
       label: 'collateral score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.collateral}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.collateral}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scoreInteractions',
       label: 'interactions score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.interactions}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.interactions}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scorePrices',
       label: 'prices score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.prices}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.prices}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scoreStorageRemaining',
       label: 'storage remaining score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.storageRemaining}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.storageRemaining}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scoreUptime',
       label: 'uptime score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.uptime}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.uptime}
+            variant="value"
+            format={(v) => v.toPrecision(2)}
+          />
+        )
+      },
     },
     {
       id: 'ap_scoreVersion',
       label: 'version score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data }) => (
-        <ValueNum
-          size="12"
-          value={data.scoreBreakdown.version}
-          variant="value"
-          format={(v) => v.toPrecision(2)}
-        />
-      ),
+      render: ({ data, context }) => {
+        if (!context.isAutopilotConfigured) {
+          return (
+            <Tooltip content="Autopilot is not configured">
+              <Text color="verySubtle">-</Text>
+            </Tooltip>
+          )
+        }
+        return (
+          <ValueNum
+            size="12"
+            value={data.scoreBreakdown.version}
+            variant="value"
+            format={(v) =>
+              context.isAutopilotConfigured ? '-' : v.toPrecision(2)
+            }
+          />
+        )
+      },
     },
     // price table
     {

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -55,7 +55,7 @@ export function useDataset({
               blocklist: blocklist.data,
               isAllowlistActive,
             }),
-            ...getAutopilotFields(ah),
+            ...getAutopilotFields(ah.checks),
           }
         }) || null
       )
@@ -133,7 +133,7 @@ function getAllowedFields({
   }
 }
 
-function getAutopilotFields(ah?: {
+function getAutopilotFields(ahc?: {
   score: number
   gougingBreakdown: {
     v2: {
@@ -163,22 +163,24 @@ function getAutopilotFields(ah?: {
   usable: boolean
 }) {
   return {
-    score: new BigNumber(ah?.score || 0),
+    score: new BigNumber(ahc?.score || 0),
     scoreBreakdown: {
-      age: new BigNumber(ah?.scoreBreakdown.age || 0),
-      collateral: new BigNumber(ah?.scoreBreakdown.collateral || 0),
-      interactions: new BigNumber(ah?.scoreBreakdown.interactions || 0),
-      prices: new BigNumber(ah?.scoreBreakdown.prices || 0),
-      storageRemaining: new BigNumber(ah?.scoreBreakdown.storageRemaining || 0),
-      uptime: new BigNumber(ah?.scoreBreakdown.uptime || 0),
-      version: new BigNumber(ah?.scoreBreakdown.version || 0),
+      age: new BigNumber(ahc?.scoreBreakdown.age || 0),
+      collateral: new BigNumber(ahc?.scoreBreakdown.collateral || 0),
+      interactions: new BigNumber(ahc?.scoreBreakdown.interactions || 0),
+      prices: new BigNumber(ahc?.scoreBreakdown.prices || 0),
+      storageRemaining: new BigNumber(
+        ahc?.scoreBreakdown.storageRemaining || 0
+      ),
+      uptime: new BigNumber(ahc?.scoreBreakdown.uptime || 0),
+      version: new BigNumber(ahc?.scoreBreakdown.version || 0),
     },
-    gougingBreakdown: ah?.gougingBreakdown || {
+    gougingBreakdown: ahc?.gougingBreakdown || {
       v2: {},
       v3: {},
     },
-    gouging: ah?.gouging,
-    unusableReasons: ah?.unusableReasons || [],
-    usable: ah?.usable,
+    gouging: ahc?.gouging,
+    unusableReasons: ahc?.unusableReasons || [],
+    usable: ahc?.usable,
   }
 }

--- a/apps/renterd/contexts/hosts/index.tsx
+++ b/apps/renterd/contexts/hosts/index.tsx
@@ -130,6 +130,14 @@ function useHostsMain() {
     autopilot.state === 'on' ? autopilotResponse.error : regularResponse.error
   const dataState = useDatasetEmptyState(dataset, isValidating, error, filters)
 
+  const isAutopilotConfigured = autopilot.status.data?.configured
+  const tableContext = useMemo(
+    () => ({
+      isAutopilotConfigured,
+    }),
+    [isAutopilotConfigured]
+  )
+
   return {
     error,
     dataState,
@@ -138,6 +146,7 @@ function useHostsMain() {
     pageCount: dataset?.length || 0,
     columns: filteredTableColumns,
     dataset,
+    tableContext,
     configurableColumns,
     enabledColumns,
     toggleColumnVisibility,

--- a/apps/renterd/hooks/useUploadPackingSettings.tsx
+++ b/apps/renterd/hooks/useUploadPackingSettings.tsx
@@ -1,0 +1,11 @@
+import { HookArgsSwr } from '@siafoundation/react-core'
+import { UploadPackingSettings, useSetting } from '@siafoundation/react-renterd'
+
+export function useUploadPackingSettings(
+  args?: HookArgsSwr<void, UploadPackingSettings>
+) {
+  return useSetting<UploadPackingSettings>({
+    ...args,
+    params: { key: 'uploadpacking' },
+  })
+}

--- a/libs/design-system/src/components/Table.tsx
+++ b/libs/design-system/src/components/Table.tsx
@@ -99,7 +99,7 @@ export function Table<
           className={cx(
             'sticky top-0 z-20 bg-white dark:bg-graydark-200',
             'border-b border-gray-400 dark:border-graydark-400',
-            'shadow-border shadow-gray-400 dark:shadow-graydark-400'
+            'shadow-border-b shadow-gray-400 dark:shadow-graydark-400'
           )}
         >
           <tr>

--- a/libs/design-system/src/config/theme.js
+++ b/libs/design-system/src/config/theme.js
@@ -19,6 +19,7 @@ module.exports = {
       colors,
       boxShadow: {
         border: 'inset 0 0 0 1px rgba(0, 0, 0, 0.3)',
+        'border-b': '0 1px 0 rgba(0, 0, 0, 0.3)',
         active: '0 0 0 2px rgba(0, 0, 0, 0.3)',
         focus: '0 0 0 1px rgba(0, 0, 0, 0.3)',
       },

--- a/libs/react-renterd/src/autopilot.ts
+++ b/libs/react-renterd/src/autopilot.ts
@@ -63,33 +63,35 @@ export function useAutopilotActions(
 
 export type AutopilotHost = {
   host: Host
-  score: number
-  scoreBreakdown: {
-    age: number
-    collateral: number
-    interactions: number
-    storageRemaining: number
-    prices: number
-    uptime: number
-    version: number
-  }
-  unusableReasons: string[]
-  gougingBreakdown: {
-    v2: {
-      contractErr?: string
-      downloadErr?: string
-      gougingErr?: string
-      uploadErr?: string
+  checks?: {
+    score: number
+    scoreBreakdown: {
+      age: number
+      collateral: number
+      interactions: number
+      storageRemaining: number
+      prices: number
+      uptime: number
+      version: number
     }
-    v3: {
-      contractErr?: string
-      downloadErr?: string
-      gougingErr?: string
-      uploadErr?: string
+    unusableReasons: string[]
+    gougingBreakdown: {
+      v2: {
+        contractErr?: string
+        downloadErr?: string
+        gougingErr?: string
+        uploadErr?: string
+      }
+      v3: {
+        contractErr?: string
+        downloadErr?: string
+        gougingErr?: string
+        uploadErr?: string
+      }
     }
+    gouging: boolean
+    usable: boolean
   }
-  gouging: boolean
-  usable: boolean
 }
 
 export const autopilotHostsKey = '/autopilot/hosts'

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -154,6 +154,7 @@ type WalletResponse = {
   scanHeight: number
   address: string
   confirmed: string
+  unconfirmed: string
   spendable: string
 }
 

--- a/libs/react-renterd/src/siaTypes.ts
+++ b/libs/react-renterd/src/siaTypes.ts
@@ -188,6 +188,10 @@ export type GougingSettings = {
   minMaxEphemeralAccountBalance: string
 }
 
+export type UploadPackingSettings = {
+  enabled: boolean
+}
+
 export type RedundancySettings = {
   minShards: number
   totalShards: number


### PR DESCRIPTION
### renterd
- Fixed a crash issue when loading the hosts explorer.
- The host explorer now works before autopilot is configured, the table shows the autopilot columns with empty values and tooltips explaining that autopilot is not configured.
- Upload packing can now be enabled from the configuration tab.
- Wallet balance is now more accurately calculated as spendable + unconfirmed.

### hostd
- The contracts table now has an egress usage column. https://github.com/SiaFoundation/hostd/issues/143