### PR TITLE
add net address and uptime to node profile

### DIFF
--- a/.changeset/gentle-coats-camp.md
+++ b/.changeset/gentle-coats-camp.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/units': minor
+---
+
+humanTime now supports up to days and long and abbreviated formatting.

--- a/.changeset/hip-ducks-occur.md
+++ b/.changeset/hip-ducks-occur.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The node profile details now include uptime.

--- a/.changeset/wicked-sloths-breathe.md
+++ b/.changeset/wicked-sloths-breathe.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The node profile details now include uptime. Closes https://github.com/SiaFoundation/hostd/issues/92

--- a/apps/hostd/components/Profile/index.tsx
+++ b/apps/hostd/components/Profile/index.tsx
@@ -13,6 +13,7 @@ import {
 import { useSyncStatus } from '../../hooks/useSyncStatus'
 import { useDialog } from '../../contexts/dialog'
 import { useSiascanUrl } from '../../hooks/useSiascanUrl'
+import { humanTime } from '@siafoundation/units'
 
 export function Profile() {
   const { openDialog } = useDialog()
@@ -38,6 +39,11 @@ export function Profile() {
   const versionUrl = version?.match(/^v\d+\.\d+\.\d+/)
     ? `https://github.com/SiaFoundation/hostd/releases/${version}`
     : `https://github.com/SiaFoundation/hostd/tree/${version}`
+
+  const uptime = state.data
+    ? new Date().getTime() - new Date(state.data?.startTime).getTime()
+    : 0
+
   return (
     <DaemonProfile
       name="hostd"
@@ -93,6 +99,16 @@ export function Profile() {
           />
         </div>
       </div>
+      {state.data && (
+        <div className="flex gap-4 justify-between items-center">
+          <Label size="14" color="subtle" noWrap className="w-[100px]">
+            Uptime
+          </Label>
+          <div className="flex-1 flex justify-end overflow-hidden -mr-0.5 pr-0.5">
+            <Text size="14">{humanTime(uptime, { format: 'long' })}</Text>
+          </div>
+        </div>
+      )}
       <div className="flex gap-2 justify-between items-center">
         <Label size="14" color="subtle" noWrap className="w-[100px]">
           Network

--- a/apps/renterd/components/Profile/index.tsx
+++ b/apps/renterd/components/Profile/index.tsx
@@ -12,6 +12,7 @@ import {
   useWallet,
 } from '@siafoundation/react-renterd'
 import { useDialog } from '../../contexts/dialog'
+import { humanTime } from '@siafoundation/units'
 
 export function Profile() {
   const { openDialog } = useDialog()
@@ -40,6 +41,10 @@ export function Profile() {
       ? `https://github.com/SiaFoundation/renterd/releases/${version}`
       : `https://github.com/SiaFoundation/renterd/tree/${version}`
 
+  const uptime = state.data
+    ? new Date().getTime() - new Date(state.data?.startTime).getTime()
+    : 0
+
   return (
     <DaemonProfile
       name="renterd"
@@ -65,6 +70,16 @@ export function Profile() {
           />
         </div>
       </div>
+      {state.data && (
+        <div className="flex gap-4 justify-between items-center">
+          <Label size="14" color="subtle" noWrap className="w-[100px]">
+            Uptime
+          </Label>
+          <div className="flex-1 flex justify-end overflow-hidden -mr-0.5 pr-0.5">
+            <Text size="14">{humanTime(uptime, { format: 'long' })}</Text>
+          </div>
+        </div>
+      )}
       <div className="flex gap-4 justify-between items-center">
         <Label size="14" color="subtle" noWrap className="w-[100px]">
           Network

--- a/libs/units/src/humanUnits.spec.ts
+++ b/libs/units/src/humanUnits.spec.ts
@@ -1,0 +1,33 @@
+import { humanTime } from './humanUnits'
+
+describe('humanTime', () => {
+  test('milliseconds', () => {
+    expect(humanTime(500, { format: 'abbreviated' })).toBe('500ms')
+    expect(humanTime(500, { format: 'full' })).toBe('500 milliseconds')
+  })
+
+  test('seconds', () => {
+    expect(humanTime(15000, { format: 'abbreviated' })).toBe('15s')
+    expect(humanTime(15000, { format: 'full' })).toBe('15 seconds')
+  })
+
+  test('minutes', () => {
+    expect(humanTime(180000, { format: 'abbreviated' })).toBe('3m')
+    expect(humanTime(180000, { format: 'full' })).toBe('3 minutes')
+  })
+
+  test('hours', () => {
+    expect(humanTime(18000000, { format: 'abbreviated' })).toBe('5h')
+    expect(humanTime(18000000, { format: 'full' })).toBe('5 hours')
+  })
+
+  test('days', () => {
+    expect(humanTime(172800000000, { format: 'abbreviated' })).toBe('2000d')
+    expect(humanTime(172800000000, { format: 'full' })).toBe('2000 days')
+  })
+
+  test('handles zero', () => {
+    expect(humanTime(0, { format: 'abbreviated' })).toBe('0ms')
+    expect(humanTime(0, { format: 'full' })).toBe('0 milliseconds')
+  })
+})

--- a/libs/units/src/humanUnits.ts
+++ b/libs/units/src/humanUnits.ts
@@ -58,16 +58,33 @@ export function humanBytes(
   return d.toFixed(fixed) + ' ' + units[digits]
 }
 
-export function humanTime(ns: number): string {
-  if (ns === 0) return '0ms'
+type UnitOptions = 'long' | 'abbreviated'
 
-  ns /= Math.pow(1000, 2)
-  if (ns < 1000) return ` ${Math.floor(ns * 100) / 100}ms`
+type HumanTimeOptions = {
+  format?: UnitOptions
+}
 
-  ns /= 1000
-  if (ns < 60) return `${Math.floor(ns * 100) / 100}s`
+export function humanTime(ms: number, options?: HumanTimeOptions): string {
+  const { format = 'abbreviated' } = options || {}
+  const abbreviate = format === 'abbreviated'
 
-  return `${Math.floor((ns / 60) * 100) / 100}m`
+  if (ms < 1000) {
+    return `${ms.toFixed(0)}${abbreviate ? 'ms' : ' milliseconds'}`
+  }
+
+  const seconds = ms / 1000
+  if (seconds < 60)
+    return `${seconds.toFixed(0)}${abbreviate ? 's' : ' seconds'}`
+
+  const minutes = seconds / 60
+  if (minutes < 60)
+    return `${minutes.toFixed(0)}${abbreviate ? 'm' : ' minutes'}`
+
+  const hours = minutes / 60
+  if (hours < 24) return `${hours.toFixed(0)}${abbreviate ? 'h' : ' hours'}`
+
+  const days = hours / 24
+  return `${days.toFixed(0)}${abbreviate ? 'd' : ' days'}`
 }
 
 type HumanNumberOptions = {


### PR DESCRIPTION
- The renterd and hostd node profile details now include uptime.

<img width="509" alt="Screenshot 2024-02-14 at 2 54 54 PM" src="https://github.com/SiaFoundation/web/assets/1412796/b1236bc2-2c36-49da-8222-62ff6b788364">



