### PR TITLE
renterd improvements

### DIFF
--- a/.changeset/calm-chairs-flash.md
+++ b/.changeset/calm-chairs-flash.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Hosts last scan column now properly displays unscanned values rather than a very large time ago value.

--- a/.changeset/hip-ravens-happen.md
+++ b/.changeset/hip-ravens-happen.md
@@ -1,0 +1,6 @@
+---
+'renterd': minor
+'@siafoundation/design-system': minor
+---
+
+Siacoin and number input placeholders now match the suggested value.

--- a/.changeset/serious-dots-occur.md
+++ b/.changeset/serious-dots-occur.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The autopilot loop is now triggered after settings are successfully updated.

--- a/.changeset/shaggy-dodos-heal.md
+++ b/.changeset/shaggy-dodos-heal.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Files are now paginated.

--- a/.changeset/silly-bobcats-reflect.md
+++ b/.changeset/silly-bobcats-reflect.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+Removed and updated deprecated route names.

--- a/.changeset/six-mugs-march.md
+++ b/.changeset/six-mugs-march.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+Add useAutopilotTrigger.

--- a/.changeset/twenty-colts-type.md
+++ b/.changeset/twenty-colts-type.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Onboarding fund wallet step now requires >0 SC instead of a full allowance.

--- a/.changeset/wild-elephants-watch.md
+++ b/.changeset/wild-elephants-watch.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The hosts table now has a last announcement column instead of the known since column.

--- a/apps/renterd/components/Files/FilesStatsMenu/index.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenu/index.tsx
@@ -1,16 +1,23 @@
-import { Separator, Text, Tooltip } from '@siafoundation/design-system'
+import {
+  PaginatorUnknownTotal,
+  Separator,
+  Text,
+  Tooltip,
+} from '@siafoundation/design-system'
 import { Filter16, Wikis16 } from '@siafoundation/react-icons'
 import { FilesStatsMenuSize } from './FilesStatsMenuSize'
 import { FilesStatsMenuHealth } from './FilesStatsMenuHealth'
 import { FilesStatsMenuWarnings } from './FilesStatsMenuWarnings'
 import { FilesStatsMenuCount } from './FilesStatsMenuCount'
+import { useFiles } from '../../../contexts/files'
 
 export function FilesStatsMenu() {
+  const { limit, offset, pageCount, dataState, isViewingABucket } = useFiles()
   return (
-    <div className="flex gap-2 w-full">
+    <div className="flex gap-4 w-full">
       <FilesStatsMenuWarnings />
       <div className="flex-1" />
-      <div className="flex gap-3">
+      <div className="flex gap-3 items-center">
         <div className="flex gap-3">
           <Tooltip side="bottom" content="Filtered statistics">
             <Text size="12" color="verySubtle">
@@ -30,6 +37,14 @@ export function FilesStatsMenu() {
           <FilesStatsMenuHealth />
         </div>
       </div>
+      {isViewingABucket && (
+        <PaginatorUnknownTotal
+          offset={offset}
+          limit={limit}
+          pageTotal={pageCount}
+          isLoading={dataState === 'loading'}
+        />
+      )}
     </div>
   )
 }

--- a/apps/renterd/components/OnboardingBar.tsx
+++ b/apps/renterd/components/OnboardingBar.tsx
@@ -56,10 +56,7 @@ export function OnboardingBar() {
 
   const step1Configured = app.autopilot.state.data?.configured
   const step2Synced = syncStatus.isSynced
-  const step3Funded =
-    app.autopilot.state.data?.configured &&
-    wallet.data &&
-    walletBalance.gte(allowance)
+  const step3Funded = walletBalance.gt(0)
   const step4Contracts = !notEnoughContracts.active
   const steps = [step1Configured, step2Synced, step3Funded, step4Contracts]
   const totalSteps = steps.length

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -19,6 +19,7 @@ import {
   RedundancySettings,
   UploadPackingSettings,
   useSettingUpdate,
+  useAutopilotTrigger,
 } from '@siafoundation/react-renterd'
 import { toSiacoins } from '@siafoundation/sia-js'
 import { getFields } from './fields'
@@ -389,6 +390,7 @@ export function useConfigMain() {
     return totalCostPerMonthTB
   }, [canEstimate, estimatedSpendingPerMonth, storageTB])
 
+  const autopilotTrigger = useAutopilotTrigger()
   const mutate = useMutate()
   const onValid = useCallback(
     async (values: typeof defaultValues) => {
@@ -474,6 +476,11 @@ export function useConfigMain() {
         triggerSuccessToast('Configuration has been saved.')
         if (isAutopilotEnabled) {
           syncDefaultContractSet(finalValues.autopilotContractSet)
+          autopilotTrigger.post({
+            payload: {
+              forceScan: false,
+            },
+          })
         }
 
         // if autopilot is being configured for the first time,
@@ -509,6 +516,7 @@ export function useConfigMain() {
       redundancy,
       gouging,
       configApp,
+      autopilotTrigger,
     ]
   )
 

--- a/apps/renterd/contexts/files/dataset.tsx
+++ b/apps/renterd/contexts/files/dataset.tsx
@@ -13,19 +13,29 @@ import {
   isDirectory,
 } from './paths'
 import { minutesInMilliseconds } from '@siafoundation/design-system'
+import { useRouter } from 'next/router'
 
 type Props = {
   activeDirectoryPath: string
   uploadsList: ObjectData[]
 }
 
+const defaultLimit = 50
+
 export function useDataset({ activeDirectoryPath, uploadsList }: Props) {
   const buckets = useBuckets()
 
+  const router = useRouter()
+  const limit = Number(router.query.limit || defaultLimit)
+  const offset = Number(router.query.offset || 0)
   const bucket = getBucketFromPath(activeDirectoryPath)
   const response = useObjectDirectory({
     disabled: !bucket,
-    params: bucketAndKeyParamsFromPath(activeDirectoryPath),
+    params: {
+      ...bucketAndKeyParamsFromPath(activeDirectoryPath),
+      offset,
+      limit,
+    },
     config: {
       swr: {
         refreshInterval: minutesInMilliseconds(1),
@@ -95,6 +105,8 @@ export function useDataset({ activeDirectoryPath, uploadsList }: Props) {
   )
 
   return {
+    limit,
+    offset,
     response,
     dataset: d.data,
   }

--- a/apps/renterd/contexts/files/index.tsx
+++ b/apps/renterd/contexts/files/index.tsx
@@ -20,8 +20,6 @@ import { useDataset } from './dataset'
 
 function useFilesMain() {
   const router = useRouter()
-  const limit = Number(router.query.limit || 20)
-  const offset = Number(router.query.offset || 0)
 
   // [bucket, key, directory]
   const activeDirectory = useMemo<FullPathSegments>(
@@ -56,7 +54,7 @@ function useFilesMain() {
   const { downloadFiles, downloadsList, getFileUrl, downloadCancel } =
     useDownloads()
 
-  const { response, dataset } = useDataset({
+  const { limit, offset, response, dataset } = useDataset({
     activeDirectoryPath,
     uploadsList,
   })

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -261,14 +261,16 @@ export const columns: HostsTableColumn[] = (
               <div className="mt-[5px]">
                 <Text color={color}>{icon}</Text>
               </div>
-              <div className="flex flex-col">
-                <Text size="12" noWrap>
-                  {ago}
-                </Text>
-                <Text color="subtle" size="10" noWrap>
-                  {format(new Date(data.lastScan), 'Pp')}
-                </Text>
-              </div>
+              {data.lastScan && (
+                <div className="flex flex-col">
+                  <Text size="12" noWrap>
+                    {ago}
+                  </Text>
+                  <Text color="subtle" size="10" noWrap>
+                    {format(new Date(data.lastScan), 'Pp')}
+                  </Text>
+                </div>
+              )}
             </div>
           </Tooltip>
         )

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -331,17 +331,17 @@ export const columns: HostsTableColumn[] = (
       ),
     },
     {
-      id: 'knownSince',
-      label: 'known since',
+      id: 'lastAnnouncement',
+      label: 'last announcement',
       category: 'general',
       render: ({ data }) => {
         return (
           <div className="flex flex-col">
             <Text size="12" noWrap>
-              {formatDistance(new Date(), new Date(data.knownSince))} old
+              {formatDistance(new Date(), new Date(data.lastAnnouncement))} ago
             </Text>
             <Text color="subtle" size="10" noWrap>
-              {formatRelative(new Date(data.knownSince), new Date())}
+              {formatRelative(new Date(data.lastAnnouncement), new Date())}
             </Text>
           </div>
         )

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -93,7 +93,10 @@ function getHostFields(host: Host, allContracts: ContractData[]) {
     netAddress: host.netAddress,
     publicKey: host.publicKey,
     lastScanSuccess: host.interactions.LastScanSuccess,
-    lastScan: host.interactions.LastScan,
+    lastScan:
+      host.interactions.LastScan === '0001-01-01T00:00:00Z'
+        ? null
+        : host.interactions.LastScan,
     knownSince: host.knownSince,
     uptime: new BigNumber(host.interactions.Uptime || 0),
     downtime: new BigNumber(host.interactions.Downtime || 0),

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -97,7 +97,12 @@ function getHostFields(host: Host, allContracts: ContractData[]) {
       host.interactions.LastScan === '0001-01-01T00:00:00Z'
         ? null
         : host.interactions.LastScan,
-    knownSince: host.knownSince,
+    knownSince:
+      host.knownSince === '0001-01-01T00:00:00Z' ? null : host.knownSince,
+    lastAnnouncement:
+      host.lastAnnouncement === '0001-01-01T00:00:00Z'
+        ? null
+        : host.lastAnnouncement,
     uptime: new BigNumber(host.interactions.Uptime || 0),
     downtime: new BigNumber(host.interactions.Downtime || 0),
     successfulInteractions: new BigNumber(

--- a/apps/renterd/contexts/hosts/types.tsx
+++ b/apps/renterd/contexts/hosts/types.tsx
@@ -11,6 +11,7 @@ export type HostData = {
   publicKey: string
   lastScanSuccess: boolean
   lastScan: string
+  lastAnnouncement: string
   knownSince: string
   uptime: BigNumber
   downtime: BigNumber
@@ -63,7 +64,7 @@ const generalColumns = [
   'publicKey',
   'lastScan',
   'totalScans',
-  'knownSince',
+  'lastAnnouncement',
   'uptime',
   'downtime',
   'successfulInteractions',
@@ -165,7 +166,7 @@ export const columnsDefaultVisible: TableColumnId[] = [
   'netAddress',
   'publicKey',
   'lastScan',
-  'knownSince',
+  'lastAnnouncement',
   'totalScans',
   'uptime',
   'hasContract',

--- a/libs/design-system/src/core/NumberField.tsx
+++ b/libs/design-system/src/core/NumberField.tsx
@@ -86,7 +86,7 @@ export const NumberField = forwardRef(function NumberField(
       data-testid="numberfield"
       size={size}
       placeholder={
-        placeholder.isNaN() ? '' : placeholder.toFixed(decimalsLimit)
+        placeholder.isNaN() ? '' : toFixedMax(placeholder, decimalsLimit)
       }
       units={units}
       value={localValue !== 'NaN' ? localValue : ''}

--- a/libs/design-system/src/core/SiacoinField.tsx
+++ b/libs/design-system/src/core/SiacoinField.tsx
@@ -189,7 +189,7 @@ export const SiacoinField = forwardRef(function SiacoinField(
         size={size}
         variant="ghost"
         focus="none"
-        placeholder={placeholder.toFixed(decimalsLimitSc)}
+        placeholder={toFixedMax(placeholder, decimalsLimitSc)}
         units={units}
         value={localSc !== 'NaN' ? localSc : ''}
         decimalsLimit={decimalsLimitSc}

--- a/libs/design-system/src/form/ConfigurationNumber.tsx
+++ b/libs/design-system/src/form/ConfigurationNumber.tsx
@@ -4,7 +4,6 @@ import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form'
 import { ConfigFields, useRegisterForm } from './configurationFields'
 import { NumberField } from '../core/NumberField'
 import { FieldLabelAndError } from '../components/Form'
-import { toFixedMax, toFixedOrPrecision } from '../lib/numbers'
 import { useMemo } from 'react'
 
 type Props<Values extends FieldValues, Categories extends string> = {

--- a/libs/design-system/src/form/ConfigurationNumber.tsx
+++ b/libs/design-system/src/form/ConfigurationNumber.tsx
@@ -4,6 +4,8 @@ import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form'
 import { ConfigFields, useRegisterForm } from './configurationFields'
 import { NumberField } from '../core/NumberField'
 import { FieldLabelAndError } from '../components/Form'
+import { toFixedMax, toFixedOrPrecision } from '../lib/numbers'
+import { useMemo } from 'react'
 
 type Props<Values extends FieldValues, Categories extends string> = {
   name: Path<Values>
@@ -22,7 +24,7 @@ export function ConfigurationNumber<
     suggestion,
     suggestionTip,
     decimalsLimit = 2,
-    placeholder,
+    placeholder: _placeholder,
     units,
   } = field
   const { setValue, value, error } = useRegisterForm({
@@ -30,6 +32,15 @@ export function ConfigurationNumber<
     field,
     name,
   })
+  const placeholder = useMemo(
+    () =>
+      _placeholder
+        ? new BigNumber(_placeholder)
+        : suggestion && typeof suggestion !== 'boolean'
+        ? new BigNumber(suggestion)
+        : undefined,
+    [_placeholder, suggestion]
+  )
   return (
     <div className="flex flex-col gap-3 items-end">
       <div className="flex flex-col gap-3 w-[220px]">
@@ -38,7 +49,7 @@ export function ConfigurationNumber<
           value={value}
           units={units}
           decimalsLimit={decimalsLimit}
-          placeholder={placeholder ? new BigNumber(placeholder) : undefined}
+          placeholder={placeholder}
           state={
             error
               ? 'invalid'

--- a/libs/design-system/src/form/ConfigurationSiacoin.tsx
+++ b/libs/design-system/src/form/ConfigurationSiacoin.tsx
@@ -6,7 +6,6 @@ import { FieldLabelAndError } from '../components/Form'
 import { ConfigFields, useRegisterForm } from './configurationFields'
 import BigNumber from 'bignumber.js'
 import { useMemo } from 'react'
-import { toFixedMax } from '../lib/numbers'
 
 type Props<Values extends FieldValues, Categories extends string> = {
   name: Path<Values>

--- a/libs/design-system/src/form/ConfigurationSiacoin.tsx
+++ b/libs/design-system/src/form/ConfigurationSiacoin.tsx
@@ -5,6 +5,8 @@ import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form'
 import { FieldLabelAndError } from '../components/Form'
 import { ConfigFields, useRegisterForm } from './configurationFields'
 import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
+import { toFixedMax } from '../lib/numbers'
 
 type Props<Values extends FieldValues, Categories extends string> = {
   name: Path<Values>
@@ -20,6 +22,7 @@ export function ConfigurationSiacoin<
   const {
     average,
     suggestion,
+    placeholder: _placeholder,
     units,
     suggestionTip,
     averageTip,
@@ -34,6 +37,15 @@ export function ConfigurationSiacoin<
     form,
   })
   const After = after || (() => null)
+  const placeholder = useMemo(
+    () =>
+      _placeholder
+        ? new BigNumber(_placeholder)
+        : suggestion && typeof suggestion !== 'boolean'
+        ? new BigNumber(suggestion)
+        : undefined,
+    [_placeholder, suggestion]
+  )
   return (
     <div className="flex flex-col gap-3 items-end">
       <div className="flex flex-col gap-3 w-[220px]">
@@ -46,7 +58,7 @@ export function ConfigurationSiacoin<
           decimalsLimitFiat={decimalsLimitFiat}
           error={error}
           changed={form.formState.dirtyFields[name]}
-          placeholder={(suggestion as BigNumber) || (average as BigNumber)}
+          placeholder={placeholder}
           onChange={(val) => {
             setValue(val as PathValue<Values, Path<Values>>, true)
           }}

--- a/libs/react-renterd/src/autopilot.ts
+++ b/libs/react-renterd/src/autopilot.ts
@@ -8,6 +8,7 @@ import {
   HookArgsCallback,
   HookArgsWithPayloadSwr,
   delay,
+  usePostFunc,
 } from '@siafoundation/react-core'
 
 type AutopilotStatus = {
@@ -104,5 +105,14 @@ export function useAutopilotHostsSearch(
   return usePostSwr({
     ...args,
     route: autopilotHostsKey,
+  })
+}
+
+export function useAutopilotTrigger(
+  args?: HookArgsCallback<void, { forceScan: boolean }, { triggered: boolean }>
+) {
+  return usePostFunc({
+    ...args,
+    route: '/autopilot/trigger',
   })
 }

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -455,7 +455,7 @@ export type ObjEntry = {
 
 export function useObjectDirectory(
   args: HookArgsSwr<
-    { key: string; bucket: string; limit: number; offset: number },
+    { key: string; bucket: string; limit?: number; offset?: number },
     { entries: ObjEntry[] }
   >
 ) {

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -454,7 +454,10 @@ export type ObjEntry = {
 }
 
 export function useObjectDirectory(
-  args: HookArgsSwr<{ key: string; bucket: string }, { entries: ObjEntry[] }>
+  args: HookArgsSwr<
+    { key: string; bucket: string; limit: number; offset: number },
+    { entries: ObjEntry[] }
+  >
 ) {
   return useGetSwr({ ...args, route: '/bus/objects/:key' })
 }

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -372,13 +372,13 @@ export function useContractsAcquire(
     ContractAcquireResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/contracts/:id/acquire' })
+  return usePostFunc({ ...args, route: '/bus/contract/:id/acquire' })
 }
 
 export function useContractsRelease(
   args: HookArgsCallback<{ id: string }, void, never>
 ) {
-  return usePostFunc({ ...args, route: '/bus/contracts/:id/release' })
+  return usePostFunc({ ...args, route: '/bus/contract/:id/release' })
 }
 
 export function useContract(args: HookArgsSwr<{ id: string }, Contract>) {
@@ -388,33 +388,33 @@ export function useContract(args: HookArgsSwr<{ id: string }, Contract>) {
 export function useContractCreate(
   args: HookArgsCallback<{ id: string }, ContractsIDAddRequest, Contract>
 ) {
-  return usePostFunc({ ...args, route: '/bus/contracts/:id/new' })
+  return usePostFunc({ ...args, route: '/bus/contract/:id/new' })
 }
 
 export function useContractRenew(
   args: HookArgsCallback<{ id: string }, ContractsIDRenewedRequest, Contract>
 ) {
-  return usePostFunc({ ...args, route: '/bus/contracts/:id/renewed' })
+  return usePostFunc({ ...args, route: '/bus/contract/:id/renewed' })
 }
 
 export function useContractDelete(
   args?: HookArgsCallback<{ id: string }, void, never>
 ) {
-  return useDeleteFunc({ ...args, route: '/bus/contracts/:id/delete' })
+  return useDeleteFunc({ ...args, route: '/bus/contract/:id' })
 }
 
 export function useContractsets(args?: HookArgsSwr<void, string[][]>) {
-  return useGetSwr({ ...args, route: '/bus/contractsets' })
+  return useGetSwr({ ...args, route: '/bus/contracts/sets' })
 }
 
 export function useContractset(args: HookArgsSwr<{ name: string }, string[]>) {
-  return useGetSwr({ ...args, route: '/bus/contractsets/:name' })
+  return useGetSwr({ ...args, route: '/bus/contracts/sets/:set' })
 }
 
 export function useContractsetUpdate(
   args: HookArgsCallback<{ name: string }, string[], never>
 ) {
-  return usePutFunc({ ...args, route: '/bus/contractsets/:name' })
+  return usePutFunc({ ...args, route: '/bus/contracts/sets/:set' })
 }
 
 // objects
@@ -440,9 +440,9 @@ export function useBucketDelete(
   args?: HookArgsCallback<{ name: string }, void, never>
 ) {
   return useDeleteFunc(
-    { ...args, route: '/bus/buckets/:name' },
+    { ...args, route: '/bus/bucket/:name' },
     async (mutate) => {
-      mutate((key) => key.startsWith('/bus/buckets'))
+      mutate((key) => key.startsWith('/bus/bucket'))
     }
   )
 }

--- a/libs/react-renterd/src/siaTypes.ts
+++ b/libs/react-renterd/src/siaTypes.ts
@@ -248,6 +248,7 @@ export interface Host {
   publicKey: string
   netAddress: string
   knownSince: string
+  lastAnnouncement: string
   Announcements?: Announcement[]
   interactions: {
     Downtime: number


### PR DESCRIPTION
- Hosts last scan column now properly displays unscanned values rather than a very large time ago value.
- Siacoin and number input placeholders now match the suggested value.
- The autopilot loop is now triggered after settings are successfully updated.
- Files are now paginated.
- Removed and updated deprecated route names.
- Onboarding fund wallet step now requires >0 SC instead of a full allowance.
- The hosts table now has a last announcement column instead of the known since column.