### PR TITLE
renterd contract graphs, suggested pricing, balances, host data metrics, other bugs

### DIFF
--- a/.changeset/blue-eels-shake.md
+++ b/.changeset/blue-eels-shake.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+ChartXY no longer adds padding point for barstack and bargroup.

--- a/.changeset/bright-chicken-live.md
+++ b/.changeset/bright-chicken-live.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Fix bug where announcement error shows both a success and error toast.

--- a/.changeset/dull-trainers-rescue.md
+++ b/.changeset/dull-trainers-rescue.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'@siafoundation/react-hostd': minor
+---
+
+Data metrics no longer use RHP version specific data.

--- a/.changeset/funny-socks-kiss.md
+++ b/.changeset/funny-socks-kiss.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Added useServerSyncedForm.

--- a/.changeset/happy-mirrors-do.md
+++ b/.changeset/happy-mirrors-do.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+The wallet balance shown on the wallet page is now spendable plus unconfirmed.

--- a/.changeset/sharp-countries-lick.md
+++ b/.changeset/sharp-countries-lick.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contract funding and spending graph now shows a data point for brand new contracts.

--- a/.changeset/soft-pianos-boil.md
+++ b/.changeset/soft-pianos-boil.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The default suggested pricing for new users is now based on Sia Central averages.

--- a/.changeset/tough-chairs-sit.md
+++ b/.changeset/tough-chairs-sit.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+Fixed an issue where currency was displayed with too many decimals.

--- a/apps/hostd/components/Config/AnnounceButton.tsx
+++ b/apps/hostd/components/Config/AnnounceButton.tsx
@@ -45,6 +45,7 @@ export function AnnounceButton() {
 
           if (response.error) {
             triggerErrorToast('Error announcing host.')
+            return
           }
           triggerSuccessToast('Successfully broadcast host announcement.')
         },

--- a/apps/hostd/contexts/metrics/index.tsx
+++ b/apps/hostd/contexts/metrics/index.tsx
@@ -520,8 +520,8 @@ function useMetricsMain() {
   const bandwidth = useMemo<Chart<BandwidthKeys, BandwidthCategories>>(() => {
     const data = formatChartData(
       metricsPeriod.data?.map((m) => ({
-        egress: m.data.rhp3.egress + m.data.rhp2.egress,
-        ingress: m.data.rhp3.ingress + m.data.rhp2.ingress,
+        egress: m.data.rhp.egress,
+        ingress: m.data.rhp.ingress,
         timestamp: new Date(m.timestamp).getTime(),
       })),
       'delta'

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -24,7 +24,7 @@ export function useConfigMain() {
     isAutopilotEnabled,
     autopilot,
     contractSet,
-    configApp,
+    display,
     gouging,
     redundancy,
     uploadPacking,
@@ -110,22 +110,22 @@ export function useConfigMain() {
   )
 
   const remoteValues: SettingsData = useMemo(() => {
-    const gougingData = buildGougingData(gouging.data)
+    const g = buildGougingData(gouging.data)
     if (
       (!isAutopilotEnabled || autopilot.data || autopilot.error) &&
-      gougingData &&
+      g &&
       redundancy.data &&
       uploadPacking.data &&
       (contractSet.data || contractSet.error) &&
-      (configApp.data || configApp.error)
+      (display.data || display.error)
     ) {
       return transformDown({
-        autopilotData: autopilot.data,
-        contractSetData: contractSet.data,
-        uploadPackingData: uploadPacking.data,
-        gougingData,
-        redundancyData: redundancy.data,
-        configAppData: configApp.data,
+        autopilot: autopilot.data,
+        contractSet: contractSet.data,
+        uploadPacking: uploadPacking.data,
+        gouging: g,
+        redundancy: redundancy.data,
+        display: display.data,
       })
     }
     return null
@@ -139,34 +139,32 @@ export function useConfigMain() {
     gouging.data,
     buildGougingData,
     redundancy.data,
-    configApp.data,
-    configApp.error,
+    display.data,
+    display.error,
   ])
 
   const revalidate = useCallback(async (): Promise<SettingsData | null> => {
-    const autopilotData = isAutopilotEnabled
-      ? await autopilot.mutate()
-      : undefined
-    const contractSetData = await contractSet.mutate()
-    const _gougingData = await gouging.mutate()
-    const redundancyData = await redundancy.mutate()
-    const uploadPackingData = await uploadPacking.mutate()
-    const configAppData = await configApp.mutate()
-    if (!_gougingData || !redundancyData) {
+    const a = isAutopilotEnabled ? await autopilot.mutate() : undefined
+    const cs = await contractSet.mutate()
+    const _g = await gouging.mutate()
+    const r = await redundancy.mutate()
+    const up = await uploadPacking.mutate()
+    const d = await display.mutate()
+    if (!_g || !r) {
       triggerErrorToast('Error fetching settings.')
       return null
     } else {
-      const gougingData = buildGougingData(_gougingData)
-      if (!gougingData) {
+      const g = buildGougingData(_g)
+      if (!g) {
         return null
       }
       return transformDown({
-        autopilotData,
-        contractSetData,
-        gougingData,
-        redundancyData,
-        uploadPackingData,
-        configAppData,
+        autopilot: a,
+        contractSet: cs,
+        gouging: g,
+        redundancy: r,
+        uploadPacking: up,
+        display: d,
       })
     }
   }, [
@@ -177,7 +175,7 @@ export function useConfigMain() {
     buildGougingData,
     uploadPacking,
     redundancy,
-    configApp,
+    display,
   ])
 
   const { isUnlockedAndAuthedRoute } = useAppSettings()
@@ -258,7 +256,7 @@ export function useConfigMain() {
     uploadPacking,
     redundancy,
     gouging,
-    configApp,
+    display,
   })
 
   const onInvalid = useOnInvalid(fields)

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -1,285 +1,193 @@
 import React, { createContext, useContext } from 'react'
 import {
-  triggerSuccessToast,
   triggerErrorToast,
   useOnInvalid,
-  minutesInMilliseconds,
+  useServerSyncedForm,
 } from '@siafoundation/design-system'
 import BigNumber from 'bignumber.js'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import {
-  AutopilotConfig,
-  autopilotHostsKey,
-  useAutopilotConfig,
-  useAutopilotConfigUpdate,
-  ContractSetSettings,
-  GougingSettings,
-  RedundancySettings,
-  UploadPackingSettings,
-  useSettingUpdate,
-  useAutopilotTrigger,
-  useBusState,
-} from '@siafoundation/react-renterd'
-import { monthsToBlocks, TBToBytes, toSiacoins } from '@siafoundation/units'
+import { useCallback, useMemo } from 'react'
+import { useBusState, GougingSettings } from '@siafoundation/react-renterd'
 import { getFields } from './fields'
-import { SettingsData, defaultValues, getAdvancedDefaults } from './types'
-import {
-  getRedundancyMultiplier,
-  getRedundancyMultiplierIfIncluded,
-  transformDown,
-  transformUpAutopilot,
-  transformUpConfigApp,
-  transformUpContractSet,
-  transformUpGouging,
-  transformUpRedundancy,
-  transformUpUploadPacking,
-} from './transform'
-import { useForm } from 'react-hook-form'
-import { useSyncContractSet } from './useSyncContractSet'
-import { delay, useAppSettings, useMutate } from '@siafoundation/react-core'
-import { useContractSetSettings } from '../../hooks/useContractSetSettings'
-import {
-  ConfigDisplayOptions,
-  configDisplayOptionsKey,
-  useConfigDisplayOptions,
-} from '../../hooks/useConfigDisplayOptions'
-import { useGougingSettings } from '../../hooks/useGougingSettings'
-import { useRedundancySettings } from '../../hooks/useRedundancySettings'
-import { useUploadPackingSettings } from '../../hooks/useUploadPackingSettings'
-import { useSiaCentralHostsNetworkAverages } from '@siafoundation/react-sia-central'
-import useLocalStorageState from 'use-local-storage-state'
-import { useApp } from '../app'
+import { SettingsData, getAdvancedDefaults } from './types'
+import { transformDown } from './transform'
+import { useAppSettings } from '@siafoundation/react-core'
+import { TBToBytes } from '@siafoundation/units'
+import { useResources } from './useResources'
+import { useOnValid } from './useOnValid'
+import { useEstimates } from './useEstimates'
+import { useForm } from './useForm'
+import { useAverages } from './useAverages'
 
 export function useConfigMain() {
-  const app = useApp()
-  const isAutopilotEnabled = app.autopilot.status === 'on'
-  // settings that 404 when empty
-  const autopilot = useAutopilotConfig({
-    disabled: !isAutopilotEnabled,
-    standalone: 'configFormAutopilot',
-    config: {
-      swr: {
-        errorRetryCount: 0,
-        refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-  const contractSet = useContractSetSettings({
-    standalone: 'configFormContractSet',
-    config: {
-      swr: {
-        errorRetryCount: 0,
-        refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-  const configApp = useConfigDisplayOptions({
-    standalone: 'configFormConfigApp',
-    config: {
-      swr: {
-        errorRetryCount: 0,
-        refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-  // settings with initial defaults
-  const gouging = useGougingSettings({
-    standalone: 'configFormGouging',
-    config: {
-      swr: {
-        refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-  const redundancy = useRedundancySettings({
-    standalone: 'configFormRedundancy',
-    config: {
-      swr: {
-        refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-  const uploadPacking = useUploadPackingSettings({
-    standalone: 'configFormUploadPacking',
-    config: {
-      swr: {
-        refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-
-  const settingUpdate = useSettingUpdate()
-
-  const averages = useSiaCentralHostsNetworkAverages({
-    config: {
-      swr: {
-        revalidateOnFocus: false,
-      },
-    },
-  })
-  const [showAdvanced, setShowAdvanced] = useLocalStorageState<boolean>(
-    'v0/config/showAdvanced',
-    {
-      defaultValue: false,
-    }
-  )
   const {
+    app,
+    isAutopilotEnabled,
+    autopilot,
+    contractSet,
+    configApp,
+    gouging,
+    redundancy,
+    uploadPacking,
+    settingUpdate,
+    averages,
+    showAdvanced,
+    setShowAdvanced,
+    mode,
     shouldSyncDefaultContractSet,
     setShouldSyncDefaultContractSet,
     syncDefaultContractSet,
-  } = useSyncContractSet()
-  const autopilotUpdate = useAutopilotConfigUpdate()
+    autopilotUpdate,
+    appSettings,
+  } = useResources()
 
-  const form = useForm({
-    mode: 'all',
-    defaultValues,
-  })
+  const {
+    form,
+    maxStoragePriceTBMonth,
+    maxDownloadPriceTB,
+    maxUploadPriceTB,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    minShards,
+    totalShards,
+    includeRedundancyMaxStoragePrice,
+    includeRedundancyMaxUploadPrice,
+    redundancyMultiplier,
+  } = useForm()
 
-  const resetFormData = useCallback(
-    (
-      autopilotData: AutopilotConfig | undefined,
-      contractSetData: ContractSetSettings | undefined,
-      uploadPackingData: UploadPackingSettings,
-      gougingData: GougingSettings,
-      redundancyData: RedundancySettings,
-      configAppData: ConfigDisplayOptions | undefined
-    ) => {
-      const settingsData = transformDown(
-        autopilotData,
-        contractSetData,
-        uploadPackingData,
-        gougingData,
-        redundancyData,
-        configAppData
-      )
-      form.reset(settingsData)
-      return settingsData
+  const { storageAverage, uploadAverage, downloadAverage, contractAverage } =
+    useAverages({
+      minShards,
+      totalShards,
+      includeRedundancyMaxStoragePrice,
+      includeRedundancyMaxUploadPrice,
+    })
+
+  // Override gouging data defaults with sia central averages.
+  // We override the remote data so that the values appear as the defaults.
+  // If we just changed the form values they would appear as a user change.
+  const buildGougingData = useCallback(
+    (gougingData: GougingSettings): GougingSettings => {
+      // wait for gouging data and for ap to be initialized
+      if (!gougingData || app.autopilot.status === 'init') {
+        return null
+      }
+      // if sia central is disabled, we cant override with averages
+      if (!appSettings.settings.siaCentral) {
+        return gougingData
+      }
+      // already configured, the user has changed the defaults
+      if (app.autopilot.state.data?.configured) {
+        return gougingData
+      }
+      if (averages.isLoading) {
+        return null
+      }
+      // first time user, override defaults
+      if (averages.data) {
+        return {
+          ...gougingData,
+          maxStoragePrice: averages.data?.settings.storage_price,
+          maxDownloadPrice: new BigNumber(
+            averages.data?.settings.download_price
+          )
+            .times(TBToBytes(1))
+            .toString(),
+          maxUploadPrice: new BigNumber(averages.data?.settings.upload_price)
+            .times(TBToBytes(1))
+            .toString(),
+        }
+      }
+      return gougingData
     },
-    [form]
-  )
-
-  const didDataRevalidate = useMemo(
-    () => [
-      autopilot.data,
-      autopilot.error,
-      contractSet.data,
-      contractSet.error,
-      uploadPacking.data,
-      gouging.data,
-      redundancy.data,
-      configApp.data,
-      configApp.error,
-    ],
     [
-      autopilot.data,
-      autopilot.error,
-      contractSet.data,
-      contractSet.error,
-      uploadPacking.data,
-      gouging.data,
-      redundancy.data,
-      configApp.data,
-      configApp.error,
+      averages.data,
+      averages.isLoading,
+      appSettings.settings.siaCentral,
+      app.autopilot.status,
+      app.autopilot.state.data?.configured,
     ]
   )
 
-  const resetFormDataIfAllDataFetched = useCallback((): SettingsData | null => {
+  const remoteValues: SettingsData = useMemo(() => {
+    const gougingData = buildGougingData(gouging.data)
     if (
       (!isAutopilotEnabled || autopilot.data || autopilot.error) &&
-      gouging.data &&
+      gougingData &&
       redundancy.data &&
       uploadPacking.data &&
       (contractSet.data || contractSet.error) &&
       (configApp.data || configApp.error)
     ) {
-      return resetFormData(
-        autopilot.data,
-        contractSet.data,
-        uploadPacking.data,
-        gouging.data,
-        redundancy.data,
-        configApp.data
-      )
+      return transformDown({
+        autopilotData: autopilot.data,
+        contractSetData: contractSet.data,
+        uploadPackingData: uploadPacking.data,
+        gougingData,
+        redundancyData: redundancy.data,
+        configAppData: configApp.data,
+      })
     }
     return null
   }, [
     isAutopilotEnabled,
-    resetFormData,
     autopilot.data,
     autopilot.error,
     contractSet.data,
     contractSet.error,
     uploadPacking.data,
     gouging.data,
+    buildGougingData,
     redundancy.data,
     configApp.data,
     configApp.error,
   ])
 
-  // init - when new config is fetched, set the form
-  const [hasInit, setHasInit] = useState(false)
-  useEffect(() => {
-    if (app.autopilot.status === 'init') {
-      return
-    }
-    if (!hasInit) {
-      const didReset = resetFormDataIfAllDataFetched()
-      if (didReset) {
-        setHasInit(true)
-      }
-    }
-  }, [hasInit, app.autopilot.status, resetFormDataIfAllDataFetched])
-
-  const revalidateAndResetFormData = useCallback(async () => {
+  const revalidate = useCallback(async (): Promise<SettingsData | null> => {
     const autopilotData = isAutopilotEnabled
       ? await autopilot.mutate()
       : undefined
     const contractSetData = await contractSet.mutate()
-    const gougingData = await gouging.mutate()
+    const _gougingData = await gouging.mutate()
     const redundancyData = await redundancy.mutate()
     const uploadPackingData = await uploadPacking.mutate()
     const configAppData = await configApp.mutate()
-    if (!gougingData || !redundancyData) {
+    if (!_gougingData || !redundancyData) {
       triggerErrorToast('Error fetching settings.')
+      return null
     } else {
-      resetFormData(
+      const gougingData = buildGougingData(_gougingData)
+      if (!gougingData) {
+        return null
+      }
+      return transformDown({
         autopilotData,
         contractSetData,
-        uploadPackingData,
         gougingData,
         redundancyData,
-        configAppData
-      )
+        uploadPackingData,
+        configAppData,
+      })
     }
   }, [
     isAutopilotEnabled,
     autopilot,
     contractSet,
     gouging,
+    buildGougingData,
     uploadPacking,
     redundancy,
     configApp,
-    resetFormData,
   ])
 
-  const maxStoragePriceTBMonth = form.watch('maxStoragePriceTBMonth')
-  const maxDownloadPriceTB = form.watch('maxDownloadPriceTB')
-  const maxUploadPriceTB = form.watch('maxUploadPriceTB')
-  const storageTB = form.watch('storageTB')
-  const downloadTBMonth = form.watch('downloadTBMonth')
-  const uploadTBMonth = form.watch('uploadTBMonth')
-  const minShards = form.watch('minShards')
-  const totalShards = form.watch('totalShards')
-  const includeRedundancyMaxStoragePrice = form.watch(
-    'includeRedundancyMaxStoragePrice'
-  )
-  const includeRedundancyMaxUploadPrice = form.watch(
-    'includeRedundancyMaxUploadPrice'
-  )
-  const redundancyMultiplier = useMemo(
-    () => getRedundancyMultiplier(minShards, totalShards),
-    [minShards, totalShards]
-  )
+  const { isUnlockedAndAuthedRoute } = useAppSettings()
+  const { revalidateAndResetFormData, changeCount } = useServerSyncedForm({
+    form,
+    remoteValues,
+    revalidate,
+    initialized: isUnlockedAndAuthedRoute,
+    mode,
+  })
 
   const renterdState = useBusState()
   const fields = useMemo(() => {
@@ -294,28 +202,10 @@ export function useConfigMain() {
         redundancyMultiplier,
         includeRedundancyMaxStoragePrice,
         includeRedundancyMaxUploadPrice,
-        storageAverage: toSiacoins(averages.data.settings.storage_price) // bytes/block
-          .times(monthsToBlocks(1)) // bytes/month
-          .times(TBToBytes(1)) // TB/month
-          .times(
-            getRedundancyMultiplierIfIncluded(
-              minShards,
-              totalShards,
-              includeRedundancyMaxStoragePrice
-            )
-          ), // redundancy
-        uploadAverage: toSiacoins(averages.data.settings.upload_price) // bytes
-          .times(TBToBytes(1)) // TB
-          .times(
-            getRedundancyMultiplierIfIncluded(
-              minShards,
-              totalShards,
-              includeRedundancyMaxUploadPrice
-            )
-          ), // redundancy
-        downloadAverage: toSiacoins(averages.data.settings.download_price) // bytes
-          .times(TBToBytes(1)), // TB
-        contractAverage: toSiacoins(averages.data.settings.contract_price),
+        storageAverage,
+        uploadAverage,
+        downloadAverage,
+        contractAverage,
       })
     }
     return getFields({
@@ -331,214 +221,45 @@ export function useConfigMain() {
     isAutopilotEnabled,
     showAdvanced,
     averages.data,
+    storageAverage,
+    uploadAverage,
+    downloadAverage,
+    contractAverage,
     redundancyMultiplier,
-    minShards,
-    totalShards,
     includeRedundancyMaxStoragePrice,
     includeRedundancyMaxUploadPrice,
   ])
 
-  const canEstimate = useMemo(() => {
-    if (!isAutopilotEnabled) {
-      return false
-    }
-    return (
-      maxStoragePriceTBMonth?.gt(0) &&
-      storageTB?.gt(0) &&
-      maxDownloadPriceTB?.gt(0) &&
-      maxUploadPriceTB?.gt(0)
-    )
-  }, [
-    isAutopilotEnabled,
-    maxStoragePriceTBMonth,
-    storageTB,
-    maxDownloadPriceTB,
-    maxUploadPriceTB,
-  ])
-
-  const estimatedSpendingPerMonth = useMemo(() => {
-    if (!canEstimate) {
-      return new BigNumber(0)
-    }
-    // if not set, just show estimate with 1 TB up/down
-    // in simple mode these are the defaults that get set anyway
-    const _downloadTBMonth = downloadTBMonth?.gt(0) ? downloadTBMonth : 1
-    const _uploadTBMonth = uploadTBMonth?.gt(0) ? uploadTBMonth : 1
-    const storageCostPerMonth = includeRedundancyMaxStoragePrice
-      ? maxStoragePriceTBMonth.times(storageTB)
-      : maxStoragePriceTBMonth.times(redundancyMultiplier).times(storageTB)
-    const downloadCostPerMonth = maxDownloadPriceTB.times(_downloadTBMonth)
-    const uploadCostPerMonth = includeRedundancyMaxUploadPrice
-      ? maxUploadPriceTB.times(_uploadTBMonth)
-      : maxUploadPriceTB.times(redundancyMultiplier).times(_uploadTBMonth)
-    const totalCostPerMonth = storageCostPerMonth
-      .plus(downloadCostPerMonth)
-      .plus(uploadCostPerMonth)
-    return totalCostPerMonth
-  }, [
-    canEstimate,
-    includeRedundancyMaxStoragePrice,
-    includeRedundancyMaxUploadPrice,
-    redundancyMultiplier,
-    maxStoragePriceTBMonth,
-    storageTB,
-    maxDownloadPriceTB,
-    downloadTBMonth,
-    maxUploadPriceTB,
-    uploadTBMonth,
-  ])
-
-  const estimatedSpendingPerTB = useMemo(() => {
-    if (!canEstimate) {
-      return new BigNumber(0)
-    }
-    const totalCostPerMonthTB = estimatedSpendingPerMonth.div(storageTB)
-    return totalCostPerMonthTB
-  }, [canEstimate, estimatedSpendingPerMonth, storageTB])
-
-  const autopilotTrigger = useAutopilotTrigger()
-  const mutate = useMutate()
-  const onValid = useCallback(
-    async (values: typeof defaultValues) => {
-      if (!gouging.data || !redundancy.data || !renterdState.data) {
-        return
-      }
-      try {
-        const calculatedValues: Partial<SettingsData> = {}
-        if (isAutopilotEnabled && !showAdvanced) {
-          calculatedValues.allowanceMonth = estimatedSpendingPerMonth
-        }
-
-        const finalValues = {
-          ...values,
-          ...calculatedValues,
-        }
-
-        const firstTimeSettingConfig = isAutopilotEnabled && !autopilot.data
-        const autopilotResponse = isAutopilotEnabled
-          ? await autopilotUpdate.put({
-              payload: transformUpAutopilot(
-                renterdState.data.network,
-                finalValues,
-                autopilot.data
-              ),
-            })
-          : undefined
-
-        const [
-          contractSetResponse,
-          uploadPackingResponse,
-          gougingResponse,
-          redundancyResponse,
-          configAppResponse,
-        ] = await Promise.all([
-          settingUpdate.put({
-            params: {
-              key: 'contractset',
-            },
-            payload: transformUpContractSet(finalValues, contractSet.data),
-          }),
-          settingUpdate.put({
-            params: {
-              key: 'uploadpacking',
-            },
-            payload: transformUpUploadPacking(finalValues, uploadPacking.data),
-          }),
-          settingUpdate.put({
-            params: {
-              key: 'gouging',
-            },
-            payload: transformUpGouging(finalValues, gouging.data),
-          }),
-          settingUpdate.put({
-            params: {
-              key: 'redundancy',
-            },
-            payload: transformUpRedundancy(finalValues, redundancy.data),
-          }),
-          settingUpdate.put({
-            params: {
-              key: configDisplayOptionsKey,
-            },
-            payload: transformUpConfigApp(finalValues, configApp.data),
-          }),
-        ])
-
-        if (autopilotResponse?.error) {
-          throw Error(autopilotResponse.error)
-        }
-        if (contractSetResponse.error) {
-          throw Error(contractSetResponse.error)
-        }
-        if (uploadPackingResponse.error) {
-          throw Error(uploadPackingResponse.error)
-        }
-        if (gougingResponse.error) {
-          throw Error(gougingResponse.error)
-        }
-        if (redundancyResponse.error) {
-          throw Error(redundancyResponse.error)
-        }
-        if (configAppResponse.error) {
-          throw Error(configAppResponse.error)
-        }
-
-        if (isAutopilotEnabled) {
-          // Sync default contract set if necessary. Only syncs if the setting
-          // is enabled in case the user changes in advanced mode and then
-          // goes back to simple mode.
-          // Might be simpler nice to just override in simple mode without a
-          // special setting since this is how other settings like allowance
-          // behave - but leaving for now.
-          syncDefaultContractSet(finalValues.autopilotContractSet)
-
-          // Trigger the autopilot loop with new settings applied.
-          autopilotTrigger.post({
-            payload: {
-              forceScan: true,
-            },
-          })
-        }
-
-        triggerSuccessToast('Configuration has been saved.')
-
-        // If autopilot is being configured for the first time,
-        // revalidate the empty hosts list.
-        if (firstTimeSettingConfig) {
-          const refreshHostsAfterDelay = async () => {
-            await delay(5_000)
-            mutate((key) => key.startsWith(autopilotHostsKey))
-            await delay(5_000)
-            mutate((key) => key.startsWith(autopilotHostsKey))
-          }
-          refreshHostsAfterDelay()
-        }
-
-        await revalidateAndResetFormData()
-      } catch (e) {
-        triggerErrorToast((e as Error).message)
-        console.log(e)
-      }
-    },
-    [
-      renterdState.data,
-      estimatedSpendingPerMonth,
-      showAdvanced,
+  const { canEstimate, estimatedSpendingPerMonth, estimatedSpendingPerTB } =
+    useEstimates({
       isAutopilotEnabled,
-      autopilot,
-      autopilotUpdate,
-      revalidateAndResetFormData,
-      syncDefaultContractSet,
-      mutate,
-      settingUpdate,
-      contractSet,
-      uploadPacking,
-      redundancy,
-      gouging,
-      configApp,
-      autopilotTrigger,
-    ]
-  )
+      includeRedundancyMaxStoragePrice,
+      includeRedundancyMaxUploadPrice,
+      redundancyMultiplier,
+      maxStoragePriceTBMonth,
+      storageTB,
+      maxDownloadPriceTB,
+      downloadTBMonth,
+      maxUploadPriceTB,
+      uploadTBMonth,
+    })
+
+  const onValid = useOnValid({
+    renterdState,
+    estimatedSpendingPerMonth,
+    showAdvanced,
+    isAutopilotEnabled,
+    autopilot,
+    autopilotUpdate,
+    revalidateAndResetFormData,
+    syncDefaultContractSet,
+    settingUpdate,
+    contractSet,
+    uploadPacking,
+    redundancy,
+    gouging,
+    configApp,
+  })
 
   const onInvalid = useOnInvalid(fields)
 
@@ -546,49 +267,6 @@ export function useConfigMain() {
     () => form.handleSubmit(onValid, onInvalid),
     [form, onValid, onInvalid]
   )
-
-  // Resets so that stale values that are no longer in sync with what is on
-  // the daemon will show up as changed.
-  const resetWithUserChanges = useCallback(() => {
-    const currentFormValues = form.getValues()
-    const serverFormValues = resetFormDataIfAllDataFetched()
-    if (!serverFormValues) {
-      return
-    }
-    form.reset(serverFormValues)
-    for (const [key, value] of Object.entries(currentFormValues)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      form.setValue(key as any, value, {
-        shouldDirty: true,
-      })
-    }
-  }, [form, resetFormDataIfAllDataFetched])
-
-  const { isUnlockedAndAuthedRoute } = useAppSettings()
-  useEffect(() => {
-    if (isUnlockedAndAuthedRoute && app.autopilot.status !== 'init') {
-      revalidateAndResetFormData()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUnlockedAndAuthedRoute, app.autopilot.status])
-
-  useEffect(() => {
-    if (form.formState.isSubmitting) {
-      return
-    }
-    resetWithUserChanges()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    form,
-    // if form mode is toggled reset
-    showAdvanced,
-    // if any of the settings are revalidated reset
-    didDataRevalidate,
-  ])
-
-  const changeCount = Object.entries(form.formState.dirtyFields).filter(
-    ([_, val]) => !!val
-  ).length
 
   return {
     onSubmit,

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -20,8 +20,8 @@ describe('tansforms', () => {
   describe('down', () => {
     it('default works', () => {
       expect(
-        transformDown(
-          {
+        transformDown({
+          autopilot: {
             wallet: {
               defragThreshold: 1000,
             },
@@ -43,9 +43,9 @@ describe('tansforms', () => {
               prune: true,
             },
           },
-          { default: 'myset' },
-          { enabled: true },
-          {
+          contractSet: { default: 'myset' },
+          uploadPacking: { enabled: true },
+          gouging: {
             hostBlockHeightLeeway: 4,
             maxContractPrice: '20000000000000000000000000',
             maxDownloadPrice: '1004310000000000000000000000',
@@ -58,15 +58,15 @@ describe('tansforms', () => {
             minPriceTableValidity: 300000000000,
             migrationSurchargeMultiplier: 10,
           },
-          {
+          redundancy: {
             minShards: 10,
             totalShards: 30,
           },
-          {
+          display: {
             includeRedundancyMaxStoragePrice: false,
             includeRedundancyMaxUploadPrice: false,
-          }
-        )
+          },
+        })
       ).toEqual({
         autopilotContractSet: 'autopilot',
         allowanceMonth: new BigNumber('500'),
@@ -103,8 +103,8 @@ describe('tansforms', () => {
 
     it('with include redundancy for storage and upload', () => {
       expect(
-        transformDown(
-          {
+        transformDown({
+          autopilot: {
             wallet: {
               defragThreshold: 1000,
             },
@@ -126,9 +126,9 @@ describe('tansforms', () => {
               prune: true,
             },
           },
-          { default: 'myset' },
-          { enabled: true },
-          {
+          contractSet: { default: 'myset' },
+          uploadPacking: { enabled: true },
+          gouging: {
             hostBlockHeightLeeway: 4,
             maxContractPrice: '20000000000000000000000000',
             maxDownloadPrice: '1004310000000000000000000000',
@@ -141,15 +141,15 @@ describe('tansforms', () => {
             minPriceTableValidity: 300000000000,
             migrationSurchargeMultiplier: 10,
           },
-          {
+          redundancy: {
             minShards: 10,
             totalShards: 30,
           },
-          {
+          display: {
             includeRedundancyMaxStoragePrice: true,
             includeRedundancyMaxUploadPrice: true,
-          }
-        )
+          },
+        })
       ).toEqual({
         autopilotContractSet: 'autopilot',
         allowanceMonth: new BigNumber('6006'),
@@ -506,8 +506,8 @@ describe('tansforms', () => {
         redundancy,
         display,
       } = buildAllResponses()
-      let settings = transformDown(
-        {
+      let settings = transformDown({
+        autopilot: {
           ...autopilot,
           contracts: {
             ...autopilot.contracts,
@@ -519,16 +519,16 @@ describe('tansforms', () => {
         uploadPacking,
         gouging,
         redundancy,
-        display
-      )
+        display,
+      })
       expect(settings.downloadTBMonth).toEqual(new BigNumber('92.72'))
       // a little different due to rounding
       expect(
         transformUpAutopilot('Mainnet', settings, autopilot).contracts.download
       ).toEqual(91088814814815)
 
-      settings = transformDown(
-        {
+      settings = transformDown({
+        autopilot: {
           ...autopilot,
           contracts: {
             ...autopilot.contracts,
@@ -540,8 +540,8 @@ describe('tansforms', () => {
         uploadPacking,
         gouging,
         redundancy,
-        display
-      )
+        display,
+      })
       expect(settings.downloadTBMonth).toEqual(new BigNumber('92.72'))
       // using the rounded value results in same value
       expect(

--- a/apps/renterd/contexts/config/transform.ts
+++ b/apps/renterd/contexts/config/transform.ts
@@ -27,9 +27,9 @@ import {
   scDecimalPlaces,
   SettingsData,
   getAdvancedDefaultAutopilot,
-  ConfigAppData,
+  DisplayData,
   ContractSetData,
-  defaultConfigApp,
+  defaultDisplay,
   defaultContractSet,
   GougingData,
   RedundancyData,
@@ -184,8 +184,8 @@ export function transformUpRedundancy(
   }
 }
 
-export function transformUpConfigApp(
-  values: ConfigAppData,
+export function transformUpDisplay(
+  values: DisplayData,
   existingValues: Record<string, unknown> | undefined
 ): ConfigDisplayOptions {
   return {
@@ -276,11 +276,9 @@ export function transformDownUploadPacking(
   }
 }
 
-export function transformDownConfigApp(
-  ca?: ConfigDisplayOptions
-): ConfigAppData {
+export function transformDownConfigApp(ca?: ConfigDisplayOptions): DisplayData {
   if (!ca) {
-    return defaultConfigApp
+    return defaultDisplay
   }
   return {
     includeRedundancyMaxStoragePrice: ca.includeRedundancyMaxStoragePrice,
@@ -291,7 +289,7 @@ export function transformDownConfigApp(
 export function transformDownGouging(
   g: GougingSettings,
   r: RedundancyData,
-  ca: ConfigAppData
+  ca: DisplayData
 ): GougingData {
   return {
     maxStoragePriceTBMonth: toSiacoins(
@@ -344,37 +342,37 @@ export function transformDownRedundancy(r: RedundancySettings): RedundancyData {
 }
 
 export type RemoteData = {
-  autopilotData: AutopilotConfig | undefined
-  contractSetData: ContractSetSettings | undefined
-  uploadPackingData: UploadPackingSettings
-  gougingData: GougingSettings
-  redundancyData: RedundancySettings
-  configAppData: ConfigDisplayOptions | undefined
+  autopilot: AutopilotConfig | undefined
+  contractSet: ContractSetSettings | undefined
+  uploadPacking: UploadPackingSettings
+  gouging: GougingSettings
+  redundancy: RedundancySettings
+  display: ConfigDisplayOptions | undefined
 }
 
 export function transformDown({
-  autopilotData,
-  contractSetData,
-  uploadPackingData,
-  gougingData,
-  redundancyData,
-  configAppData,
+  autopilot,
+  contractSet,
+  uploadPacking,
+  gouging,
+  redundancy,
+  display,
 }: RemoteData): SettingsData {
-  const configApp = transformDownConfigApp(configAppData)
-  const redundancy = transformDownRedundancy(redundancyData)
+  const d = transformDownConfigApp(display)
+  const r = transformDownRedundancy(redundancy)
   return {
     // autopilot
-    ...transformDownAutopilot(autopilotData),
+    ...transformDownAutopilot(autopilot),
     // contractset
-    ...transformDownContractSet(contractSetData),
+    ...transformDownContractSet(contractSet),
     // uploadpacking
-    ...transformDownUploadPacking(uploadPackingData),
+    ...transformDownUploadPacking(uploadPacking),
     // gouging
-    ...transformDownGouging(gougingData, redundancy, configApp),
+    ...transformDownGouging(gouging, r, d),
     // redundancy
-    ...redundancy,
+    ...r,
     // config app
-    ...configApp,
+    ...d,
   }
 }
 

--- a/apps/renterd/contexts/config/transform.ts
+++ b/apps/renterd/contexts/config/transform.ts
@@ -343,25 +343,34 @@ export function transformDownRedundancy(r: RedundancySettings): RedundancyData {
   }
 }
 
-export function transformDown(
-  a: AutopilotConfig | undefined,
-  c: ContractSetSettings | undefined,
-  u: UploadPackingSettings,
-  g: GougingSettings,
-  r: RedundancySettings,
-  ca: ConfigDisplayOptions | undefined
-): SettingsData {
-  const configApp = transformDownConfigApp(ca)
-  const redundancy = transformDownRedundancy(r)
+export type RemoteData = {
+  autopilotData: AutopilotConfig | undefined
+  contractSetData: ContractSetSettings | undefined
+  uploadPackingData: UploadPackingSettings
+  gougingData: GougingSettings
+  redundancyData: RedundancySettings
+  configAppData: ConfigDisplayOptions | undefined
+}
+
+export function transformDown({
+  autopilotData,
+  contractSetData,
+  uploadPackingData,
+  gougingData,
+  redundancyData,
+  configAppData,
+}: RemoteData): SettingsData {
+  const configApp = transformDownConfigApp(configAppData)
+  const redundancy = transformDownRedundancy(redundancyData)
   return {
     // autopilot
-    ...transformDownAutopilot(a),
+    ...transformDownAutopilot(autopilotData),
     // contractset
-    ...transformDownContractSet(c),
+    ...transformDownContractSet(contractSetData),
     // uploadpacking
-    ...transformDownUploadPacking(u),
+    ...transformDownUploadPacking(uploadPackingData),
     // gouging
-    ...transformDownGouging(g, redundancy, configApp),
+    ...transformDownGouging(gougingData, redundancy, configApp),
     // redundancy
     ...redundancy,
     // config app

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -30,7 +30,7 @@ export const defaultUploadPacking = {
   uploadPackingEnabled: true,
 }
 
-export const defaultConfigApp = {
+export const defaultDisplay = {
   includeRedundancyMaxStoragePrice: true,
   includeRedundancyMaxUploadPrice: true,
 }
@@ -65,14 +65,14 @@ export const defaultValues = {
   ...defaultGouging,
   // redundancy
   ...defaultRedundancy,
-  // config app
-  ...defaultConfigApp,
+  // config display
+  ...defaultDisplay,
 }
 
 export type AutopilotData = typeof defaultAutopilot
 export type ContractSetData = typeof defaultContractSet
 export type UploadPackingData = typeof defaultUploadPacking
-export type ConfigAppData = typeof defaultConfigApp
+export type DisplayData = typeof defaultDisplay
 export type GougingData = typeof defaultGouging
 export type RedundancyData = typeof defaultRedundancy
 export type SettingsData = typeof defaultValues
@@ -120,8 +120,8 @@ export const advancedDefaultContractSet: ContractSetData = {
   defaultContractSet: 'autopilot',
 }
 
-export const advancedDefaultConfigApp: ConfigAppData = {
-  ...defaultConfigApp,
+export const advancedDefaultDisplay: DisplayData = {
+  ...defaultDisplay,
 }
 
 export const advancedDefaultUploadPacking: UploadPackingData = {
@@ -152,7 +152,7 @@ export function getAdvancedDefaults(
   return {
     ...getAdvancedDefaultAutopilot(network),
     ...advancedDefaultContractSet,
-    ...advancedDefaultConfigApp,
+    ...advancedDefaultDisplay,
     ...advancedDefaultUploadPacking,
     ...advancedDefaultGouging,
     ...getAdvancedDefaultRedundancy(network),

--- a/apps/renterd/contexts/config/useAverages.tsx
+++ b/apps/renterd/contexts/config/useAverages.tsx
@@ -1,0 +1,90 @@
+import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
+import { monthsToBlocks, TBToBytes, toSiacoins } from '@siafoundation/units'
+import { getRedundancyMultiplierIfIncluded } from './transform'
+import { useSiaCentralHostsNetworkAverages } from '@siafoundation/react-sia-central'
+
+export function useAverages({
+  minShards,
+  totalShards,
+  includeRedundancyMaxStoragePrice,
+  includeRedundancyMaxUploadPrice,
+}: {
+  minShards: BigNumber
+  totalShards: BigNumber
+  includeRedundancyMaxStoragePrice: boolean
+  includeRedundancyMaxUploadPrice: boolean
+}) {
+  const averages = useSiaCentralHostsNetworkAverages({
+    config: {
+      swr: {
+        revalidateOnFocus: false,
+      },
+    },
+  })
+  const storageAverage = useMemo(
+    () =>
+      averages.data
+        ? new BigNumber(
+            toSiacoins(averages.data.settings.storage_price) // bytes/block
+              .times(monthsToBlocks(1)) // bytes/month
+              .times(TBToBytes(1)) // TB/month
+              .times(
+                getRedundancyMultiplierIfIncluded(
+                  minShards,
+                  totalShards,
+                  includeRedundancyMaxStoragePrice
+                )
+              ) // redundancy
+              .toFixed(0)
+          )
+        : undefined,
+    [averages.data, minShards, totalShards, includeRedundancyMaxStoragePrice]
+  )
+  const uploadAverage = useMemo(
+    () =>
+      averages.data
+        ? new BigNumber(
+            toSiacoins(averages.data.settings.upload_price) // bytes
+              .times(TBToBytes(1)) // TB
+              .times(
+                getRedundancyMultiplierIfIncluded(
+                  minShards,
+                  totalShards,
+                  includeRedundancyMaxUploadPrice
+                )
+              ) // redundancy
+              .toFixed(0)
+          )
+        : undefined,
+    [averages.data, minShards, totalShards, includeRedundancyMaxUploadPrice]
+  )
+  const downloadAverage = useMemo(
+    () =>
+      averages.data
+        ? new BigNumber(
+            toSiacoins(averages.data.settings.download_price) // bytes
+              .times(TBToBytes(1)) // TB
+              .toFixed(0)
+          )
+        : undefined,
+    [averages.data]
+  )
+
+  const contractAverage = useMemo(
+    () =>
+      averages.data
+        ? new BigNumber(
+            toSiacoins(averages.data.settings.contract_price).toFixed(0)
+          )
+        : undefined,
+    [averages.data]
+  )
+
+  return {
+    storageAverage,
+    uploadAverage,
+    downloadAverage,
+    contractAverage,
+  }
+}

--- a/apps/renterd/contexts/config/useEstimates.tsx
+++ b/apps/renterd/contexts/config/useEstimates.tsx
@@ -1,0 +1,93 @@
+import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
+
+export function useEstimates({
+  isAutopilotEnabled,
+  includeRedundancyMaxStoragePrice,
+  includeRedundancyMaxUploadPrice,
+  redundancyMultiplier,
+  maxStoragePriceTBMonth,
+  storageTB,
+  maxDownloadPriceTB,
+  downloadTBMonth,
+  maxUploadPriceTB,
+  uploadTBMonth,
+}) {
+  const canEstimate = useMemo(() => {
+    if (!isAutopilotEnabled) {
+      return false
+    }
+    return (
+      maxStoragePriceTBMonth?.gt(0) &&
+      storageTB?.gt(0) &&
+      maxDownloadPriceTB?.gt(0) &&
+      maxUploadPriceTB?.gt(0)
+    )
+  }, [
+    isAutopilotEnabled,
+    maxStoragePriceTBMonth,
+    storageTB,
+    maxDownloadPriceTB,
+    maxUploadPriceTB,
+  ])
+
+  const estimatedSpendingPerMonth = useMemo(() => {
+    if (!canEstimate) {
+      return new BigNumber(0)
+    }
+    const _storageTB = storageTB?.gt(0) ? storageTB : new BigNumber(0)
+    const _downloadTBMonth = downloadTBMonth?.gt(0)
+      ? downloadTBMonth
+      : new BigNumber(0)
+    const _uploadTBMonth = uploadTBMonth?.gt(0)
+      ? uploadTBMonth
+      : new BigNumber(0)
+    const _maxStoragePriceTBMonth = maxStoragePriceTBMonth?.gt(0)
+      ? maxStoragePriceTBMonth
+      : new BigNumber(0)
+    const _maxUploadPriceTB = maxUploadPriceTB?.gt(0)
+      ? maxUploadPriceTB
+      : new BigNumber(0)
+    const _maxDownloadPriceTB = maxDownloadPriceTB?.gt(0)
+      ? maxDownloadPriceTB
+      : new BigNumber(0)
+
+    const storageCostPerMonth = includeRedundancyMaxStoragePrice
+      ? _maxStoragePriceTBMonth.times(_storageTB)
+      : _maxStoragePriceTBMonth.times(redundancyMultiplier).times(_storageTB)
+    const downloadCostPerMonth = _maxDownloadPriceTB.times(_downloadTBMonth)
+    const uploadCostPerMonth = includeRedundancyMaxUploadPrice
+      ? _maxUploadPriceTB.times(_uploadTBMonth)
+      : _maxUploadPriceTB.times(redundancyMultiplier).times(_uploadTBMonth)
+
+    const totalCostPerMonth = storageCostPerMonth
+      .plus(downloadCostPerMonth)
+      .plus(uploadCostPerMonth)
+    return totalCostPerMonth
+  }, [
+    canEstimate,
+    includeRedundancyMaxStoragePrice,
+    includeRedundancyMaxUploadPrice,
+    redundancyMultiplier,
+    maxStoragePriceTBMonth,
+    storageTB,
+    maxDownloadPriceTB,
+    downloadTBMonth,
+    maxUploadPriceTB,
+    uploadTBMonth,
+  ])
+
+  const estimatedSpendingPerTB = useMemo(() => {
+    if (!canEstimate) {
+      return new BigNumber(0)
+    }
+    const totalCostPerMonthTB = estimatedSpendingPerMonth.div(storageTB)
+    return totalCostPerMonthTB
+  }, [canEstimate, estimatedSpendingPerMonth, storageTB])
+
+  return {
+    canEstimate,
+    estimatedSpendingPerMonth,
+    estimatedSpendingPerTB,
+  }
+}

--- a/apps/renterd/contexts/config/useForm.tsx
+++ b/apps/renterd/contexts/config/useForm.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react'
+import { defaultValues } from './types'
+import { getRedundancyMultiplier } from './transform'
+import { useForm as useHookForm } from 'react-hook-form'
+
+export function useForm() {
+  const form = useHookForm({
+    mode: 'all',
+    defaultValues,
+  })
+  const maxStoragePriceTBMonth = form.watch('maxStoragePriceTBMonth')
+  const maxDownloadPriceTB = form.watch('maxDownloadPriceTB')
+  const maxUploadPriceTB = form.watch('maxUploadPriceTB')
+  const storageTB = form.watch('storageTB')
+  const downloadTBMonth = form.watch('downloadTBMonth')
+  const uploadTBMonth = form.watch('uploadTBMonth')
+  const minShards = form.watch('minShards')
+  const totalShards = form.watch('totalShards')
+  const includeRedundancyMaxStoragePrice = form.watch(
+    'includeRedundancyMaxStoragePrice'
+  )
+  const includeRedundancyMaxUploadPrice = form.watch(
+    'includeRedundancyMaxUploadPrice'
+  )
+  const redundancyMultiplier = useMemo(
+    () => getRedundancyMultiplier(minShards, totalShards),
+    [minShards, totalShards]
+  )
+
+  return {
+    form,
+    maxStoragePriceTBMonth,
+    maxDownloadPriceTB,
+    maxUploadPriceTB,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    minShards,
+    totalShards,
+    includeRedundancyMaxStoragePrice,
+    includeRedundancyMaxUploadPrice,
+    redundancyMultiplier,
+  }
+}

--- a/apps/renterd/contexts/config/useOnValid.tsx
+++ b/apps/renterd/contexts/config/useOnValid.tsx
@@ -1,0 +1,183 @@
+import {
+  triggerSuccessToast,
+  triggerErrorToast,
+} from '@siafoundation/design-system'
+import { useCallback } from 'react'
+import {
+  autopilotHostsKey,
+  useAutopilotTrigger,
+} from '@siafoundation/react-renterd'
+import { SettingsData, defaultValues } from './types'
+import {
+  transformUpAutopilot,
+  transformUpConfigApp,
+  transformUpContractSet,
+  transformUpGouging,
+  transformUpRedundancy,
+  transformUpUploadPacking,
+} from './transform'
+import { delay, useMutate } from '@siafoundation/react-core'
+import { configDisplayOptionsKey } from '../../hooks/useConfigDisplayOptions'
+
+export function useOnValid({
+  gouging,
+  redundancy,
+  renterdState,
+  estimatedSpendingPerMonth,
+  isAutopilotEnabled,
+  showAdvanced,
+  revalidateAndResetFormData,
+  syncDefaultContractSet,
+  settingUpdate,
+  contractSet,
+  uploadPacking,
+  configApp,
+  autopilot,
+  autopilotUpdate,
+}) {
+  const autopilotTrigger = useAutopilotTrigger()
+  const mutate = useMutate()
+  const onValid = useCallback(
+    async (values: typeof defaultValues) => {
+      if (!gouging.data || !redundancy.data || !renterdState.data) {
+        return
+      }
+      try {
+        const calculatedValues: Partial<SettingsData> = {}
+        if (isAutopilotEnabled && !showAdvanced) {
+          calculatedValues.allowanceMonth = estimatedSpendingPerMonth
+        }
+
+        const finalValues = {
+          ...values,
+          ...calculatedValues,
+        }
+
+        const firstTimeSettingConfig = isAutopilotEnabled && !autopilot.data
+        const autopilotResponse = isAutopilotEnabled
+          ? await autopilotUpdate.put({
+              payload: transformUpAutopilot(
+                renterdState.data.network,
+                finalValues,
+                autopilot.data
+              ),
+            })
+          : undefined
+
+        const [
+          contractSetResponse,
+          uploadPackingResponse,
+          gougingResponse,
+          redundancyResponse,
+          configAppResponse,
+        ] = await Promise.all([
+          settingUpdate.put({
+            params: {
+              key: 'contractset',
+            },
+            payload: transformUpContractSet(finalValues, contractSet.data),
+          }),
+          settingUpdate.put({
+            params: {
+              key: 'uploadpacking',
+            },
+            payload: transformUpUploadPacking(finalValues, uploadPacking.data),
+          }),
+          settingUpdate.put({
+            params: {
+              key: 'gouging',
+            },
+            payload: transformUpGouging(finalValues, gouging.data),
+          }),
+          settingUpdate.put({
+            params: {
+              key: 'redundancy',
+            },
+            payload: transformUpRedundancy(finalValues, redundancy.data),
+          }),
+          settingUpdate.put({
+            params: {
+              key: configDisplayOptionsKey,
+            },
+            payload: transformUpConfigApp(finalValues, configApp.data),
+          }),
+        ])
+
+        if (autopilotResponse?.error) {
+          throw Error(autopilotResponse.error)
+        }
+        if (contractSetResponse.error) {
+          throw Error(contractSetResponse.error)
+        }
+        if (uploadPackingResponse.error) {
+          throw Error(uploadPackingResponse.error)
+        }
+        if (gougingResponse.error) {
+          throw Error(gougingResponse.error)
+        }
+        if (redundancyResponse.error) {
+          throw Error(redundancyResponse.error)
+        }
+        if (configAppResponse.error) {
+          throw Error(configAppResponse.error)
+        }
+
+        if (isAutopilotEnabled) {
+          // Sync default contract set if necessary. Only syncs if the setting
+          // is enabled in case the user changes in advanced mode and then
+          // goes back to simple mode.
+          // Might be simpler nice to just override in simple mode without a
+          // special setting since this is how other settings like allowance
+          // behave - but leaving for now.
+          syncDefaultContractSet(finalValues.autopilotContractSet)
+
+          // Trigger the autopilot loop with new settings applied.
+          autopilotTrigger.post({
+            payload: {
+              forceScan: true,
+            },
+          })
+        }
+
+        triggerSuccessToast('Configuration has been saved.')
+
+        // If autopilot is being configured for the first time,
+        // revalidate the empty hosts list.
+        if (firstTimeSettingConfig) {
+          const refreshHostsAfterDelay = async () => {
+            await delay(5_000)
+            mutate((key) => key.startsWith(autopilotHostsKey))
+            await delay(5_000)
+            mutate((key) => key.startsWith(autopilotHostsKey))
+          }
+          refreshHostsAfterDelay()
+        }
+
+        await revalidateAndResetFormData()
+      } catch (e) {
+        triggerErrorToast((e as Error).message)
+        console.log(e)
+      }
+    },
+    [
+      renterdState.data,
+      estimatedSpendingPerMonth,
+      showAdvanced,
+      isAutopilotEnabled,
+      autopilot,
+      autopilotUpdate,
+      revalidateAndResetFormData,
+      syncDefaultContractSet,
+      mutate,
+      settingUpdate,
+      contractSet,
+      uploadPacking,
+      redundancy,
+      gouging,
+      configApp,
+      autopilotTrigger,
+    ]
+  )
+
+  return onValid
+}

--- a/apps/renterd/contexts/config/useOnValid.tsx
+++ b/apps/renterd/contexts/config/useOnValid.tsx
@@ -10,7 +10,7 @@ import {
 import { SettingsData, defaultValues } from './types'
 import {
   transformUpAutopilot,
-  transformUpConfigApp,
+  transformUpDisplay,
   transformUpContractSet,
   transformUpGouging,
   transformUpRedundancy,
@@ -31,7 +31,7 @@ export function useOnValid({
   settingUpdate,
   contractSet,
   uploadPacking,
-  configApp,
+  display,
   autopilot,
   autopilotUpdate,
 }) {
@@ -99,7 +99,7 @@ export function useOnValid({
             params: {
               key: configDisplayOptionsKey,
             },
-            payload: transformUpConfigApp(finalValues, configApp.data),
+            payload: transformUpDisplay(finalValues, display.data),
           }),
         ])
 
@@ -174,7 +174,7 @@ export function useOnValid({
       uploadPacking,
       redundancy,
       gouging,
-      configApp,
+      display,
       autopilotTrigger,
     ]
   )

--- a/apps/renterd/contexts/config/useResources.tsx
+++ b/apps/renterd/contexts/config/useResources.tsx
@@ -1,0 +1,123 @@
+import { minutesInMilliseconds } from '@siafoundation/design-system'
+import {
+  useAutopilotConfig,
+  useAutopilotConfigUpdate,
+  useSettingUpdate,
+} from '@siafoundation/react-renterd'
+import { useSyncContractSet } from './useSyncContractSet'
+import { useAppSettings } from '@siafoundation/react-core'
+import { useContractSetSettings } from '../../hooks/useContractSetSettings'
+import { useConfigDisplayOptions } from '../../hooks/useConfigDisplayOptions'
+import { useGougingSettings } from '../../hooks/useGougingSettings'
+import { useRedundancySettings } from '../../hooks/useRedundancySettings'
+import { useUploadPackingSettings } from '../../hooks/useUploadPackingSettings'
+import { useSiaCentralHostsNetworkAverages } from '@siafoundation/react-sia-central'
+import useLocalStorageState from 'use-local-storage-state'
+import { useApp } from '../app'
+
+export function useResources() {
+  const app = useApp()
+  const isAutopilotConfigured = app.autopilot.state.data?.configured
+  const isAutopilotEnabled = app.autopilot.status === 'on'
+  // settings that 404 when empty
+  const autopilot = useAutopilotConfig({
+    disabled: !isAutopilotEnabled,
+    standalone: 'configFormAutopilot',
+    config: {
+      swr: {
+        errorRetryCount: 0,
+        refreshInterval: minutesInMilliseconds(1),
+      },
+    },
+  })
+  const contractSet = useContractSetSettings({
+    standalone: 'configFormContractSet',
+    config: {
+      swr: {
+        errorRetryCount: 0,
+        refreshInterval: minutesInMilliseconds(1),
+      },
+    },
+  })
+  const configApp = useConfigDisplayOptions({
+    standalone: 'configFormConfigApp',
+    config: {
+      swr: {
+        errorRetryCount: 0,
+        refreshInterval: minutesInMilliseconds(1),
+      },
+    },
+  })
+  // settings with initial defaults
+  const gouging = useGougingSettings({
+    standalone: 'configFormGouging',
+    config: {
+      swr: {
+        refreshInterval: minutesInMilliseconds(1),
+      },
+    },
+  })
+  const redundancy = useRedundancySettings({
+    standalone: 'configFormRedundancy',
+    config: {
+      swr: {
+        refreshInterval: minutesInMilliseconds(1),
+      },
+    },
+  })
+  const uploadPacking = useUploadPackingSettings({
+    standalone: 'configFormUploadPacking',
+    config: {
+      swr: {
+        refreshInterval: minutesInMilliseconds(1),
+      },
+    },
+  })
+
+  const settingUpdate = useSettingUpdate()
+
+  const averages = useSiaCentralHostsNetworkAverages({
+    config: {
+      swr: {
+        revalidateOnFocus: false,
+      },
+    },
+  })
+  const [showAdvanced, setShowAdvanced] = useLocalStorageState<boolean>(
+    'v0/config/showAdvanced',
+    {
+      defaultValue: false,
+    }
+  )
+  const mode: 'advanced' | 'simple' = showAdvanced ? 'advanced' : 'simple'
+  const {
+    shouldSyncDefaultContractSet,
+    setShouldSyncDefaultContractSet,
+    syncDefaultContractSet,
+  } = useSyncContractSet()
+  const autopilotUpdate = useAutopilotConfigUpdate()
+
+  const appSettings = useAppSettings()
+
+  return {
+    app,
+    isAutopilotConfigured,
+    isAutopilotEnabled,
+    autopilot,
+    contractSet,
+    configApp,
+    gouging,
+    redundancy,
+    uploadPacking,
+    settingUpdate,
+    averages,
+    showAdvanced,
+    setShowAdvanced,
+    mode,
+    shouldSyncDefaultContractSet,
+    setShouldSyncDefaultContractSet,
+    syncDefaultContractSet,
+    autopilotUpdate,
+    appSettings,
+  }
+}

--- a/apps/renterd/contexts/config/useResources.tsx
+++ b/apps/renterd/contexts/config/useResources.tsx
@@ -39,7 +39,7 @@ export function useResources() {
       },
     },
   })
-  const configApp = useConfigDisplayOptions({
+  const display = useConfigDisplayOptions({
     standalone: 'configFormConfigApp',
     config: {
       swr: {
@@ -105,7 +105,7 @@ export function useResources() {
     isAutopilotEnabled,
     autopilot,
     contractSet,
-    configApp,
+    display,
     gouging,
     redundancy,
     uploadPacking,

--- a/apps/renterd/contexts/contracts/useContractMetrics.tsx
+++ b/apps/renterd/contexts/contracts/useContractMetrics.tsx
@@ -34,7 +34,8 @@ export function useContractMetrics({
     const now = new Date().getTime()
     const today = getTimeClampedToNearest5min(now)
     const span = today - start
-    return Math.round(span / interval)
+    const numberOfPeriods = Math.round(span / interval)
+    return Math.max(numberOfPeriods, 1)
   }, [start, interval])
 
   const params = useMemo(() => {

--- a/libs/design-system/src/app/WalletBalance.tsx
+++ b/libs/design-system/src/app/WalletBalance.tsx
@@ -36,7 +36,7 @@ export function WalletBalance({
           </Text>
           <ValueScFiat
             variant="value"
-            value={balanceSc.spendable}
+            value={balanceSc.spendable.plus(balanceSc.unconfirmed)}
             size="12"
             showTooltip={false}
           />
@@ -50,7 +50,7 @@ export function WalletBalance({
       <Panel className="hidden sm:flex h-7 px-3 items-center">
         <ValueScFiat
           variant="value"
-          value={balanceSc.spendable}
+          value={balanceSc.spendable.plus(balanceSc.unconfirmed)}
           size="12"
           showTooltip={false}
         />

--- a/libs/design-system/src/components/Form.tsx
+++ b/libs/design-system/src/components/Form.tsx
@@ -30,7 +30,7 @@ export function FieldLabel<Values extends FieldValues>({
 
 type FieldErrorProps<Values extends FieldValues> = {
   form: UseFormReturn<Values>
-  name: Path<Values>
+  name: 'root' | Path<Values>
 }
 
 export function FieldError<Values extends FieldValues>({

--- a/libs/design-system/src/form/useServerSyncedForm.tsx
+++ b/libs/design-system/src/form/useServerSyncedForm.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { FieldValues, UseFormReturn } from 'react-hook-form'
+
+type Props<DataForm extends FieldValues> = {
+  form: UseFormReturn<DataForm>
+  remoteValues?: DataForm
+  revalidate: () => Promise<DataForm>
+  mode?: 'simple' | 'advanced'
+  // used to reset the init process
+  initialized?: boolean
+}
+
+export function useServerSyncedForm<DataForm extends FieldValues>({
+  form,
+  remoteValues,
+  revalidate,
+  mode,
+  initialized,
+}: Props<DataForm>) {
+  const changeCount = Object.entries(form.formState.dirtyFields).filter(
+    ([_, val]) => !!val
+  ).length
+
+  const revalidateAndResetFormData = useCallback(async () => {
+    const remoteData = await revalidate()
+    if (remoteData) {
+      form.reset(remoteData)
+    }
+  }, [form, revalidate])
+
+  // init - when new config is fetched, set the form
+  const [hasInit, setHasInit] = useState(false)
+  useEffect(() => {
+    if (!initialized) {
+      setHasInit(false)
+    }
+  }, [initialized])
+
+  useEffect(() => {
+    if (!hasInit && remoteValues) {
+      form.reset(remoteValues)
+      setHasInit(true)
+    }
+    // Try to initialize whenever remoteData changes from null to a value
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [remoteValues])
+
+  // Syncs updated remote data and re-applies user changes to the form.
+  const syncRemoteDataWithUserChanges = useCallback(() => {
+    if (!hasInit || form.formState.isSubmitting || !remoteValues) {
+      return
+    }
+    const localValues = form.getValues()
+    form.reset(remoteValues)
+    for (const [key, value] of Object.entries(localValues)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      form.setValue(key as any, value, {
+        shouldDirty: true,
+      })
+    }
+  }, [form, hasInit, remoteValues])
+
+  useEffect(() => {
+    syncRemoteDataWithUserChanges()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    // if form mode is toggled reset
+    mode,
+    // if any of the remote data changes, trigger a sync
+    remoteValues,
+  ])
+
+  return {
+    changeCount,
+    revalidateAndResetFormData,
+  }
+}

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -123,6 +123,7 @@ export * from './form/FieldText'
 export * from './form/FieldTextArea'
 export * from './form/FieldSwitch'
 export * from './form/FieldSelect'
+export * from './form/useServerSyncedForm'
 
 // site
 export * from './site/SiteHeading'

--- a/libs/react-core/src/useAppSettings/index.tsx
+++ b/libs/react-core/src/useAppSettings/index.tsx
@@ -66,7 +66,7 @@ function useAppSettingsMain({
     () => getDefaultSettings(overrideDefaultSettings),
     [overrideDefaultSettings]
   )
-  const [_settings, _setSettings] = useLocalStorageState('v0/settings', {
+  const [_settings, _setSettings] = useLocalStorageState('v1/settings', {
     defaultValue: customDefaultSettings,
   })
   // Merge in defaults incase new settings have been introduced

--- a/libs/react-hostd/src/api.ts
+++ b/libs/react-hostd/src/api.ts
@@ -300,8 +300,7 @@ type RevenueMetrics = {
 
 // DataMetrics is a collection of metrics related to data usage.
 type DataMetrics = {
-  rhp2: Data
-  rhp3: Data
+  rhp: Data
 }
 
 type Metrics = {


### PR DESCRIPTION
- Fix bug where announcement error shows both a success and error toast.
- Data metrics no longer use RHP version specific data.
- The wallet balance shown on the wallet page is now spendable plus unconfirmed.
- The contract funding and spending graph now shows a data point for brand new contracts.
- The default suggested pricing for new users is now based on Sia Central averages.
- Fixed an issue where currency was displayed with too many decimals.
- Added useServerSyncedForm.
- ChartXY no longer adds padding point for barstack and bargroup.