### PR TITLE
fix: hostd metrics min zero, remove registry

### DIFF
--- a/.changeset/cool-beds-hunt.md
+++ b/.changeset/cool-beds-hunt.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Revenue metrics no longer show negative potential on the bar graph.

--- a/.changeset/dull-birds-push.md
+++ b/.changeset/dull-birds-push.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Metrics no longer include registry related data.

--- a/.changeset/swift-kiwis-clean.md
+++ b/.changeset/swift-kiwis-clean.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Earned revenue stat cards are now clearly labeled as earned.

--- a/apps/hostd/components/Home/HomeOperations.tsx
+++ b/apps/hostd/components/Home/HomeOperations.tsx
@@ -35,26 +35,6 @@ export function HomeOperations() {
             enabledModes={['total', 'average', 'latest']}
             format={humanNumber}
           />
-          <DatumCardConfigurable
-            category="operations"
-            label="registry reads"
-            color={operations.config.data['registryReads'].color}
-            value={operations.stats['registryReads']}
-            defaultMode="total"
-            isLoading={operations.isLoading}
-            enabledModes={['total', 'average', 'latest']}
-            format={humanNumber}
-          />
-          <DatumCardConfigurable
-            category="operations"
-            label="registry writes"
-            color={operations.config.data['registryWrites'].color}
-            value={operations.stats['registryWrites']}
-            defaultMode="total"
-            isLoading={operations.isLoading}
-            enabledModes={['total', 'average', 'latest']}
-            format={humanNumber}
-          />
         </DatumScrollArea>
         <ChartXY
           id="operations"

--- a/apps/hostd/components/Home/HomeRevenue.tsx
+++ b/apps/hostd/components/Home/HomeRevenue.tsx
@@ -4,6 +4,7 @@ import {
   Heading,
   DatumCardConfigurable,
   DatumScrollArea,
+  Separator,
 } from '@siafoundation/design-system'
 import { useMetrics } from '../../contexts/metrics'
 
@@ -16,7 +17,17 @@ export function HomeRevenue() {
       <DatumScrollArea bleed>
         <DatumCardConfigurable
           category="revenue"
-          label="earned revenue"
+          label="potential - all"
+          color={revenue.config.data['potential'].color}
+          sc={revenue.stats['potential']}
+          defaultMode="total"
+          isLoading={revenue.isLoading}
+          showChange={false}
+        />
+        <Separator variant="vertical" />
+        <DatumCardConfigurable
+          category="revenue"
+          label="earned - all"
           color={revenue.config.data['earned'].color}
           sc={revenue.stats['earned']}
           defaultMode="total"
@@ -24,16 +35,7 @@ export function HomeRevenue() {
         />
         <DatumCardConfigurable
           category="revenue"
-          label="potential revenue"
-          color={revenue.config.data['potential'].color}
-          sc={revenue.stats['potential']}
-          defaultMode="total"
-          isLoading={revenue.isLoading}
-          showChange={false}
-        />
-        <DatumCardConfigurable
-          category="revenue"
-          label="storage"
+          label="earned - storage"
           color={revenue.config.data['storage'].color}
           sc={revenue.stats['storage']}
           defaultMode="total"
@@ -41,7 +43,7 @@ export function HomeRevenue() {
         />
         <DatumCardConfigurable
           category="revenue"
-          label="egress"
+          label="earned - egress"
           color={revenue.config.data['egress'].color}
           sc={revenue.stats['egress']}
           defaultMode="total"
@@ -49,25 +51,9 @@ export function HomeRevenue() {
         />
         <DatumCardConfigurable
           category="revenue"
-          label="ingress"
+          label="earned - ingress"
           color={revenue.config.data['ingress'].color}
           sc={revenue.stats['ingress']}
-          defaultMode="total"
-          isLoading={revenue.isLoading}
-        />
-        <DatumCardConfigurable
-          category="revenue"
-          label="registry read"
-          color={revenue.config.data['registryRead'].color}
-          sc={revenue.stats['registryRead']}
-          defaultMode="total"
-          isLoading={revenue.isLoading}
-        />
-        <DatumCardConfigurable
-          category="revenue"
-          label="registry write"
-          color={revenue.config.data['registryWrite'].color}
-          sc={revenue.stats['registryWrite']}
           defaultMode="total"
           isLoading={revenue.isLoading}
         />

--- a/apps/hostd/components/Home/HomeStorage.tsx
+++ b/apps/hostd/components/Home/HomeStorage.tsx
@@ -16,7 +16,7 @@ export function HomeStorage() {
       <DatumScrollArea>
         <DatumCardConfigurable
           category="storage"
-          label="storage (physical)"
+          label="storage - physical"
           color={storage.config.data['physicalSectors'].color}
           value={storage.stats['physicalSectors']}
           defaultMode="latest"
@@ -26,9 +26,19 @@ export function HomeStorage() {
         />
         <DatumCardConfigurable
           category="storage"
-          label="registry"
-          color={storage.config.data['registryEntries'].color}
-          value={storage.stats['registryEntries']}
+          label="storage - contract"
+          color={storage.config.data['contractSectors'].color}
+          value={storage.stats['contractSectors']}
+          defaultMode="latest"
+          isLoading={storage.isLoading}
+          enabledModes={['latest', 'average']}
+          format={humanBytes}
+        />
+        <DatumCardConfigurable
+          category="storage"
+          label="storage - temp"
+          color={storage.config.data['tempSectors'].color}
+          value={storage.stats['tempSectors']}
           defaultMode="latest"
           isLoading={storage.isLoading}
           enabledModes={['latest', 'average']}

--- a/apps/hostd/contexts/metrics/types.tsx
+++ b/apps/hostd/contexts/metrics/types.tsx
@@ -5,14 +5,8 @@ import {
 } from '@siafoundation/design-system'
 
 export type RevenueKeys =
-  | 'potential'
-  | 'earned'
   | 'rpcPotential'
   | 'rpc'
-  | 'registryWritePotential'
-  | 'registryWrite'
-  | 'registryReadPotential'
-  | 'registryRead'
   | 'egressPotential'
   | 'egress'
   | 'ingressPotential'
@@ -47,18 +41,12 @@ export type StorageKeys =
   | 'physicalSectors'
   | 'tempSectors'
   | 'contractSectors'
-  | 'registryEntries'
-  | 'maxRegistryEntries'
 
 export type StorageCategories = 'storage used' | 'storage capacity'
 
 export type BandwidthKeys = 'ingress' | 'egress'
 
-export type OperationsKeys =
-  | 'storageReads'
-  | 'storageWrites'
-  | 'registryReads'
-  | 'registryWrites'
+export type OperationsKeys = 'storageReads' | 'storageWrites'
 
 export type BandwidthCategories = 'ingress' | 'egress'
 


### PR DESCRIPTION
- Revenue metrics no longer show negative potential on the bar graph.
- Metrics no longer include registry related data.
- Earned revenue stat cards are now clearly labeled as earned.