### PR TITLE
renterd reset lost sector count

### DIFF
--- a/.changeset/happy-ads-matter.md
+++ b/.changeset/happy-ads-matter.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The host context menu now has an option to reset the lost sector count.

--- a/.changeset/red-vans-relate.md
+++ b/.changeset/red-vans-relate.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-renterd': minor
+---
+
+Add useHostResetLostSectorCount.

--- a/apps/renterd/components/Hosts/HostContextMenu.tsx
+++ b/apps/renterd/components/Hosts/HostContextMenu.tsx
@@ -15,8 +15,10 @@ import {
   ListChecked16,
   Filter16,
   Copy16,
+  ResetAlt16,
 } from '@siafoundation/react-icons'
 import {
+  useHostResetLostSectorCount,
   useHostsAllowlist,
   useHostsBlocklist,
   useRhpScan,
@@ -54,6 +56,7 @@ export function HostContextMenu({
   const blocklistUpdate = useBlocklistUpdate()
   const allowlistUpdate = useAllowlistUpdate()
   const rescan = useRhpScan()
+  const resetLostSectors = useHostResetLostSectorCount()
   return (
     <DropdownMenu
       trigger={
@@ -174,6 +177,20 @@ export function HostContextMenu({
           Add public key to allowlist
         </DropdownMenuItem>
       )}
+      <DropdownMenuItem
+        onSelect={() =>
+          resetLostSectors.post({
+            params: {
+              publicKey,
+            },
+          })
+        }
+      >
+        <DropdownMenuLeftSlot>
+          <ResetAlt16 />
+        </DropdownMenuLeftSlot>
+        Reset lost sector count
+      </DropdownMenuItem>
       <DropdownMenuLabel>Copy</DropdownMenuLabel>
       <DropdownMenuItem
         onSelect={() => copyToClipboard(publicKey, 'host public key')}

--- a/libs/react-renterd/src/bus.ts
+++ b/libs/react-renterd/src/bus.ts
@@ -406,6 +406,15 @@ export function useHostsBlocklistUpdate(
   )
 }
 
+export function useHostResetLostSectorCount(
+  args?: HookArgsCallback<{ publicKey: string }, void, void>
+) {
+  return usePostFunc({
+    ...args,
+    route: '/bus/host/:publicKey/resetlostsectors',
+  })
+}
+
 // contracts
 
 const contractsActiveRoute = '/bus/contracts'


### PR DESCRIPTION
- The host context menu now has an option to reset the lost sector count.

<img width="544" alt="Screenshot 2024-02-14 at 2 03 03 PM" src="https://github.com/SiaFoundation/web/assets/1412796/aa570d1c-b9d4-48c0-8b24-c0d4a4ea1fd9">

