### PR TITLE
renterd hide 0 file health, hostd fix configuration save error, other changes

### DIFF
--- a/.changeset/cool-walls-jam.md
+++ b/.changeset/cool-walls-jam.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The file stats now only show health once there is more than 0 bytes of file data.

--- a/.changeset/stale-ties-yell.md
+++ b/.changeset/stale-ties-yell.md
@@ -1,0 +1,5 @@
+---
+'website': minor
+---
+
+The roadmap page layout has been updated.

--- a/.changeset/tricky-brooms-drive.md
+++ b/.changeset/tricky-brooms-drive.md
@@ -1,0 +1,5 @@
+---
+'website': minor
+---
+
+Header spacing has been updated for markdown based content.

--- a/.changeset/twenty-seals-allow.md
+++ b/.changeset/twenty-seals-allow.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Fixed an error with "lastAnnouncement" that occurs the first time the configuration is saved.

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+.next

--- a/apps/hostd/contexts/config/useOnValid.tsx
+++ b/apps/hostd/contexts/config/useOnValid.tsx
@@ -52,7 +52,7 @@ export function useOnValid({
           throw Error(response.error)
         }
         const needsToAnnounce =
-          host.data.lastAnnouncement?.address !== values.netAddress
+          host.data?.lastAnnouncement?.address !== values.netAddress
         if (needsToAnnounce) {
           triggerSuccessToast(
             'Settings have been saved. Address has changed, make sure to re-announce the host.',
@@ -69,7 +69,7 @@ export function useOnValid({
         console.log(e)
       }
     },
-    [showAdvanced, resources, settingsUpdate, revalidateAndResetForm, host]
+    [showAdvanced, resources, settingsUpdate, revalidateAndResetForm, host.data]
   )
   return onValid
 }

--- a/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuHealth.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenu/FilesStatsMenuHealth.tsx
@@ -20,7 +20,8 @@ export function FilesStatsMenuHealth() {
     isDirectory: true,
   })
 
-  if (!stats.data) {
+  const noDataYet = stats.data?.totalObjectsSize === 0
+  if (!stats.data || noDataYet) {
     return null
   }
 

--- a/apps/website/config/mdx.tsx
+++ b/apps/website/config/mdx.tsx
@@ -21,7 +21,7 @@ export const components = {
     </SectionHeading>
   ),
   h2: ({ children }) => (
-    <SectionHeading size="24" className="pb-4 pt-6">
+    <SectionHeading size="24" className="pb-4 pt-20">
       {children}
     </SectionHeading>
   ),

--- a/apps/website/pages/roadmap/index.tsx
+++ b/apps/website/pages/roadmap/index.tsx
@@ -13,7 +13,6 @@ import { getMinutesInSeconds } from '../../lib/time'
 import { SectionSolid } from '../../components/SectionSolid'
 import { MDXRemote } from 'next-mdx-remote'
 import { components } from '../../config/mdx'
-import { TableOfContents } from '../../components/TableOfContents'
 import { getPrs } from '../../content/prs'
 import { GitHubActivity } from '../../components/GitHubActivity'
 import { backgrounds, previews } from '../../content/assets'
@@ -34,31 +33,13 @@ export default function Roadmap({ date, source, prs }: Props) {
       description={description}
       path={routes.roadmap.index}
       heading={
-        <SectionTransparent className="pt-24 md:pt-40 pb-6">
+        <SectionTransparent className="pt-24 md:pt-40 pb-20 md:pb-40">
           <SiteHeading
             title={title}
             description={description}
             size="64"
             anchorLink={false}
-          >
-            <TableOfContents
-              className="mt-10"
-              items={[
-                {
-                  href: '#current',
-                  title: 'Current',
-                },
-                {
-                  href: '#future',
-                  title: 'Future',
-                },
-                {
-                  href: '#activity',
-                  title: 'Activity',
-                },
-              ]}
-            />
-          </SiteHeading>
+          />
         </SectionTransparent>
       }
       backgroundImage={backgrounds.nateTrickle}

--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -10,14 +10,7 @@
       "defaultConfiguration": "production",
       "options": {
         "outputPath": "dist/apps/website",
-        "postcssConfig": "apps/website/postcss.config.js",
-        "assets": [
-          {
-            "glob": "**/*",
-            "input": "libs/design-system/src/public/",
-            "output": "/"
-          }
-        ]
+        "postcssConfig": "apps/website/postcss.config.js"
       },
       "configurations": {
         "development": {},


### PR DESCRIPTION
- The file stats now only show health once there is more than 0 bytes of file data.
- Fixed an error with "lastAnnouncement" that occurs the first time the configuration is saved.