### PR TITLE
chore: strict lint configuration for ci

### DIFF
--- a/apps/website/components/Layout/Footer.tsx
+++ b/apps/website/components/Layout/Footer.tsx
@@ -10,7 +10,6 @@ import { Statsbar } from '../Statsbar'
 import { SectionTransparent } from '../SectionTransparent'
 import { SectionSolid } from '../SectionSolid'
 import { routes } from '../../config/routes'
-import { cx } from 'class-variance-authority'
 
 export function Footer() {
   return (

--- a/nx.json
+++ b/nx.json
@@ -26,7 +26,10 @@
     },
     "@nx/eslint:lint": {
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json"],
-      "cache": true
+      "cache": true,
+      "options": {
+        "maxWarnings": 0
+      }
     },
     "@nx/js:tsc": {
       "cache": true,


### PR DESCRIPTION
CI lint configuration was switched to a warning during an NX version migration, this makes it strict again.
