### PR TITLE
renterd nested directory uploads, sort files by size

### DIFF
--- a/.changeset/good-flies-doubt.md
+++ b/.changeset/good-flies-doubt.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Uploading nested directories now preserves structure rather than flattening files into current directory.

--- a/.changeset/healthy-cars-cover.md
+++ b/.changeset/healthy-cars-cover.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Files can now be sorted by size. Closes https://github.com/SiaFoundation/renterd/issues/860

--- a/.changeset/pretty-hats-count.md
+++ b/.changeset/pretty-hats-count.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+useObjectDirectory now supports sortBy size.

--- a/apps/renterd/contexts/files/types.ts
+++ b/apps/renterd/contexts/files/types.ts
@@ -33,7 +33,7 @@ export const columnsDefaultVisible: TableColumnId[] = [
   'health',
 ]
 
-export type SortField = 'name' | 'health'
+export type SortField = 'name' | 'health' | 'size'
 
 export const defaultSortField: SortField = 'name'
 
@@ -47,6 +47,11 @@ export const sortOptions: { id: SortField; label: string; category: string }[] =
     {
       id: 'health',
       label: 'health',
+      category: 'general',
+    },
+    {
+      id: 'size',
+      label: 'size',
       category: 'general',
     },
   ]

--- a/apps/renterd/contexts/files/uploads.tsx
+++ b/apps/renterd/contexts/files/uploads.tsx
@@ -89,8 +89,14 @@ export function useUploads({ activeDirectoryPath }: Props) {
   const uploadFiles = async (files: File[]) => {
     files.forEach(async (file) => {
       const name = file.name
+      // https://developer.mozilla.org/en-US/docs/Web/API/File
+      // Documentation does not include `path` but all browsers populate it
+      // with the relative path of the file. Whereas webkitRelativePath is
+      // empty string in most browsers.
+      // Try `path` otherwise fallback to flat file structure.
+      const relativeUserFilePath = (file['path'] as string) || file.name
       // TODO: check if name has /prefix
-      const path = getFilePath(activeDirectoryPath, name)
+      const path = getFilePath(activeDirectoryPath, relativeUserFilePath)
       const bucketName = getBucketFromPath(path)
       const bucket = buckets.data?.find((b) => b.name === bucketName)
 

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -551,7 +551,7 @@ export type ObjectDirectoryParams = {
   limit?: number
   prefix?: string
   offset?: number
-  sortBy?: 'name' | 'health'
+  sortBy?: 'name' | 'health' | 'size'
   sortDir?: 'asc' | 'desc'
 }
 


### PR DESCRIPTION
- Uploading nested directories now preserves structure rather than flattening files into current directory.
- Files can now be sorted by size.