### PR TITLE
fix: renterd multipart etag error

### DIFF
--- a/.changeset/tricky-tables-know.md
+++ b/.changeset/tricky-tables-know.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Uploads will now error and abort if responses are missing etags.


### PR DESCRIPTION
- Uploads will now error and abort if responses are missing etags.

