### PR TITLE
fix: renterd alerts data text size

### DIFF
--- a/apps/renterd/contexts/alerts/data.tsx
+++ b/apps/renterd/contexts/alerts/data.tsx
@@ -44,6 +44,7 @@ export const dataFields: Record<
             contract ID
           </Text>
           <ValueMenu
+            size="12"
             value={value}
             menu={
               <ContractContextMenuFromId
@@ -85,6 +86,7 @@ export const dataFields: Record<
             host key
           </Text>
           <ValueMenu
+            size="12"
             value={value}
             menu={
               <HostContextMenu


### PR DESCRIPTION
- Two data fields were using 14 instead of 12.
