### PR TITLE
renterd total file count fixes

### DIFF
--- a/.changeset/early-otters-pretend.md
+++ b/.changeset/early-otters-pretend.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The total file count now includes in-progress uploads.

--- a/.changeset/many-planes-shout.md
+++ b/.changeset/many-planes-shout.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The renterd file count stats tooltip description is now more accurate.

--- a/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuCount.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuCount.tsx
@@ -3,7 +3,7 @@ import { useFiles } from '../../../contexts/files'
 import { useObjectStats } from '@siafoundation/react-renterd'
 
 export function FilesStatsMenuCount() {
-  const { isViewingABucket, pageCount } = useFiles()
+  const { isViewingABucket, pageCount, uploadsList } = useFiles()
   const stats = useObjectStats({
     config: {
       swr: {
@@ -14,6 +14,10 @@ export function FilesStatsMenuCount() {
       },
     },
   })
+
+  const numberObject = stats.data?.numObjects || 0
+  const uploadsInProgress = uploadsList.length
+  const totalObjects = numberObject + uploadsInProgress
 
   if (isViewingABucket) {
     return (
@@ -31,9 +35,7 @@ export function FilesStatsMenuCount() {
         </Text>
         <Tooltip side="bottom" content="Number of files across all buckets">
           <Text size="12" font="mono">
-            {stats.data
-              ? `${stats.data?.numObjects.toLocaleString()} files`
-              : ' files'}
+            {stats.data ? `${totalObjects.toLocaleString()} files` : ' files'}
           </Text>
         </Tooltip>
       </div>
@@ -43,7 +45,7 @@ export function FilesStatsMenuCount() {
     <Tooltip side="bottom" content="Number of files across all buckets">
       {stats.data ? (
         <Text size="12" font="mono">
-          {stats.data?.numObjects.toLocaleString()} files
+          {totalObjects.toLocaleString()} files
         </Text>
       ) : (
         <LoadingDots />

--- a/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuCount.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuCount.tsx
@@ -17,14 +17,26 @@ export function FilesStatsMenuCount() {
 
   if (isViewingABucket) {
     return (
-      <Tooltip side="bottom" content="Number of files in current directory">
+      <div className="flex gap-1">
+        <Tooltip
+          side="bottom"
+          content="Number of files in page of current directory"
+        >
+          <Text size="12" font="mono">
+            {pageCount.toLocaleString()}
+          </Text>
+        </Tooltip>
         <Text size="12" font="mono">
-          {pageCount.toLocaleString()}
-          {stats.data
-            ? ` of ${stats.data?.numObjects.toLocaleString()} files`
-            : ' files'}
+          of
         </Text>
-      </Tooltip>
+        <Tooltip side="bottom" content="Number of files across all buckets">
+          <Text size="12" font="mono">
+            {stats.data
+              ? `${stats.data?.numObjects.toLocaleString()} files`
+              : ' files'}
+          </Text>
+        </Tooltip>
+      </div>
     )
   }
   return (


### PR DESCRIPTION
- The total file count now includes in-progress uploads.
- The renterd file count stats tooltip description is now more accurate.