### PR TITLE
renterd aggregate contract stats, partial slab heath, alerts all filter, faucet limit

### DIFF
--- a/.changeset/old-tomatoes-divide.md
+++ b/.changeset/old-tomatoes-divide.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The faucet validation now allows up to 50,000 SC.

--- a/.changeset/spicy-colts-glow.md
+++ b/.changeset/spicy-colts-glow.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contracts feature now includes a graph of aggregate funding and spending across all active contracts.

--- a/.changeset/swift-apples-allow.md
+++ b/.changeset/swift-apples-allow.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contracts feature now includes a contract count graph for the autopilot contract set.

--- a/.changeset/swift-tools-remain.md
+++ b/.changeset/swift-tools-remain.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+Updated the object partial slab response structure.

--- a/.changeset/tender-peaches-breathe.md
+++ b/.changeset/tender-peaches-breathe.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed an issue with the file health popover and updated it to display more accurate information.

--- a/.changeset/witty-peaches-help.md
+++ b/.changeset/witty-peaches-help.md
@@ -1,0 +1,7 @@
+---
+'hostd': minor
+'renterd': minor
+'@siafoundation/design-system': minor
+---
+
+The alerts dialog now has an "all" filter.

--- a/apps/explorer/components/Faucet/FaucetFundForm.tsx
+++ b/apps/explorer/components/Faucet/FaucetFundForm.tsx
@@ -25,8 +25,8 @@ const validationSchema = Yup.object().shape({
       'Must be greater than 0 SC',
       (val) => !new BigNumber(val || 0).isZero()
     )
-    .test('less than 1000', 'Must be 1,000 SC or less', (val) =>
-      new BigNumber(val || 0).lte(1000)
+    .test('less than 1000', 'Must be 50,000 SC or less', (val) =>
+      new BigNumber(val || 0).lte(50_000)
     ),
 })
 

--- a/apps/renterd/components/Contracts/ContractMetrics.tsx
+++ b/apps/renterd/components/Contracts/ContractMetrics.tsx
@@ -1,28 +1,82 @@
-import { ChartXY, Text, stripPrefix } from '@siafoundation/design-system'
+import { Button, ChartXY, stripPrefix } from '@siafoundation/design-system'
 import { useContracts } from '../../contexts/contracts'
+import { StateNoData } from './StateNoData'
 
 export function ContractMetrics() {
-  const { selectedContract, contractMetrics } = useContracts()
+  const {
+    selectedContract,
+    allContractsSpendingMetrics,
+    selectedContractSpendingMetrics,
+    contractSetCountMetrics,
+    graphMode,
+    setGraphMode,
+  } = useContracts()
 
-  if (!selectedContract) {
-    return null
-  }
+  const tabsEl = (
+    <div className="flex gap-2">
+      {!selectedContract && (
+        <Button
+          variant={graphMode === 'spending' ? 'accent' : 'gray'}
+          onClick={() => setGraphMode('spending')}
+        >
+          Funding & spending: All contracts
+        </Button>
+      )}
+      {selectedContract && (
+        <Button
+          variant={graphMode === 'spending' ? 'accent' : 'gray'}
+          onClick={() => setGraphMode('spending')}
+        >
+          Funding & spending: Contract{' '}
+          {stripPrefix(selectedContract.id).slice(0, 6)}
+        </Button>
+      )}
+      {!selectedContract && (
+        <Button
+          variant={graphMode === 'count' ? 'accent' : 'gray'}
+          onClick={() => setGraphMode('count')}
+        >
+          Count
+        </Button>
+      )}
+    </div>
+  )
 
   return (
-    <ChartXY
-      id="fundingAndSpending"
-      height="100%"
-      data={contractMetrics.data}
-      config={contractMetrics.config}
-      isLoading={contractMetrics.isLoading}
-      actionsLeft={
-        <>
-          <Text font="mono" weight="semibold">
-            Contract {stripPrefix(selectedContract.id).slice(0, 6)}: funding &
-            spending
-          </Text>
-        </>
-      }
-    />
+    <div className="w-full h-full">
+      {graphMode === 'spending' && !selectedContract && (
+        <ChartXY
+          id="fundingAndSpending"
+          height="100%"
+          data={allContractsSpendingMetrics.data}
+          config={allContractsSpendingMetrics.config}
+          isLoading={allContractsSpendingMetrics.isLoading}
+          actionsLeft={tabsEl}
+          emptyState={<StateNoData />}
+        />
+      )}
+      {graphMode === 'spending' && selectedContract && (
+        <ChartXY
+          id="fundingAndSpending"
+          height="100%"
+          data={selectedContractSpendingMetrics.data}
+          config={selectedContractSpendingMetrics.config}
+          isLoading={selectedContractSpendingMetrics.isLoading}
+          actionsLeft={tabsEl}
+          emptyState={<StateNoData />}
+        />
+      )}
+      {graphMode === 'count' && !selectedContract && (
+        <ChartXY
+          id="count"
+          height="100%"
+          data={contractSetCountMetrics.data}
+          config={contractSetCountMetrics.config}
+          isLoading={contractSetCountMetrics.isLoading}
+          actionsLeft={tabsEl}
+          emptyState={<StateNoData />}
+        />
+      )}
+    </div>
   )
 }

--- a/apps/renterd/components/Contracts/ContractsActionsMenu.tsx
+++ b/apps/renterd/components/Contracts/ContractsActionsMenu.tsx
@@ -1,8 +1,20 @@
+import { Button } from '@siafoundation/design-system'
+import { useContracts } from '../../contexts/contracts'
 import { ContractsViewDropdownMenu } from './ContractsViewDropdownMenu'
+import { ChartArea16 } from '@siafoundation/react-icons'
 
 export function ContractsActionsMenu() {
+  const { setViewMode } = useContracts()
   return (
     <div className="flex gap-2">
+      <Button
+        tip="Toggle graphs"
+        onClick={() =>
+          setViewMode((mode) => (mode === 'detail' ? 'list' : 'detail'))
+        }
+      >
+        <ChartArea16 />
+      </Button>
       <ContractsViewDropdownMenu />
     </div>
   )

--- a/apps/renterd/components/Contracts/StateNoData.tsx
+++ b/apps/renterd/components/Contracts/StateNoData.tsx
@@ -1,0 +1,15 @@
+import { Text } from '@siafoundation/design-system'
+import { ChartArea32 } from '@siafoundation/react-icons'
+
+export function StateNoData() {
+  return (
+    <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
+      <Text>
+        <ChartArea32 className="scale-[200%]" />
+      </Text>
+      <Text color="subtle" className="text-center max-w-[500px]">
+        No data available.
+      </Text>
+    </div>
+  )
+}

--- a/apps/renterd/contexts/contracts/types.ts
+++ b/apps/renterd/contexts/contracts/types.ts
@@ -138,6 +138,7 @@ export const sortOptions: {
 ]
 
 export type ViewMode = 'list' | 'detail'
+export type GraphMode = 'spending' | 'count'
 
 export type ChartContractKey =
   | 'uploadSpending'
@@ -148,3 +149,11 @@ export type ChartContractKey =
   | 'remainingFunds'
 
 export type ChartContractCategory = 'funding' | 'spending'
+
+export type ChartContractSetKey = 'contracts'
+
+export type ChartContractSetCategory = never
+
+export type ChartContractSetChurnKey = 'contracts'
+
+export type ChartContractSetChurnCategory = never

--- a/apps/renterd/contexts/contracts/useContractMetrics.tsx
+++ b/apps/renterd/contexts/contracts/useContractMetrics.tsx
@@ -1,0 +1,156 @@
+import {
+  daysInMilliseconds,
+  Chart,
+  formatChartData,
+  computeChartStats,
+  ValueScFiat,
+  colors,
+  getDataIntervalLabelFormatter,
+} from '@siafoundation/design-system'
+import {
+  ContractMetricsParams,
+  useMetricsContract,
+} from '@siafoundation/react-renterd'
+import { useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+import { ChartContractCategory, ChartContractKey } from './types'
+import { humanSiacoin } from '@siafoundation/units'
+import { getTimeClampedToNearest5min } from './utils'
+
+export function useContractMetrics({
+  start: _start,
+  disabled,
+  contractId,
+}: {
+  contractId?: string
+  disabled?: boolean
+  start: number
+}) {
+  // don't use exact times, round to 5 minutes so that swr can cache
+  // if the user flips back and forth between contracts.
+  const start = getTimeClampedToNearest5min(_start)
+  const interval = daysInMilliseconds(1)
+  const periods = useMemo(() => {
+    const now = new Date().getTime()
+    const today = getTimeClampedToNearest5min(now)
+    const span = today - start
+    return Math.round(span / interval)
+  }, [start, interval])
+
+  const params = useMemo(() => {
+    const p: ContractMetricsParams = {
+      start: new Date(start || 0).toISOString(),
+      interval,
+      n: periods,
+    }
+    if (contractId) {
+      p.contractID = contractId
+    }
+    return p
+  }, [start, interval, periods, contractId])
+
+  const contractMetricsResponse = useMetricsContract({
+    disabled,
+    params,
+  })
+
+  const contractMetrics = useMemo<
+    Chart<ChartContractKey, ChartContractCategory>
+  >(() => {
+    const data = formatChartData(
+      contractMetricsResponse.data?.map((m) => ({
+        uploadSpending: Number(m.uploadSpending),
+        listSpending: Number(m.listSpending),
+        deleteSpending: Number(m.deleteSpending),
+        fundAccountSpending: Number(m.fundAccountSpending),
+        remainingCollateral: Number(m.remainingCollateral),
+        remainingFunds: Number(m.remainingFunds),
+        timestamp: new Date(m.timestamp).getTime(),
+      })),
+      'none'
+    )
+    const stats = computeChartStats(data)
+    return {
+      data,
+      stats,
+      config: {
+        enabledGraph: [
+          'remainingFunds',
+          'remainingCollateral',
+          'fundAccountSpending',
+          'uploadSpending',
+          'listSpending',
+          'deleteSpending',
+        ],
+        enabledTip: [
+          'remainingFunds',
+          'remainingCollateral',
+          'fundAccountSpending',
+          'uploadSpending',
+          'listSpending',
+          'deleteSpending',
+        ],
+        categories: ['funding', 'spending'],
+        data: {
+          remainingFunds: {
+            label: 'remaining funds',
+            category: 'funding',
+            color: colors.emerald[600],
+          },
+          remainingCollateral: {
+            label: 'remaining collateral',
+            category: 'funding',
+            pattern: true,
+            color: colors.emerald[600],
+          },
+          fundAccountSpending: {
+            label: 'fund account',
+            category: 'spending',
+            color: colors.red[600],
+          },
+          uploadSpending: {
+            label: 'upload',
+            category: 'spending',
+            color: colors.red[600],
+          },
+          listSpending: {
+            label: 'list',
+            category: 'spending',
+            color: colors.red[600],
+          },
+          deleteSpending: {
+            label: 'delete',
+            category: 'spending',
+            color: colors.red[600],
+          },
+        },
+        formatComponent: function ({ value }) {
+          return <ValueScFiat variant="value" value={new BigNumber(value)} />
+        },
+        formatTimestamp:
+          interval === daysInMilliseconds(1)
+            ? getDataIntervalLabelFormatter('daily')
+            : undefined,
+        formatTickY: (v) =>
+          humanSiacoin(v, {
+            fixed: 0,
+            dynamicUnits: true,
+          }),
+        disableAnimations: true,
+        chartType: 'barstack',
+        curveType: 'linear',
+        stackOffset: 'none',
+      },
+      isLoading:
+        contractMetricsResponse.isValidating && !contractMetricsResponse.data,
+    }
+  }, [
+    contractMetricsResponse.data,
+    contractMetricsResponse.isValidating,
+    interval,
+  ])
+
+  return {
+    contractMetrics,
+  }
+}

--- a/apps/renterd/contexts/contracts/useContractSetMetrics.tsx
+++ b/apps/renterd/contexts/contracts/useContractSetMetrics.tsx
@@ -1,0 +1,85 @@
+import {
+  daysInMilliseconds,
+  Chart,
+  formatChartData,
+  computeChartStats,
+  colors,
+  getDataIntervalLabelFormatter,
+} from '@siafoundation/design-system'
+import {
+  useAutopilotConfig,
+  useMetricsContractSet,
+} from '@siafoundation/react-renterd'
+import { useMemo } from 'react'
+import { ChartContractSetCategory, ChartContractSetKey } from './types'
+import { getTimeClampedToNearest5min } from './utils'
+
+export function useContractSetMetrics() {
+  // don't use exact times, round to 5 minutes so that swr can cache
+  // if the user flips back and forth between contracts.
+  const start = getTimeClampedToNearest5min(
+    new Date().getTime() - daysInMilliseconds(30)
+  )
+  const interval = daysInMilliseconds(1)
+  const periods = useMemo(() => {
+    const now = new Date().getTime()
+    const today = getTimeClampedToNearest5min(now)
+    const span = today - start
+    return Math.round(span / interval)
+  }, [start, interval])
+
+  const config = useAutopilotConfig()
+  const response = useMetricsContractSet({
+    disabled: !config.data,
+    params: {
+      name: config.data?.contracts.set,
+      start: new Date(start).toISOString(),
+      interval,
+      n: periods,
+    },
+  })
+
+  const contractSetMetrics = useMemo<
+    Chart<ChartContractSetKey, ChartContractSetCategory>
+  >(() => {
+    const data = formatChartData(
+      response.data?.map((m) => ({
+        contracts: Number(m.contracts),
+        timestamp: new Date(m.timestamp).getTime(),
+      })),
+      'none'
+    )
+    const stats = computeChartStats(data)
+    return {
+      data,
+      stats,
+      config: {
+        enabledGraph: ['contracts'],
+        enabledTip: ['contracts'],
+        data: {
+          contracts: {
+            label: 'contracts',
+            color: colors.emerald[600],
+          },
+        },
+        // formatComponent: function ({ value }) {
+        //   return <ValueScFiat variant="value" value={new BigNumber(value)} />
+        // },
+        formatTimestamp:
+          interval === daysInMilliseconds(1)
+            ? getDataIntervalLabelFormatter('daily')
+            : undefined,
+        // formatTickY: (v) => `${v} contracts`,
+        disableAnimations: true,
+        chartType: 'line',
+        curveType: 'linear',
+        stackOffset: 'none',
+      },
+      isLoading: response.isValidating && !response.data,
+    }
+  }, [response.data, response.isValidating, interval])
+
+  return {
+    contractSetMetrics,
+  }
+}

--- a/apps/renterd/contexts/contracts/utils.ts
+++ b/apps/renterd/contexts/contracts/utils.ts
@@ -1,0 +1,6 @@
+import { minutesInMilliseconds } from '@siafoundation/design-system'
+
+export function getTimeClampedToNearest5min(t: number) {
+  const granularity = minutesInMilliseconds(5)
+  return Math.round(t / granularity) * granularity
+}

--- a/apps/renterd/dialogs/AlertsDialog.tsx
+++ b/apps/renterd/dialogs/AlertsDialog.tsx
@@ -183,6 +183,11 @@ const dataFields: Record<
         params: {
           key: value,
         },
+        config: {
+          swr: {
+            revalidateOnFocus: false,
+          },
+        },
       })
       return (
         <>

--- a/libs/design-system/src/app/AlertsDialog/index.tsx
+++ b/libs/design-system/src/app/AlertsDialog/index.tsx
@@ -99,38 +99,32 @@ export function AlertsDialog({
           </Heading>
           <div className="flex gap-1">
             <Button
+              variant={filter === undefined ? 'accent' : 'gray'}
+              onClick={() => setFilter(undefined)}
+            >
+              all
+            </Button>
+            <Button
               variant={filter === 'info' ? 'accent' : 'gray'}
-              onClick={() =>
-                filter === 'info' ? setFilter(undefined) : setFilter('info')
-              }
+              onClick={() => setFilter('info')}
             >
               info
             </Button>
             <Button
               variant={filter === 'warning' ? 'accent' : 'gray'}
-              onClick={() =>
-                filter === 'warning'
-                  ? setFilter(undefined)
-                  : setFilter('warning')
-              }
+              onClick={() => setFilter('warning')}
             >
               warning
             </Button>
             <Button
               variant={filter === 'error' ? 'accent' : 'gray'}
-              onClick={() =>
-                filter === 'error' ? setFilter(undefined) : setFilter('error')
-              }
+              onClick={() => setFilter('error')}
             >
               error
             </Button>
             <Button
               variant={filter === 'critical' ? 'accent' : 'gray'}
-              onClick={() =>
-                filter === 'critical'
-                  ? setFilter(undefined)
-                  : setFilter('critical')
-              }
+              onClick={() => setFilter('critical')}
             >
               critical
             </Button>

--- a/libs/design-system/src/components/ChartXY/index.tsx
+++ b/libs/design-system/src/components/ChartXY/index.tsx
@@ -30,6 +30,7 @@ type Props<Key extends string, Cat extends string> = {
   stackOffset?: StackOffset
   actionsRight?: React.ReactNode
   actionsLeft?: React.ReactNode
+  emptyState?: React.ReactNode
   allowConfiguration?: boolean
   variant?: 'panel' | 'ghost'
 }
@@ -42,6 +43,7 @@ export function ChartXY<Key extends string, Cat extends string>({
   actionsLeft,
   isLoading,
   actionsRight,
+  emptyState,
   variant = 'panel',
   allowConfiguration = true,
 }: Props<Key, Cat>) {
@@ -62,6 +64,8 @@ export function ChartXY<Key extends string, Cat extends string>({
             <div className="flex items-center justify-center h-full">
               <LoadingDots className="scale-150" />
             </div>
+          ) : data.length === 0 && emptyState ? (
+            emptyState
           ) : (
             <ChartXYGraph {...props} width={width} height={height} />
           )

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -702,13 +702,13 @@ export function useSlabObjects(args: HookArgsSwr<{ key: string }, ObjEntry[]>) {
 
 // metrics
 
-type MetricsParams = {
+export type MetricsParams = {
   start: string
   interval: number
   n: number
 }
 
-type ContractMetric = {
+export type ContractMetric = {
   timestamp: string
   contractID: string
   hostKey: string
@@ -722,7 +722,7 @@ type ContractMetric = {
   listSpending: string
 }
 
-type ContractMetricsParams = MetricsParams & {
+export type ContractMetricsParams = MetricsParams & {
   contractID?: string
   hostKey?: string
 }
@@ -733,13 +733,13 @@ export function useMetricsContract(
   return useGetSwr({ ...args, route: '/bus/metric/contract' })
 }
 
-type ContractSetMetric = {
+export type ContractSetMetric = {
   contracts: number
   name: string
   timestamp: string
 }
 
-type ContractSetMetricsParams = MetricsParams & {
+export type ContractSetMetricsParams = MetricsParams & {
   name: string
 }
 
@@ -749,7 +749,7 @@ export function useMetricsContractSet(
   return useGetSwr({ ...args, route: '/bus/metric/contractset' })
 }
 
-type ContractSetChurnMetric = {
+export type ContractSetChurnMetric = {
   direction: string
   contractID: string
   name: string
@@ -757,10 +757,10 @@ type ContractSetChurnMetric = {
   timestamp: string
 }
 
-type ContractSetChurnMetricsParams = MetricsParams & {
+export type ContractSetChurnMetricsParams = MetricsParams & {
   name: string
-  direction: string
-  reason: string
+  direction?: string
+  reason?: string
 }
 
 export function useMetricsContractSetChurn(
@@ -769,14 +769,14 @@ export function useMetricsContractSetChurn(
   return useGetSwr({ ...args, route: '/bus/metric/churn' })
 }
 
-type WalletMetric = {
+export type WalletMetric = {
   timestamp: string
   confirmed: string
   spendable: string
   unconfirmed: string
 }
 
-type WalletMetricsParams = MetricsParams
+export type WalletMetricsParams = MetricsParams
 
 export function useMetricsWallet(
   args: HookArgsSwr<WalletMetricsParams, WalletMetric[]>
@@ -784,7 +784,7 @@ export function useMetricsWallet(
   return useGetSwr({ ...args, route: '/bus/metric/wallet' })
 }
 
-// type PerformanceMetric = {
+// export type PerformanceMetric = {
 //   action: string
 //   hostKey: string
 //   origin: string
@@ -792,7 +792,7 @@ export function useMetricsWallet(
 //   timestamp: string
 // }
 
-// type PerformanceMetricsParams = MetricsParams & {
+// export type PerformanceMetricsParams = MetricsParams & {
 //   action: string
 //   hostKey: string
 //   origin: string

--- a/libs/react-renterd/src/siaTypes.ts
+++ b/libs/react-renterd/src/siaTypes.ts
@@ -91,7 +91,8 @@ export type Slab = {
   health: number
   key: EncryptionKey
   minShards: number
-  shards: Sector[]
+  // if no shards, then its a partial slab
+  shards?: Sector[]
 }
 
 export type SlabSlice = {
@@ -105,12 +106,10 @@ export type Obj = {
   size: number
   health: number
   key: EncryptionKey
-  slabs?: SlabSlice[]
-  partialSlab?: {
-    minShards: number
-    totalShards: number
-    data?: string
-  }
+  eTag: string
+  mimeType: string
+  modTime: string
+  slabs: SlabSlice[]
 }
 
 export type ContractSetSettings = {


### PR DESCRIPTION
- The contracts feature now includes a graph of aggregate funding and spending across all active contracts.
- The contracts feature now includes a contract count graph for the autopilot contract set.
- The alerts dialog now has an "all" filter. https://github.com/SiaFoundation/hostd/issues/197
- Fixed an issue with the file health popover and updated it to display more accurate information. https://github.com/SiaFoundation/renterd/issues/804
- Updated the object partial slab response structure.
- The faucet validation now allows up to 50,000 SC.