### PR TITLE
fix: renterd file health stats popover

### DIFF
--- a/.changeset/fuzzy-eagles-admire.md
+++ b/.changeset/fuzzy-eagles-admire.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where hovering over the file health information would crash the app. Closes https://github.com/SiaFoundation/renterd/issues/997

--- a/apps/renterd/components/Files/Columns/FilesHealthColumn/FilesHealthColumnContents.tsx
+++ b/apps/renterd/components/Files/Columns/FilesHealthColumn/FilesHealthColumnContents.tsx
@@ -55,8 +55,9 @@ export function FilesHealthColumnContents({
   }
 
   const slabs = sortBy(
-    obj.data.object.slabs.map((s) => ({
+    obj.data.object.slabs?.map((s) => ({
       ...s.slab,
+      key: `${s.offset}${s.length}${s.slab.key}`,
       isPartialSlab: !!s.slab.shards,
       contractSetShards: s.slab.shards?.length
         ? computeSlabContractSetShards({
@@ -65,7 +66,7 @@ export function FilesHealthColumnContents({
             health: s.slab.health,
           })
         : 0,
-    })),
+    })) || [],
     'contractSetShards'
   )
 


### PR DESCRIPTION
- Fixed an issue where hovering over the file health information would crash the app.

