### PR TITLE
fix: explorer proof output labels

### DIFF
--- a/.changeset/rotten-kangaroos-train.md
+++ b/.changeset/rotten-kangaroos-train.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Add use client / RSC support to Table.

--- a/.changeset/stupid-fishes-brake.md
+++ b/.changeset/stupid-fishes-brake.md
@@ -1,0 +1,5 @@
+---
+'explorer': patch
+---
+
+Add detailed labels to contract proof outputs explaining what each output is for.

--- a/.changeset/weak-tips-raise.md
+++ b/.changeset/weak-tips-raise.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fix flex layout and add a title tooltip to EntityListItem.

--- a/apps/explorer/components/ExplorerDatum.tsx
+++ b/apps/explorer/components/ExplorerDatum.tsx
@@ -32,7 +32,7 @@ export function ExplorerDatum({
   comment,
 }: DatumProps) {
   return (
-    <div className="flex flex-wrap gap-x-12 gap-y-4 items-baseline py-1.5 overflow-hidden">
+    <div className="flex flex-wrap gap-x-12 gap-y-4 items-baseline py-1.5">
       <Text color="subtle" scaleSize="14" ellipsis className="flex-1">
         {upperFirst(label)}
       </Text>

--- a/libs/design-system/src/components/EntityListItem.tsx
+++ b/libs/design-system/src/components/EntityListItem.tsx
@@ -17,6 +17,7 @@ import BigNumber from 'bignumber.js'
 import { DotMark16 } from '@siafoundation/react-icons'
 import { EntityListItemLayout } from './EntityListItemLayout'
 import { ValueScFiat } from './ValueScFiat'
+import { Tooltip } from '../core/Tooltip'
 
 export type EntityListItemProps = {
   label?: string
@@ -62,9 +63,9 @@ export function EntityListItem(entity: EntityListItemProps) {
   const title = isValidUrl(label) ? label : upperFirst(label)
   return (
     <EntityListItemLayout {...entity}>
-      <div className="flex flex-col items-center gap-1 w-full">
+      <div className="flex flex-col items-center gap-1 w-full min-w-0">
         <div className="flex gap-2 items-center w-full">
-          <div className="flex gap-2 items-center">
+          <div className="flex gap-2 items-center min-w-0">
             {entity.height && entity.blockHref && (
               <Text color="subtle" weight="semibold">
                 <Link href={entity.blockHref} underline="none">
@@ -72,11 +73,23 @@ export function EntityListItem(entity: EntityListItemProps) {
                 </Link>
               </Text>
             )}
-            <Text weight="medium">{title || truncHashEl}</Text>
+            {title ? (
+              <Tooltip content={title}>
+                <Text ellipsis weight="medium">
+                  {title}
+                </Text>
+              </Tooltip>
+            ) : (
+              <Text ellipsis weight="medium">
+                {truncHashEl}
+              </Text>
+            )}
           </div>
           <div className="flex-1" />
-          {!!sc && <ValueScFiat variant={entity.scVariant} value={sc} />}
-          {!!sf && <ValueSf variant={entity.sfVariant} value={sf} />}
+          <div className="flex items-center">
+            {!!sc && <ValueScFiat variant={entity.scVariant} value={sc} />}
+            {!!sf && <ValueSf variant={entity.sfVariant} value={sf} />}
+          </div>
         </div>
         <div className="flex justify-between w-full">
           <div className="flex gap-1">{!!title && truncHashEl}</div>

--- a/libs/design-system/src/components/Table/TableRow.tsx
+++ b/libs/design-system/src/components/Table/TableRow.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { CSSProperties, forwardRef, useMemo } from 'react'
 import { cx } from 'class-variance-authority'
 import { useDroppable, useDraggable } from '@dnd-kit/core'

--- a/libs/design-system/src/components/Table/index.tsx
+++ b/libs/design-system/src/components/Table/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Tooltip } from '../../core/Tooltip'
 import { Panel } from '../../core/Panel'
 import { Text } from '../../core/Text'


### PR DESCRIPTION
- Add detailed labels to contract proof outputs explaining what each output is for.

<img width="1306" alt="Screenshot 2024-02-23 at 5 02 28 PM" src="https://github.com/SiaFoundation/web/assets/1412796/6fac3eb4-376c-459d-898c-2062321e9400">
<img width="1446" alt="Screenshot 2024-02-24 at 10 35 15 AM" src="https://github.com/SiaFoundation/web/assets/1412796/2e21df8a-4a94-4add-8cc1-1330f7b4da80">


