### PR TITLE
fix: renterd alerts relative time and column state

### DIFF
--- a/.changeset/violet-starfishes-swim.md
+++ b/.changeset/violet-starfishes-swim.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the alert data fields showed the wrong dates.

--- a/.changeset/wise-eagles-allow.md
+++ b/.changeset/wise-eagles-allow.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the alert columns were not initially showing.

--- a/apps/renterd/contexts/alerts/columns.tsx
+++ b/apps/renterd/contexts/alerts/columns.tsx
@@ -129,7 +129,7 @@ export const columns: KeysTableColumn[] = [
     render: ({ data: { timestamp } }) => {
       return (
         <Text color="subtle" size="12" ellipsis>
-          {formatRelative(new Date(), new Date(timestamp))}
+          {formatRelative(new Date(timestamp), new Date())}
         </Text>
       )
     },

--- a/apps/renterd/contexts/alerts/data.tsx
+++ b/apps/renterd/contexts/alerts/data.tsx
@@ -370,7 +370,7 @@ function ContractSetChange({
               time
             </Text>
             <Text size="12" ellipsis>
-              {formatRelative(new Date(), new Date(time))}
+              {formatRelative(new Date(time), new Date())}
             </Text>
           </div>
           <div className="flex gap-2">

--- a/apps/renterd/contexts/alerts/index.tsx
+++ b/apps/renterd/contexts/alerts/index.tsx
@@ -130,7 +130,7 @@ function useAlertsMain() {
     sortField,
     sortDirection,
     resetDefaultColumnVisibility,
-  } = useTableState('renterd/v0/keys', {
+  } = useTableState('renterd/v0/alerts', {
     columns,
     columnsDefaultVisible,
     sortOptions,


### PR DESCRIPTION
- Fixed an issue where the alert data fields showed the wrong dates.
- Fixed an issue where the alert columns were not initially showing.

