### PR TITLE
refactor: migrate wallet wasm into sdk

### DIFF
--- a/.changeset/real-carrots-cry.md
+++ b/.changeset/real-carrots-cry.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/sdk': minor
+---
+
+Wallet and transaction signing methods are now part of the sdk.

--- a/apps/walletd/hooks/useSyncStatus.ts
+++ b/apps/walletd/hooks/useSyncStatus.ts
@@ -1,7 +1,7 @@
 import { hoursInMilliseconds } from '@siafoundation/design-system'
 import { useAppSettings } from '@siafoundation/react-core'
+import { ConsensusState } from '@siafoundation/types'
 import {
-  ConsensusState,
   useConsensusTip,
   useConsensusTipState,
   useEstimatedNetworkBlockHeight,

--- a/apps/walletd/lib/signSeed.ts
+++ b/apps/walletd/lib/signSeed.ts
@@ -1,8 +1,9 @@
-import { ConsensusState, ConsensusNetwork } from '@siafoundation/react-walletd'
 import {
   SiacoinElement,
   Transaction,
   SiafundElement,
+  ConsensusState,
+  ConsensusNetwork,
 } from '@siafoundation/types'
 import { getWalletWasm } from './wasm'
 import { AddressData } from '../contexts/addresses/types'

--- a/libs/react-walletd/src/api.ts
+++ b/libs/react-walletd/src/api.ts
@@ -11,6 +11,8 @@ import {
   useDeleteFunc,
 } from '@siafoundation/react-core'
 import {
+  ConsensusState,
+  ConsensusNetwork,
   Currency,
   BlockHeight,
   ChainIndex,
@@ -20,13 +22,7 @@ import {
   SiafundElement,
   Transaction,
 } from '@siafoundation/types'
-import {
-  ConsensusState,
-  ConsensusNetwork,
-  PoolTransaction,
-  WalletEvent,
-  GatewayPeer,
-} from './siaTypes'
+import { PoolTransaction, WalletEvent, GatewayPeer } from './siaTypes'
 
 // consensus
 

--- a/libs/react-walletd/src/siaTypes.ts
+++ b/libs/react-walletd/src/siaTypes.ts
@@ -9,63 +9,6 @@ import {
   FileContractElement,
 } from '@siafoundation/types'
 
-export type ConsensusNetwork = {
-  name: 'mainnet' | 'zen'
-  initialCoinbase: Currency
-  minimumCoinbase: Currency
-  initialTarget: string
-  hardforkDevAddr: {
-    height: number
-    oldAddress: string
-    newAddress: string
-  }
-  hardforkTax: {
-    height: number
-  }
-  hardforkStorageProof: {
-    height: number
-  }
-  hardforkOak: {
-    height: number
-    fixHeight: number
-    genesisTimestamp: string
-  }
-  hardforkASIC: {
-    height: number
-    oakTime: number
-    oakTarget: string
-  }
-  hardforkFoundation: {
-    height: number
-    primaryAddress: string
-    failsafeAddress: string
-  }
-  hardforkV2: {
-    allowHeight: number
-    requireHeight: number
-  }
-}
-
-export type ConsensusState = {
-  index: ChainIndex
-  prevTimestamps: string[]
-  depth: string
-  childTarget: string
-  siafundPool: string
-  oakTime: number
-  oakTarget: string
-  foundationPrimaryAddress: string
-  foundationFailsafeAddress: string
-  totalWork: string
-  difficulty: string
-  oakWork: string
-  elements: {
-    numLeaves: number
-    trees: string[]
-  }
-  attestations: number
-}
-
 export type GatewayPeer = {
   addr: string
   inbound: boolean

--- a/libs/sdk/README.md
+++ b/libs/sdk/README.md
@@ -2,6 +2,15 @@
 
 SDK for interacting directly with the Sia network from browsers and web clients.
 
-## Running unit tests
+## Installation
 
-Run `nx test sdk` to execute the unit tests via [Jest](https://jestjs.io).
+`npm install @siafoundation/sdk`
+
+## Usage
+
+```js
+import { initSDK } from '@siafoundation/sdk'
+
+const sdk = await initSDK()
+const { phrase, error } = sdk.wallet.generateSeedPhrase()
+```

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -3,6 +3,9 @@
   "description": "SDK for interacting directly with the Sia network from browsers and web clients.",
   "version": "0.0.2",
   "license": "MIT",
+  "dependencies": {
+    "@siafoundation/types": "0.1.3"
+  },
   "devDependencies": {
     "undici": "5.28.3"
   },

--- a/libs/sdk/src/sdk.ts
+++ b/libs/sdk/src/sdk.ts
@@ -6,6 +6,7 @@ export function getSDK() {
   const wasm = (global as any).sia as WASM
   return {
     rhp: wasm.rhp,
+    wallet: wasm.wallet,
     WebTransportClient,
   }
 }

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -1,3 +1,10 @@
+import {
+  Transaction,
+  UnlockConditions,
+  ConsensusNetwork,
+  ConsensusState,
+} from '@siafoundation/types'
+
 type Currency = string
 type Signature = string
 type Address = string
@@ -141,6 +148,59 @@ export type WASM = {
     }
     decodeWriteSectorResponse: (rpc: Uint8Array) => {
       data?: RPCWriteSectorResponse
+      error?: string
+    }
+  }
+  wallet: {
+    generateSeedPhrase: () => {
+      phrase?: string
+      error?: string
+    }
+    generateKeyPair: () => {
+      privateKey?: string
+      publicKey?: string
+      error?: string
+    }
+    keyPairFromSeedPhrase: (
+      phrase: string,
+      index: number
+    ) => {
+      privateKey?: string
+      publicKey?: string
+      error?: string
+    }
+    standardUnlockConditions: (publicKey: string) => {
+      unlockConditions?: UnlockConditions
+      error?: string
+    }
+    standardUnlockHash: (publicKey: string) => {
+      address?: string
+      error?: string
+    }
+    addressFromUnlockConditions: (unlockConditions: UnlockConditions) => {
+      address?: string
+      error?: string
+    }
+    addressFromSpendPolicy: (spendPolicy: string) => {
+      address?: string
+      error?: string
+    }
+    encodeTransaction: (txn: Transaction) => {
+      encodedTransaction?: string
+      error?: string
+    }
+    signTransaction: (
+      cs: ConsensusState,
+      cn: ConsensusNetwork,
+      txn: Transaction,
+      sigIndex: number,
+      privateKey: string
+    ) => {
+      signature?: string
+      error?: string
+    }
+    transactionId: (txn: Transaction) => {
+      id?: string
       error?: string
     }
   }

--- a/libs/sdk/src/wallet.mock.ts
+++ b/libs/sdk/src/wallet.mock.ts
@@ -1,30 +1,13 @@
-import Sia from '@siacentral/ledgerjs-sia'
-import { LedgerDevice } from '../contexts/ledger/types'
 import { Transaction } from '@siafoundation/types'
 
-export function getMockDevice() {
-  return {
-    type: 'HID',
-    sia: {
-      transport: {},
-      getVersion: jest.fn(() => '0.4.5'),
-      signTransaction: jest
-        .fn()
-        .mockReturnValueOnce(
-          'Xt1EJckLmWXU+7HHHDN9bRV5KRuLdC4YY01LzaAMF269QH4hWV8zFkY3kCWs65svhb9HhA1Ix1MRGvhN9orBDpAA'
-        )
-        .mockReturnValueOnce(
-          'fvmSaRzlO/n2L5tsT32e82kWqHnIjQJ8cqjWOc37TtlK6p/vIiOG+TO98HfvbgObTOYVqlKMtUyxTOjGb3bfCpAA'
-        ),
-    } as unknown as Sia,
-    transport: {
-      forget: jest.fn(),
-      deviceModel: {
-        productName: 'Ledger Nano S',
-      },
-      _disconnectEmitted: false,
-    },
-  } as LedgerDevice
+export const mockPhrase =
+  'print fragile winter vote coach pledge deal lazy soap crystal easy amount'
+
+export const mockKeyPair0 = {
+  privateKey:
+    'c0f720e0ba1d80f8b34c71ec93421083e72204bf14bc5bebb5bcdc3c621eb20e859398ea9342a3cb8fb62506e502907eec0831ff5846fa9b7f7664253462266d',
+  publicKey:
+    'ed25519:859398ea9342a3cb8fb62506e502907eec0831ff5846fa9b7f7664253462266d',
 }
 
 export function getTransaction(): Transaction {
@@ -35,9 +18,7 @@ export function getTransaction(): Transaction {
           'scoid:b222428602c8382b67a769d17e1cdc0952f37f2441a872b92671a6ed76cf22f5',
         unlockConditions: {
           timelock: 0,
-          publicKeys: [
-            'ed25519:b5b9196a3c19f94982bcdba250a973181b22112437832a8f818f4aa73b8add74',
-          ],
+          publicKeys: [mockKeyPair0.publicKey],
           signaturesRequired: 1,
         },
       },
@@ -71,15 +52,24 @@ export function getTransaction(): Transaction {
           'addr:eb2ee5169dd9aaab804b38f7e70043690ac21da1144990a4a28c1dcf66cd7ee9845aef03006f',
       },
     ],
+    signatures: [
+      {
+        parentID:
+          'h:b53e88ce69f19f0bf1d3496479f20b72e1133c719e82278830ee6618bb582852',
+        publicKeyIndex: 0,
+        timelock: 0,
+        coveredFields: {
+          wholeTransaction: true,
+        },
+        signature: '',
+      },
+    ],
     minerFees: ['3930000000000000000000'],
   }
 }
 
 export function getToSign() {
-  return [
-    'h:b53e88ce69f19f0bf1d3496479f20b72e1133c719e82278830ee6618bb582852',
-    'h:b222428602c8382b67a769d17e1cdc0952f37f2441a872b92671a6ed76cf22f5',
-  ]
+  return ['h:b53e88ce69f19f0bf1d3496479f20b72e1133c719e82278830ee6618bb582852']
 }
 
 export function getAddresses() {

--- a/libs/sdk/src/wallet.spec.ts
+++ b/libs/sdk/src/wallet.spec.ts
@@ -1,0 +1,194 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { initSDKTest } from './initTest'
+import {
+  getConsensusNetwork,
+  getConsensusState,
+  getTransaction,
+  mockPhrase,
+} from './wallet.mock'
+
+describe('wallet', () => {
+  it('generateSeedPhrase', async () => {
+    const sdk = await initSDKTest()
+    const { phrase, error } = sdk.wallet.generateSeedPhrase()
+    expect(error).toBeUndefined()
+    expect(phrase?.split(' ').length).toBe(12)
+  })
+  it('generateKeyPair', async () => {
+    const sdk = await initSDKTest()
+    const { privateKey, publicKey, error } = sdk.wallet.generateKeyPair()
+    expect(error).toBeUndefined()
+    expect(privateKey).toBeDefined()
+    expect(publicKey).toBeDefined()
+  })
+  it('keyPairFromSeedPhrase', async () => {
+    const sdk = await initSDKTest()
+    const index0 = sdk.wallet.keyPairFromSeedPhrase(
+      'bundle castle coil dismiss patient patrol blind erode future pave eyebrow manual',
+      0
+    )
+    expect(index0.error).toBeUndefined()
+    expect(index0.privateKey).toBe(
+      '61ca130e51261fc8657fe20616c79c69188c0d28048cb8b09010682e65bb346bec5f92330370362126df379ac6235dc3e4e2d03822922646051a341e8fcb4035'
+    )
+    expect(index0.publicKey).toBe(
+      'ed25519:ec5f92330370362126df379ac6235dc3e4e2d03822922646051a341e8fcb4035'
+    )
+    const index1 = sdk.wallet.keyPairFromSeedPhrase(
+      'bundle castle coil dismiss patient patrol blind erode future pave eyebrow manual',
+      1
+    )
+    expect(index1.error).toBeUndefined()
+    expect(index1.privateKey).toBe(
+      '5c797a530f532c967a6097922b39d43407ec1f8cc8e04316a0458b63f1ba06e88aed9bed8227bcd8ed6b0671b13f3b5a7d7c4f0636353372ccd9b037759ce6c7'
+    )
+    expect(index1.publicKey).toBe(
+      'ed25519:8aed9bed8227bcd8ed6b0671b13f3b5a7d7c4f0636353372ccd9b037759ce6c7'
+    )
+  })
+  describe('standardUnlockConditions', () => {
+    it('valid', async () => {
+      const sdk = await initSDKTest()
+      const { error, unlockConditions } = sdk.wallet.standardUnlockConditions(
+        'ed25519:ec5f92330370362126df379ac6235dc3e4e2d03822922646051a341e8fcb4035'
+      )
+      expect(error).toBeUndefined()
+      expect(unlockConditions).toEqual({
+        publicKeys: [
+          'ed25519:ec5f92330370362126df379ac6235dc3e4e2d03822922646051a341e8fcb4035',
+        ],
+        signaturesRequired: 1,
+        timelock: 0,
+      })
+    })
+    it('invalid', async () => {
+      const sdk = await initSDKTest()
+      const { error, unlockConditions } =
+        sdk.wallet.standardUnlockConditions('invalid')
+      expect(error).toEqual('invalid public key')
+      expect(unlockConditions).toBeUndefined()
+    })
+  })
+  describe('standardUnlockHash', () => {
+    it('valid', async () => {
+      const sdk = await initSDKTest()
+      const { error, address } = sdk.wallet.standardUnlockHash(
+        'ed25519:ec5f92330370362126df379ac6235dc3e4e2d03822922646051a341e8fcb4035'
+      )
+      expect(error).toBeUndefined()
+      expect(address).toBe(
+        'addr:69e52c7d3f57df42b9736a1b5a0e67ab2e4a1cda4b0e5c0c858929a5284d843278a7ce009198'
+      )
+    })
+    it('invalid', async () => {
+      const sdk = await initSDKTest()
+      const { error, address } = sdk.wallet.standardUnlockHash('invalid')
+      expect(error).toEqual('invalid public key')
+      expect(address).toBeUndefined()
+    })
+  })
+  describe('addressFromUnlockConditions', () => {
+    it('valid', async () => {
+      const sdk = await initSDKTest()
+      const { error, address } = sdk.wallet.addressFromUnlockConditions({
+        publicKeys: [
+          'ed25519:ec5f92330370362126df379ac6235dc3e4e2d03822922646051a341e8fcb4035',
+        ],
+        signaturesRequired: 1,
+        timelock: 0,
+      })
+      expect(error).toBeUndefined()
+      expect(address).toBe(
+        'addr:69e52c7d3f57df42b9736a1b5a0e67ab2e4a1cda4b0e5c0c858929a5284d843278a7ce009198'
+      )
+    })
+    it('invalid', async () => {
+      const sdk = await initSDKTest()
+      const { error, address } = sdk.wallet.addressFromUnlockConditions({
+        publicKeys: ['invalid public key'],
+        signaturesRequired: 1,
+        timelock: 0,
+      })
+      expect(error).toEqual(
+        'decoding <algorithm>:<key> failed: wrong number of separators'
+      )
+      expect(address).toBeUndefined()
+    })
+  })
+  describe('addressFromSpendPolicy', () => {
+    it('valid', async () => {
+      const sdk = await initSDKTest()
+      const spendPolicy =
+        'thresh(1, [above(100),pk(0x5e4bbc181bae781575a30fabdce472842d0373c12eafcd8013dba0cbf69e34e0)])'
+      const { error, address } = sdk.wallet.addressFromSpendPolicy(spendPolicy)
+      expect(error).toBeUndefined()
+      expect(address).toEqual(
+        'addr:170bf8f730c072a881edf9be3c08d0491f23810f7344125444ebff4bd8855d98dd9159fe1cea'
+      )
+    })
+  })
+  describe('encodeTransaction', () => {
+    it('valid', async () => {
+      const sdk = await initSDKTest()
+      const txn = getTransaction()
+      const { error, encodedTransaction } = sdk.wallet.encodeTransaction(txn)
+      expect(error).toBeUndefined()
+      expect(encodedTransaction).toBeDefined()
+    })
+  })
+  describe('transactionId', () => {
+    it('valid', async () => {
+      const sdk = await initSDKTest()
+      const txn = getTransaction()
+      const { error, id } = sdk.wallet.transactionId(txn)
+      expect(error).toBeUndefined()
+      expect(id).toEqual(
+        'txid:21cedbd4948a11132d54b278a9d0a51e23dbf03a727e01fe08875b7073ae9912'
+      )
+    })
+  })
+  describe('signTransaction', () => {
+    it('signs a valid transaction', async () => {
+      const sdk = await initSDKTest()
+      const { privateKey } = sdk.wallet.keyPairFromSeedPhrase(mockPhrase!, 0)
+      const { error, signature } = sdk.wallet.signTransaction(
+        getConsensusState(),
+        getConsensusNetwork(),
+        getTransaction(),
+        0,
+        privateKey!
+      )
+      expect(error).toBeUndefined()
+      expect(signature).toEqual(
+        'sig:c58f8fe1ee5a08147484a53af7d3a64eca8039794b6c475342f0d8927b04d3172b3ed72861c183c73e87d719b782fb291dbfe8b3e0b1088095a9264bc97b6f06'
+      )
+    })
+    it('errors if the signature index is invalid', async () => {
+      const sdk = await initSDKTest()
+      const { privateKey } = sdk.wallet.keyPairFromSeedPhrase(mockPhrase!, 0)
+      const { error, signature } = sdk.wallet.signTransaction(
+        getConsensusState(),
+        getConsensusNetwork(),
+        getTransaction(),
+        1,
+        privateKey!
+      )
+      expect(error).toEqual('signature index out of range: 1')
+      expect(signature).toBeUndefined()
+    })
+    it('errors if the private key is invalid', async () => {
+      const sdk = await initSDKTest()
+      const { error, signature } = sdk.wallet.signTransaction(
+        getConsensusState(),
+        getConsensusNetwork(),
+        getTransaction(),
+        1,
+        'invalid private key'
+      )
+      expect(error).toEqual(
+        "error decoding private key: encoding/hex: invalid byte: U+0069 'i'"
+      )
+      expect(signature).toBeUndefined()
+    })
+  })
+})

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -146,3 +146,60 @@ export type ChainIndex = {
   height: number
   id: string
 }
+
+export type ConsensusNetwork = {
+  name: 'mainnet' | 'zen'
+  initialCoinbase: Currency
+  minimumCoinbase: Currency
+  initialTarget: string
+  hardforkDevAddr: {
+    height: number
+    oldAddress: string
+    newAddress: string
+  }
+  hardforkTax: {
+    height: number
+  }
+  hardforkStorageProof: {
+    height: number
+  }
+  hardforkOak: {
+    height: number
+    fixHeight: number
+    genesisTimestamp: string
+  }
+  hardforkASIC: {
+    height: number
+    oakTime: number
+    oakTarget: string
+  }
+  hardforkFoundation: {
+    height: number
+    primaryAddress: string
+    failsafeAddress: string
+  }
+  hardforkV2: {
+    allowHeight: number
+    requireHeight: number
+  }
+}
+
+export type ConsensusState = {
+  index: ChainIndex
+  prevTimestamps: string[]
+  depth: string
+  childTarget: string
+  siafundPool: string
+  oakTime: number
+  oakTarget: string
+  foundationPrimaryAddress: string
+  foundationFailsafeAddress: string
+  totalWork: string
+  difficulty: string
+  oakWork: string
+  elements: {
+    numLeaves: number
+    trees: string[]
+  }
+  attestations: number
+}

--- a/sdk/main.go
+++ b/sdk/main.go
@@ -24,6 +24,18 @@ func main() {
 			"encodeWriteSectorResponse": jsFunc(encodeWriteSectorResponse),
 			"decodeWriteSectorResponse": jsFunc(decodeWriteSectorResponse),
 		},
+		"wallet": map[string]any{
+			"generateSeedPhrase":          jsFunc(generateSeedPhrase),
+			"generateKeyPair":             jsFunc(generateKeyPair),
+			"keyPairFromSeedPhrase":       jsFunc(keyPairFromSeedPhrase),
+			"standardUnlockConditions":    jsFunc(standardUnlockConditions),
+			"standardUnlockHash":          jsFunc(standardUnlockHash),
+			"addressFromUnlockConditions": jsFunc(addressFromUnlockConditions),
+			"addressFromSpendPolicy":      jsFunc(addressFromSpendPolicy),
+			"encodeTransaction":           jsFunc(encodeTransaction),
+			"transactionId":               jsFunc(transactionID),
+			"signTransaction":             jsFunc(signTransaction),
+		},
 	})
 	c := make(chan bool, 1)
 	<-c

--- a/sdk/wallet.go
+++ b/sdk/wallet.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"syscall/js"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/wallet"
+)
+
+func encodeToBytes(v types.EncoderTo) []byte {
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	v.EncodeTo(e)
+	e.Flush()
+	return buf.Bytes()
+}
+
+// GenerateSeedPhrase returns a new seed phrase.
+func generateSeedPhrase(this js.Value, args []js.Value) result {
+	if err := checkArgs(args); err != nil {
+		return resultErr(err)
+	}
+
+	return result(map[string]any{
+		"phrase": wallet.NewSeedPhrase(),
+	})
+}
+
+// GenerateKeyPair returns a new ed25519 key pair.
+func generateKeyPair(this js.Value, args []js.Value) result {
+	if err := checkArgs(args); err != nil {
+		return resultErr(err)
+	}
+
+	pk := types.GeneratePrivateKey()
+	return result(map[string]any{
+		"privateKey": hex.EncodeToString(pk),
+		"publicKey":  pk.PublicKey().String(),
+	})
+}
+
+// KeyPairFromSeedPhrase returns the key pair corresponding to the given seed phrase and index.
+func keyPairFromSeedPhrase(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeString, js.TypeNumber); err != nil {
+		return resultErr(err)
+	}
+
+	var seed [32]byte
+	if err := wallet.SeedFromPhrase(&seed, args[0].String()); err != nil {
+		return resultErr(err)
+	}
+	priv := wallet.KeyFromSeed(&seed, uint64(args[1].Int()))
+	return result(map[string]any{
+		"privateKey": hex.EncodeToString(priv),
+		"publicKey":  priv.PublicKey().String(),
+	})
+}
+
+// StandardUnlockConditions returns the unlock conditions for a standard v1 unlockhash.
+func standardUnlockConditions(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeString); err != nil {
+		return resultErr(err)
+	}
+
+	var pub types.PublicKey
+	if pub.UnmarshalText([]byte(args[0].String())) != nil {
+		return resultErrStr("invalid public key")
+	}
+	uc := types.StandardUnlockConditions(pub)
+	obj, err := marshalStruct(uc)
+	if err != nil {
+		return resultErrStr(fmt.Sprintf("error marshaling unlock conditions: %s", err))
+	}
+	return result(map[string]any{
+		"unlockConditions": obj,
+	})
+}
+
+// StandardUnlockHash returns the v1 unlockhash corresponding to the given public key.
+func standardUnlockHash(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeString); err != nil {
+		return resultErr(err)
+	}
+
+	var pub types.PublicKey
+	if pub.UnmarshalText([]byte(args[0].String())) != nil {
+		return resultErrStr("invalid public key")
+	}
+	return result(map[string]any{
+		"address": types.StandardUnlockHash(pub).String(),
+	})
+}
+
+// AddressFromUnlockConditions returns the address corresponding to the given unlock conditions.
+func addressFromUnlockConditions(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeObject); err != nil {
+		return resultErr(err)
+	}
+
+	var uc types.UnlockConditions
+	if err := unmarshalStruct(args[0], &uc); err != nil {
+		return resultErr(err)
+	}
+
+	return result(map[string]any{
+		"address": uc.UnlockHash().String(),
+	})
+}
+
+// AddressFromSpendPolicy returns the address of a spend policy.
+func addressFromSpendPolicy(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeString); err != nil {
+		return resultErr(err)
+	}
+
+	var sp types.SpendPolicy
+	if err := unmarshalStruct(args[0], &sp); err != nil {
+		return resultErr(err)
+	}
+
+	return result(map[string]any{
+		"address": sp.Address().String(),
+	})
+}
+
+// EncodeTransaction returns the binary encoding of a transaction.
+func encodeTransaction(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeObject); err != nil {
+		return resultErr(err)
+	}
+
+	var txn types.Transaction
+	if err := unmarshalStruct(args[0], &txn); err != nil {
+		return resultErrStr(fmt.Sprintf("error decoding transaction: %s", err))
+	}
+
+	encoded := encodeToBytes(txn)
+	return result(map[string]any{
+		"encodedTransaction": marshalUint8Array(encoded),
+	})
+}
+
+// SignTransaction returns the signature of a transaction.
+func signTransaction(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeObject, js.TypeObject, js.TypeObject, js.TypeNumber, js.TypeString); err != nil {
+		return resultErr(err)
+	}
+
+	var cs consensus.State
+	if err := unmarshalStruct(args[0], &cs); err != nil {
+		return resultErrStr(fmt.Sprintf("error decoding consensus state: %s", err))
+	}
+
+	var cn consensus.Network
+	if err := unmarshalStruct(args[1], &cn); err != nil {
+		return resultErrStr(fmt.Sprintf("error decoding consensus network: %s", err))
+	}
+
+	var txn types.Transaction
+	if err := unmarshalStruct(args[2], &txn); err != nil {
+		return resultErrStr(fmt.Sprintf("error decoding transaction: %s", err))
+	}
+	cs.Network = &cn
+
+	sigIndex := args[3].Int()
+
+	buf, err := hex.DecodeString(args[4].String())
+	if err != nil {
+		return resultErrStr(fmt.Sprintf("error decoding private key: %s", err))
+	} else if len(buf) != ed25519.PrivateKeySize {
+		return resultErrStr(fmt.Sprintf("invalid private key length: %d", len(buf)))
+	}
+	privateKey := types.PrivateKey(buf)
+
+	if sigIndex < 0 || sigIndex >= len(txn.Signatures) {
+		return resultErrStr(fmt.Sprintf("signature index out of range: %d", sigIndex))
+	}
+	tsig := &txn.Signatures[sigIndex]
+	var sigHash types.Hash256
+	if tsig.CoveredFields.WholeTransaction {
+		sigHash = cs.WholeSigHash(txn, tsig.ParentID, tsig.PublicKeyIndex, tsig.Timelock, tsig.CoveredFields.Signatures)
+	} else {
+		sigHash = cs.PartialSigHash(txn, tsig.CoveredFields)
+	}
+	return result(map[string]any{
+		"signature": privateKey.SignHash(sigHash).String(),
+	})
+}
+
+// TransactionID returns the ID of a transaction.
+func transactionID(this js.Value, args []js.Value) result {
+	if err := checkArgs(args, js.TypeObject); err != nil {
+		return resultErr(err)
+	}
+
+	var txn types.Transaction
+	if err := unmarshalStruct(args[0], &txn); err != nil {
+		return resultErrStr(fmt.Sprintf("error decoding transaction: %s", err))
+	}
+
+	return result(map[string]any{
+		"id": txn.ID().String(),
+	})
+}


### PR DESCRIPTION
- Wallet and transaction signing methods are now part of the sdk.

