### PR TITLE
renterd host context menu copy, redundancy tooltip, prune validation, refine contract graph

### DIFF
--- a/.changeset/neat-mayflies-remember.md
+++ b/.changeset/neat-mayflies-remember.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The host context menu now has options for copying public key or address to clipboard.

--- a/.changeset/tidy-zebras-exist.md
+++ b/.changeset/tidy-zebras-exist.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The redundancy tooltip now correctly describes the ratio as total shards / min shards.

--- a/.changeset/witty-dryers-camp.md
+++ b/.changeset/witty-dryers-camp.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed an issue with the prune sector roots setting validation.

--- a/apps/renterd/components/Contracts/index.tsx
+++ b/apps/renterd/components/Contracts/index.tsx
@@ -26,15 +26,17 @@ export function Contracts() {
     cellContext,
     error,
     viewMode,
+    filters,
     selectedContract,
   } = useContracts()
 
-  const listHeight =
-    viewMode === 'detail'
-      ? datasetPage && datasetPage.length
-        ? `${400 - Math.max((2 - datasetPage.length) * 100, 0)}px`
-        : '400px'
-      : '100%'
+  const showDetailView =
+    viewMode === 'detail' && (!filters.length || selectedContract)
+  const listHeight = showDetailView
+    ? datasetPage && datasetPage.length
+      ? `${400 - Math.max((2 - datasetPage.length) * 100, 0)}px`
+      : '400px'
+    : '100%'
 
   return (
     <RenterdAuthedLayout
@@ -51,15 +53,15 @@ export function Contracts() {
         <div
           className={cx(
             'absolute w-full',
-            viewMode === 'detail' ? 'block' : 'invisible',
+            showDetailView ? 'block' : 'invisible',
             'transition-all',
             'p-6'
           )}
           style={{
-            height: `calc(100% - ${listHeight})`,
+            height: showDetailView ? `calc(100% - ${listHeight})` : 0,
           }}
         >
-          <ContractMetrics />
+          {showDetailView ? <ContractMetrics /> : null}
         </div>
         <div
           className={cx(
@@ -74,10 +76,7 @@ export function Contracts() {
         >
           <ScrollArea className="z-0" id="scroll-hosts">
             <div
-              className={cx(
-                viewMode === 'detail' ? 'pb-6 px-6' : 'p-6',
-                'min-w-fit'
-              )}
+              className={cx(showDetailView ? 'pb-6 px-6' : 'p-6', 'min-w-fit')}
             >
               <Table
                 context={cellContext}

--- a/apps/renterd/components/Hosts/HostContextMenu.tsx
+++ b/apps/renterd/components/Hosts/HostContextMenu.tsx
@@ -7,12 +7,14 @@ import {
   Text,
   secondsInMilliseconds,
   truncate,
+  copyToClipboard,
 } from '@siafoundation/design-system'
 import {
   Draggable16,
   DataView16,
   ListChecked16,
   Filter16,
+  Copy16,
 } from '@siafoundation/react-icons'
 import {
   useHostsAllowlist,
@@ -172,6 +174,23 @@ export function HostContextMenu({
           Add public key to allowlist
         </DropdownMenuItem>
       )}
+      <DropdownMenuLabel>Copy</DropdownMenuLabel>
+      <DropdownMenuItem
+        onSelect={() => copyToClipboard(publicKey, 'host public key')}
+      >
+        <DropdownMenuLeftSlot>
+          <Copy16 />
+        </DropdownMenuLeftSlot>
+        Host public key
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={() => copyToClipboard(address, 'host address')}
+      >
+        <DropdownMenuLeftSlot>
+          <Copy16 />
+        </DropdownMenuLeftSlot>
+        Host address
+      </DropdownMenuItem>
     </DropdownMenu>
   )
 }

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -704,7 +704,7 @@ function getRedundancyTip(
         </Text>
         <Text color="subtle">
           Redundancy is calculated from the ratio of data shards:{' '}
-          <Code>min shards / total shards</Code>.
+          <Code>total shards / min shards</Code>.
         </Text>
       </div>
     )

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -213,12 +213,7 @@ export function getFields({
         </>
       ),
       hidden: !isAutopilotEnabled || !showAdvanced,
-      validation:
-        isAutopilotEnabled && showAdvanced
-          ? {
-              required: 'required',
-            }
-          : {},
+      validation: {},
     },
 
     // hosts

--- a/libs/design-system/src/core/InfoTip.tsx
+++ b/libs/design-system/src/core/InfoTip.tsx
@@ -9,7 +9,7 @@ type Props = {
 export function InfoTip({ children }: Props) {
   return (
     <Tooltip content={children}>
-      <div className="relative flex items-center inline mx-1">
+      <div className="relative items-center inline mx-1">
         <Text color="subtle">
           <Information16 className="scale-75" />
         </Text>


### PR DESCRIPTION
- The host context menu now has options for copying public key or address to clipboard.
- The redundancy tooltip now correctly describes the ratio as total shards / min shards. https://github.com/SiaFoundation/renterd/issues/810
- Fixed an issue with the prune sector roots setting validation.  https://github.com/SiaFoundation/renterd/issues/812