### PR TITLE
renterd prune sector roots, fix host interactions data, onboarding display, balance evolution, decimal inputs

### DIFF
--- a/.changeset/chilly-walls-jump.md
+++ b/.changeset/chilly-walls-jump.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed an issue with the host interaction values showing as 0s on the host explorer.

--- a/.changeset/gorgeous-snakes-hide.md
+++ b/.changeset/gorgeous-snakes-hide.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The advanced configuration now includes a prune sector roots setting.

--- a/.changeset/short-cheetahs-enjoy.md
+++ b/.changeset/short-cheetahs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+Update host interaction type casing.

--- a/.changeset/six-buses-grin.md
+++ b/.changeset/six-buses-grin.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The wallet page now shows the balance evolution again, using the new wallet metrics API.

--- a/.changeset/small-pandas-sniff.md
+++ b/.changeset/small-pandas-sniff.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+Add metrics APIs.

--- a/.changeset/swift-cobras-sleep.md
+++ b/.changeset/swift-cobras-sleep.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+The onboarding wizard no longer shows on the login page.

--- a/.changeset/warm-ants-collect.md
+++ b/.changeset/warm-ants-collect.md
@@ -1,0 +1,7 @@
+---
+'hostd': minor
+'renterd': minor
+'@siafoundation/design-system': minor
+---
+
+Fixed an issue where number fields would not properly handle user input starting with a decimal separator.

--- a/apps/hostd/components/CmdKDialog/index.tsx
+++ b/apps/hostd/components/CmdKDialog/index.tsx
@@ -11,13 +11,13 @@ type Props = {
 }
 
 export function CmdKDialog({ open, onOpenChange, setOpen }: Props) {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const { isConnected } = useConnectivity({
     route: connectivityRoute,
   })
   // Toggle the menu when ⌘K is pressed
   useEffect(() => {
-    if (!isUnlocked || !isConnected) {
+    if (!isUnlockedAndAuthedRoute || !isConnected) {
       return
     }
     const down = (e: KeyboardEvent) => {
@@ -28,7 +28,7 @@ export function CmdKDialog({ open, onOpenChange, setOpen }: Props) {
 
     document.addEventListener('keydown', down)
     return () => document.removeEventListener('keydown', down)
-  }, [isUnlocked, isConnected, setOpen])
+  }, [isUnlockedAndAuthedRoute, isConnected, setOpen])
 
   return (
     <>

--- a/apps/hostd/components/OnboardingBar.tsx
+++ b/apps/hostd/components/OnboardingBar.tsx
@@ -25,7 +25,7 @@ import { useVolumes } from '../contexts/volumes'
 import useLocalStorageState from 'use-local-storage-state'
 
 export function OnboardingBar() {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const { openDialog } = useDialog()
   const { dataset: volumes } = useVolumes()
   const settings = useSettings()
@@ -38,7 +38,7 @@ export function OnboardingBar() {
   )
   const syncStatus = useSyncStatus()
 
-  if (!isUnlocked) {
+  if (!isUnlockedAndAuthedRoute) {
     return null
   }
 

--- a/apps/hostd/contexts/config/index.tsx
+++ b/apps/hostd/contexts/config/index.tsx
@@ -173,13 +173,13 @@ export function useConfigMain() {
     }
   }, [form, resetFormDataIfAllDataFetched])
 
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   useEffect(() => {
-    if (isUnlocked) {
+    if (isUnlockedAndAuthedRoute) {
       revalidateAndResetFormData()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUnlocked])
+  }, [isUnlockedAndAuthedRoute])
 
   useEffect(() => {
     if (form.formState.isSubmitting) {

--- a/apps/hostd/hooks/useSyncStatus.ts
+++ b/apps/hostd/hooks/useSyncStatus.ts
@@ -6,7 +6,7 @@ import {
 } from '@siafoundation/react-hostd'
 
 export function useSyncStatus() {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const state = useStateConsensus({
     config: {
       swr: {
@@ -26,14 +26,14 @@ export function useSyncStatus() {
   })
 
   const syncPercent =
-    isUnlocked && nodeBlockHeight && estimatedBlockHeight
+    isUnlockedAndAuthedRoute && nodeBlockHeight && estimatedBlockHeight
       ? Number(
           (Math.min(nodeBlockHeight / estimatedBlockHeight, 1) * 100).toFixed(1)
         )
       : 0
 
   const walletScanPercent =
-    isUnlocked && nodeBlockHeight && wallet.data
+    isUnlockedAndAuthedRoute && nodeBlockHeight && wallet.data
       ? Number(
           (
             Math.min(wallet.data.scanHeight / estimatedBlockHeight, 1) * 100

--- a/apps/renterd/components/CmdKDialog/index.tsx
+++ b/apps/renterd/components/CmdKDialog/index.tsx
@@ -11,13 +11,13 @@ type Props = {
 }
 
 export function CmdKDialog({ open, onOpenChange, setOpen }: Props) {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const { isConnected } = useConnectivity({
     route: connectivityRoute,
   })
   // Toggle the menu when ⌘K is pressed
   useEffect(() => {
-    if (!isUnlocked || !isConnected) {
+    if (!isUnlockedAndAuthedRoute || !isConnected) {
       return
     }
     const down = (e: KeyboardEvent) => {
@@ -28,7 +28,7 @@ export function CmdKDialog({ open, onOpenChange, setOpen }: Props) {
 
     document.addEventListener('keydown', down)
     return () => document.removeEventListener('keydown', down)
-  }, [isUnlocked, isConnected, setOpen])
+  }, [isUnlockedAndAuthedRoute, isConnected, setOpen])
 
   return (
     <>

--- a/apps/renterd/components/OnboardingBar.tsx
+++ b/apps/renterd/components/OnboardingBar.tsx
@@ -26,7 +26,7 @@ import { useAppSettings } from '@siafoundation/react-core'
 import useLocalStorageState from 'use-local-storage-state'
 
 export function OnboardingBar() {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const app = useApp()
   const { openDialog } = useDialog()
   const wallet = useWallet()
@@ -47,7 +47,7 @@ export function OnboardingBar() {
   const syncStatus = useSyncStatus()
   const notEnoughContracts = useNotEnoughContracts()
 
-  if (!isUnlocked || app.autopilot.status !== 'on') {
+  if (!isUnlockedAndAuthedRoute || app.autopilot.status !== 'on') {
     return null
   }
 

--- a/apps/renterd/components/TransfersBar.tsx
+++ b/apps/renterd/components/TransfersBar.tsx
@@ -21,7 +21,7 @@ function getProgress(transfer: { loaded?: number; size?: number }) {
 }
 
 export function TransfersBar() {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const { uploadsList, uploadCancel, downloadsList, downloadCancel } =
     useFiles()
   const [maximized, setMaximized] = useState<boolean>(true)
@@ -29,7 +29,7 @@ export function TransfersBar() {
   const uploadCount = uploadsList.length
   const downloadCount = downloadsList.length
 
-  if (!isUnlocked) {
+  if (!isUnlockedAndAuthedRoute) {
     return null
   }
 

--- a/apps/renterd/components/Wallet/index.tsx
+++ b/apps/renterd/components/Wallet/index.tsx
@@ -1,4 +1,5 @@
 import {
+  BalanceEvolution,
   EntityList,
   PaginatorUnknownTotal,
   WalletLayoutActions,
@@ -17,7 +18,8 @@ import { WalletFilterBar } from './WalletFilterBar'
 export function Wallet() {
   const { openDialog } = useDialog()
   const wallet = useWallet()
-  const { dataset, offset, limit, pageCount, dataState } = useTransactions()
+  const { dataset, offset, limit, pageCount, dataState, balances, metrics } =
+    useTransactions()
   const { isSynced, syncPercent, isWalletSynced, walletScanPercent } =
     useSyncStatus()
 
@@ -49,14 +51,14 @@ export function Wallet() {
       stats={<WalletFilterBar />}
     >
       <div className="p-6 flex flex-col gap-5">
-        {/* {balances?.length ? (
+        {balances?.length ? (
           <BalanceEvolution
             // see comment above
             chartType="line"
             balances={balances}
-            isLoading={transactions.isValidating}
+            isLoading={metrics.isValidating}
           />
-        ) : null} */}
+        ) : null}
         <EntityList
           title="Transactions"
           isLoading={dataState === 'loading'}

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -192,6 +192,34 @@ export function getFields({
             }
           : {},
     },
+    prune: {
+      type: 'boolean',
+      category: 'storage',
+      title: 'Prune sector roots',
+      description: (
+        <>
+          When enabled, autopilot will try to prune deleted sector roots from
+          contracts one contract at a time, for a max duration of 10 minutes per
+          contract. For old hosts this process takes quite a while, while for
+          new hosts it is fast. For new hosts pruning effectively deletes data
+          from the contract, allowing the renter to stop paying for storage they
+          are not using.
+        </>
+      ),
+      suggestion: advancedDefaults?.prune,
+      suggestionTip: (
+        <>
+          The default value is <Code>{advancedDefaults?.prune}</Code>.
+        </>
+      ),
+      hidden: !isAutopilotEnabled || !showAdvanced,
+      validation:
+        isAutopilotEnabled && showAdvanced
+          ? {
+              required: 'required',
+            }
+          : {},
+    },
 
     // hosts
     allowRedundantIPs: {

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -566,13 +566,13 @@ export function useConfigMain() {
     }
   }, [form, resetFormDataIfAllDataFetched])
 
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   useEffect(() => {
-    if (isUnlocked && app.autopilot.status !== 'init') {
+    if (isUnlockedAndAuthedRoute && app.autopilot.status !== 'init') {
       revalidateAndResetFormData()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUnlocked, app.autopilot.status])
+  }, [isUnlockedAndAuthedRoute, app.autopilot.status])
 
   useEffect(() => {
     if (form.formState.isSubmitting) {

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -40,6 +40,7 @@ describe('tansforms', () => {
               download: 1099511627776,
               upload: 1100000000000,
               storage: 1000000000000,
+              prune: true,
             },
           },
           { default: 'myset' },
@@ -75,6 +76,7 @@ describe('tansforms', () => {
         downloadTBMonth: new BigNumber('1.1'),
         uploadTBMonth: new BigNumber('1.1'),
         storageTB: new BigNumber('1'),
+        prune: true,
         allowRedundantIPs: false,
         maxDowntimeHours: new BigNumber('1440'),
         minRecentScanFailures: new BigNumber('10'),
@@ -121,6 +123,7 @@ describe('tansforms', () => {
               download: 1099511627776,
               upload: 1100000000000,
               storage: 1000000000000,
+              prune: true,
             },
           },
           { default: 'myset' },
@@ -177,6 +180,7 @@ describe('tansforms', () => {
         totalShards: new BigNumber(30),
         includeRedundancyMaxStoragePrice: true,
         includeRedundancyMaxUploadPrice: true,
+        prune: true,
       } as SettingsData)
     })
   })
@@ -195,6 +199,7 @@ describe('tansforms', () => {
             downloadTBMonth: new BigNumber('0.785365448411428571428571428571'),
             uploadTBMonth: new BigNumber('0.785714285714285714285714285714'),
             storageTB: new BigNumber('1'),
+            prune: true,
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
@@ -221,6 +226,7 @@ describe('tansforms', () => {
           download: 1099511627776,
           upload: 1100000000000,
           storage: 1000000000000,
+          prune: true,
         },
       })
     })
@@ -237,6 +243,7 @@ describe('tansforms', () => {
             downloadTBMonth: new BigNumber('0.785365448411428571428571428571'),
             uploadTBMonth: new BigNumber('0.785714285714285714285714285714'),
             storageTB: new BigNumber('1'),
+            prune: true,
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
@@ -280,6 +287,7 @@ describe('tansforms', () => {
           download: 1099511627776,
           upload: 1100000000000,
           storage: 1000000000000,
+          prune: true,
         },
       })
     })
@@ -296,6 +304,7 @@ describe('tansforms', () => {
             downloadTBMonth: new BigNumber('0.785365448411428571428571428571'),
             uploadTBMonth: new BigNumber('0.785714285714285714285714285714'),
             storageTB: new BigNumber('1'),
+            prune: true,
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
@@ -329,6 +338,7 @@ describe('tansforms', () => {
           download: 1099511627776,
           upload: 1100000000000,
           storage: 1000000000000,
+          prune: true,
         },
       })
     })
@@ -363,6 +373,7 @@ describe('tansforms', () => {
             downloadTBMonth: new BigNumber('0.785365448411428571428571428571'),
             uploadTBMonth: new BigNumber('0.785714285714285714285714285714'),
             storageTB: new BigNumber('1'),
+            prune: true,
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
@@ -419,6 +430,7 @@ describe('tansforms', () => {
             downloadTBMonth: new BigNumber('0.785365448411428571428571428571'),
             uploadTBMonth: new BigNumber('0.785714285714285714285714285714'),
             storageTB: new BigNumber('1'),
+            prune: true,
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
@@ -594,6 +606,7 @@ function buildAllResponses() {
         download: 1099511627776,
         upload: 1100000000000,
         storage: 1000000000000,
+        prune: true,
       },
     },
     contractSet: { default: 'myset' },

--- a/apps/renterd/contexts/config/transform.ts
+++ b/apps/renterd/contexts/config/transform.ts
@@ -82,6 +82,7 @@ export function transformUpAutopilot(
         ).toFixed(0)
       ),
       storage: TBToBytes(v.storageTB).toNumber(),
+      prune: v.prune,
     },
     hosts: {
       ...existingValues?.hosts,
@@ -231,6 +232,7 @@ export function transformDownAutopilot(
     )
   )
   const storageTB = bytesToTB(new BigNumber(config.contracts.storage))
+  const prune = config.contracts.prune
 
   return {
     // contracts
@@ -242,6 +244,7 @@ export function transformDownAutopilot(
     downloadTBMonth,
     uploadTBMonth,
     storageTB,
+    prune,
     // hosts
     allowRedundantIPs: config.hosts.allowRedundantIPs,
     maxDowntimeHours: new BigNumber(config.hosts.maxDowntimeHours),

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -13,6 +13,7 @@ export const defaultAutopilot = {
   downloadTBMonth: undefined as BigNumber | undefined,
   uploadTBMonth: undefined as BigNumber | undefined,
   storageTB: undefined as BigNumber | undefined,
+  prune: true,
   // hosts
   allowRedundantIPs: false,
   maxDowntimeHours: undefined as BigNumber | undefined,
@@ -98,6 +99,7 @@ export function getAdvancedDefaultAutopilot(
           maxDowntimeHours: new BigNumber(336),
           minRecentScanFailures: new BigNumber(10),
           defragThreshold: new BigNumber(1000),
+          prune: true,
         }
       : {
           periodWeeks: new BigNumber(6),
@@ -108,6 +110,7 @@ export function getAdvancedDefaultAutopilot(
           maxDowntimeHours: new BigNumber(336),
           minRecentScanFailures: new BigNumber(10),
           defragThreshold: new BigNumber(1000),
+          prune: true,
         }),
   }
 }

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -92,30 +92,30 @@ function getHostFields(host: Host, allContracts: ContractData[]) {
     id: host.publicKey,
     netAddress: host.netAddress,
     publicKey: host.publicKey,
-    lastScanSuccess: host.interactions.LastScanSuccess,
+    lastScanSuccess: host.interactions.lastScanSuccess,
     lastScan:
-      host.interactions.LastScan === '0001-01-01T00:00:00Z'
+      host.interactions.lastScan === '0001-01-01T00:00:00Z'
         ? null
-        : host.interactions.LastScan,
+        : host.interactions.lastScan,
     knownSince:
       host.knownSince === '0001-01-01T00:00:00Z' ? null : host.knownSince,
     lastAnnouncement:
       host.lastAnnouncement === '0001-01-01T00:00:00Z'
         ? null
         : host.lastAnnouncement,
-    uptime: new BigNumber(host.interactions.Uptime || 0),
-    downtime: new BigNumber(host.interactions.Downtime || 0),
+    uptime: new BigNumber(host.interactions.uptime || 0),
+    downtime: new BigNumber(host.interactions.downtime || 0),
     successfulInteractions: new BigNumber(
-      host.interactions.SuccessfulInteractions || 0
+      host.interactions.successfulInteractions || 0
     ),
     totalInteractions: new BigNumber(
-      host.interactions.SuccessfulInteractions +
-        host.interactions.FailedInteractions || 0
+      host.interactions.successfulInteractions +
+        host.interactions.failedInteractions || 0
     ),
     failedInteractions: new BigNumber(
-      host.interactions.FailedInteractions || 0
+      host.interactions.failedInteractions || 0
     ),
-    totalScans: new BigNumber(host.interactions.TotalScans || 0),
+    totalScans: new BigNumber(host.interactions.totalScans || 0),
     activeContractsCount: new BigNumber(
       allContracts?.filter((c) => c.hostKey === host.publicKey).length || 0
     ),

--- a/apps/renterd/contexts/transactions/index.tsx
+++ b/apps/renterd/contexts/transactions/index.tsx
@@ -2,7 +2,6 @@ import {
   EntityListItemProps,
   daysInMilliseconds,
   getTransactionType,
-  hoursInMilliseconds,
   secondsInMilliseconds,
   useDatasetEmptyState,
 } from '@siafoundation/design-system'
@@ -112,8 +111,8 @@ function useTransactionsMain() {
     filters
   )
 
-  const periods = 24
-  const intervalMs = hoursInMilliseconds(1)
+  const periods = 30
+  const intervalMs = daysInMilliseconds(1)
   const start = useMemo(() => {
     const today = new Date().getTime()
     const periodsInMs = periods * intervalMs

--- a/apps/renterd/hooks/useSyncStatus.ts
+++ b/apps/renterd/hooks/useSyncStatus.ts
@@ -7,7 +7,7 @@ import {
 } from '@siafoundation/react-renterd'
 
 export function useSyncStatus() {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const state = useConsensusState({
     config: {
       swr: {
@@ -30,14 +30,14 @@ export function useSyncStatus() {
   })
 
   const syncPercent =
-    isUnlocked && nodeBlockHeight && estimatedBlockHeight
+    isUnlockedAndAuthedRoute && nodeBlockHeight && estimatedBlockHeight
       ? Number(
           (Math.min(nodeBlockHeight / estimatedBlockHeight, 1) * 100).toFixed(1)
         )
       : 0
 
   const walletScanPercent =
-    isUnlocked && nodeBlockHeight && wallet.data
+    isUnlockedAndAuthedRoute && nodeBlockHeight && wallet.data
       ? Number(
           (
             Math.min(wallet.data.scanHeight / estimatedBlockHeight, 1) * 100

--- a/apps/walletd/hooks/useSyncStatus.ts
+++ b/apps/walletd/hooks/useSyncStatus.ts
@@ -8,7 +8,7 @@ import {
 } from '@siafoundation/react-walletd'
 
 export function useSyncStatus() {
-  const { isUnlocked } = useAppSettings()
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
   const state = useConsensusTip({
     config: {
       swr: {
@@ -29,7 +29,7 @@ export function useSyncStatus() {
   const nodeBlockHeight = state.data ? state.data?.height : 0
 
   const syncPercent =
-    isUnlocked && nodeBlockHeight && estimatedBlockHeight
+    isUnlockedAndAuthedRoute && nodeBlockHeight && estimatedBlockHeight
       ? Number(
           (Math.min(nodeBlockHeight / estimatedBlockHeight, 1) * 100).toFixed(1)
         )

--- a/libs/design-system/src/core/BaseNumberField.tsx
+++ b/libs/design-system/src/core/BaseNumberField.tsx
@@ -58,6 +58,18 @@ export function BaseNumberField({
         autoComplete="off"
         spellCheck={false}
         onValueChange={onValueChange}
+        transformRawValue={(value) => {
+          if (value.length > 0) {
+            if (value[0] === '.') {
+              return '0.' + value.slice(1)
+            }
+            if (value[0] === ',') {
+              return '0,' + value.slice(1)
+            }
+          }
+
+          return value
+        }}
         className={cx(
           textFieldStyles({
             variant,

--- a/libs/design-system/src/core/NumberField.spec.tsx
+++ b/libs/design-system/src/core/NumberField.spec.tsx
@@ -46,6 +46,39 @@ describe('NumberField', () => {
     expectOnChangeValues([undefined, '4', '44', '44', '444', '444'], onChange)
   })
 
+  it('updates value starting with decimal', async () => {
+    const user = userEvent.setup()
+    const onChange = jest.fn()
+    const { input } = await renderNode({
+      initialValue: new BigNumber(33),
+      onChange,
+    })
+
+    expect(input.value).toBe('33')
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, '.44')
+    fireEvent.blur(input)
+    expect(input.value).toBe('0.44')
+  })
+
+  it('updates value starting with comma decimal separator', async () => {
+    const user = userEvent.setup()
+    const onChange = jest.fn()
+    const { input } = await renderNode({
+      initialValue: new BigNumber(33),
+      locale: 'de-DE',
+      onChange,
+    })
+
+    expect(input.value).toBe('33')
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, ',44')
+    fireEvent.blur(input)
+    expect(input.value).toBe('0,44')
+  })
+
   it('works with alternate locale: DE', async () => {
     const user = userEvent.setup()
     const onChange = jest.fn()

--- a/libs/design-system/src/core/SiacoinField.spec.tsx
+++ b/libs/design-system/src/core/SiacoinField.spec.tsx
@@ -64,6 +64,45 @@ describe('SiacoinField', () => {
     expectOnChangeValues([undefined, '4', '44', '44', '444', '444'], onChange)
   })
 
+  it('updates value starting with decimal', async () => {
+    siaCentralExchangeRateEndpoint('1')
+    const user = userEvent.setup()
+    const onChange = jest.fn()
+    const { scInput, fiatInput } = await renderNode({
+      sc: new BigNumber(33),
+      onChange,
+    })
+
+    expect(scInput.value).toBe('33')
+    expect(fiatInput.value).toBe('$33')
+    await user.click(scInput)
+    await user.clear(scInput)
+    await user.type(scInput, '.44')
+    fireEvent.blur(scInput)
+    expect(scInput.value).toBe('0.44')
+    expect(fiatInput.value).toBe('$0.44')
+  })
+
+  it('updates value starting with comma decimal separator', async () => {
+    siaCentralExchangeRateEndpoint('1')
+    const user = userEvent.setup()
+    const onChange = jest.fn()
+    const { scInput, fiatInput } = await renderNode({
+      sc: new BigNumber(33),
+      locale: 'de-DE',
+      onChange,
+    })
+
+    expect(scInput.value).toBe('33')
+    expect(fiatInput.value).toBe('$33')
+    await user.click(scInput)
+    await user.clear(scInput)
+    await user.type(scInput, ',44')
+    fireEvent.blur(scInput)
+    expect(scInput.value).toBe('0,44')
+    expect(fiatInput.value).toBe('$0,44')
+  })
+
   it('works with alternate locale: DE', async () => {
     siaCentralExchangeRateEndpoint('1')
     const user = userEvent.setup()

--- a/libs/react-core/src/useAppSettings/index.tsx
+++ b/libs/react-core/src/useAppSettings/index.tsx
@@ -8,6 +8,7 @@ import { useGpuFeatures } from './useGpuFeatures'
 import { clearAllSwrKeys } from '../utils'
 import { useWorkflows } from '../workflows'
 import { CurrencyId, CurrencyOption, currencyOptions } from './currency'
+import { useIsAuthenticatedRoute } from './useIsAuthenticatedRoute'
 
 export type CurrencyDisplay = 'sc' | 'fiat' | 'bothPreferSc' | 'bothPreferFiat'
 
@@ -147,7 +148,11 @@ function useAppSettingsMain({
     pathname,
   ])
 
+  const isAuthenticatedRoute = useIsAuthenticatedRoute({
+    login: lockRoutes?.login || '/login',
+  })
   const isUnlocked = useMemo(() => !!settings.password, [settings])
+  const isUnlockedAndAuthedRoute = isUnlocked && isAuthenticatedRoute
 
   const gpu = useGpuFeatures()
 
@@ -158,7 +163,7 @@ function useAppSettingsMain({
     currencyOptions,
     gpu,
     lock,
-    isUnlocked,
+    isUnlockedAndAuthedRoute,
     passwordProtectRequestHooks,
     setOnLockCallback,
   }

--- a/libs/react-core/src/useAppSettings/useIsAuthenticatedRoute.ts
+++ b/libs/react-core/src/useAppSettings/useIsAuthenticatedRoute.ts
@@ -1,12 +1,12 @@
 'use client'
 
-import { useRouter } from 'next/router'
+import { usePathname } from 'next/navigation'
 
 type UnauthenticatedRoutes = {
   login: string
 }
 
 export function useIsAuthenticatedRoute(routes: UnauthenticatedRoutes) {
-  const router = useRouter()
-  return ![routes.login].includes(router.asPath)
+  const pathname = usePathname()
+  return ![routes.login].includes(pathname)
 }

--- a/libs/react-core/src/useAppSettings/useIsAuthenticatedRoute.ts
+++ b/libs/react-core/src/useAppSettings/useIsAuthenticatedRoute.ts
@@ -1,0 +1,12 @@
+'use client'
+
+import { useRouter } from 'next/router'
+
+type UnauthenticatedRoutes = {
+  login: string
+}
+
+export function useIsAuthenticatedRoute(routes: UnauthenticatedRoutes) {
+  const router = useRouter()
+  return ![routes.login].includes(router.asPath)
+}

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -625,3 +625,101 @@ export function useAlertsDismiss(
 export function useSlabObjects(args: HookArgsSwr<{ key: string }, ObjEntry[]>) {
   return useGetSwr({ ...args, route: '/bus/slab/:key/objects' })
 }
+
+// metrics
+
+type MetricsParams = {
+  start: string
+  interval: number
+  n: number
+}
+
+type ContractMetric = {
+  timeStamp: string
+  contractID: string
+  hostKey: string
+  remainingCollateral: string
+  remainingFunds: string
+  revisionNumber: number
+  uploadSpending: string
+  downloadSpending: string
+  fundAccountSpending: string
+  deleteSpending: string
+  listSpending: string
+}
+
+type ContractMetricsParams = MetricsParams & {
+  contractID: string
+  hostKey: string
+}
+
+export function useMetricsContract(
+  args: HookArgsSwr<ContractMetricsParams, ContractMetric[]>
+) {
+  return useGetSwr({ ...args, route: '/bus/metric/contract' })
+}
+
+type ContractSetMetric = {
+  contracts: number
+  name: string
+  timestamp: string
+}
+
+type ContractSetMetricsParams = MetricsParams & {
+  name: string
+}
+
+export function useMetricsContractSet(
+  args: HookArgsSwr<ContractSetMetricsParams, ContractSetMetric[]>
+) {
+  return useGetSwr({ ...args, route: '/bus/metric/contractset' })
+}
+
+type ContractSetChurnMetric = {
+  direction: string
+  contractID: string
+  name: string
+  reason: string
+  timestamp: string
+}
+
+type ContractSetChurnMetricsParams = MetricsParams & {
+  name: string
+  direction: string
+  reason: string
+}
+
+export function useMetricsContractSetChurn(
+  args: HookArgsSwr<ContractSetChurnMetricsParams, ContractSetChurnMetric[]>
+) {
+  return useGetSwr({ ...args, route: '/bus/metric/churn' })
+}
+
+type WalletMetric = {
+  timestamp: string
+  confirmed: string
+  spendable: string
+  unconfirmed: string
+}
+
+type WalletMetricsParams = MetricsParams
+
+export function useMetricsWallet(
+  args: HookArgsSwr<WalletMetricsParams, WalletMetric[]>
+) {
+  return useGetSwr({ ...args, route: '/bus/metric/wallet' })
+}
+
+// type PerformanceMetric = {
+//   action: string
+//   hostKey: string
+//   origin: string
+//   duration: number
+//   timestamp: string
+// }
+
+// type PerformanceMetricsParams = MetricsParams & {
+//   action: string
+//   hostKey: string
+//   origin: string
+// }

--- a/libs/react-renterd/src/siaTypes.ts
+++ b/libs/react-renterd/src/siaTypes.ts
@@ -236,12 +236,6 @@ export interface Block {
   transactions?: Transaction[]
 }
 
-export interface Announcement {
-  Index: ChainIndex
-  Timestamp: string
-  NetAddress: string
-}
-
 export interface Interaction {
   Timestamp: string
   Type: string
@@ -253,16 +247,16 @@ export interface Host {
   netAddress: string
   knownSince: string
   lastAnnouncement: string
-  Announcements?: Announcement[]
   interactions: {
-    Downtime: number
-    FailedInteractions: number
-    LastScan?: string
-    LastScanSuccess: boolean
-    SecondToLastScanSuccess: boolean
-    SuccessfulInteractions: number
-    TotalScans: number
-    Uptime: number
+    downtime: number
+    failedInteractions: number
+    lastScan?: string
+    lastScanSuccess: boolean
+    lostSectors: number
+    secondToLastScanSuccess: boolean
+    successfulInteractions: number
+    totalScans: number
+    uptime: number
   }
   scanned: boolean
   priceTable?: {

--- a/libs/react-renterd/src/siaTypes.ts
+++ b/libs/react-renterd/src/siaTypes.ts
@@ -356,6 +356,7 @@ export interface AutopilotContractsConfig {
   download: number
   upload: number
   storage: number
+  prune: boolean
 }
 
 export interface AutopilotConfig {


### PR DESCRIPTION
- Fixed an issue where number fields would not properly handle user input starting with a decimal separator.
- Fixed an issue with the host interaction values showing as 0s on the host explorer.
- The advanced configuration now includes a prune sector roots setting.
- The wallet page now shows the balance evolution again, using the new wallet metrics API.
- The onboarding wizard no longer shows on the login page.