### PR TITLE
fix: renterd memory leak, abort uploads, inline progress

### DIFF
--- a/.changeset/few-chefs-love.md
+++ b/.changeset/few-chefs-love.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Directory and global file explorers now show upload progress inline.

--- a/.changeset/large-crews-play.md
+++ b/.changeset/large-crews-play.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed a slow memory leak that became especially apparent during long running large uploads, memory usage is now minimal and stable over time.

--- a/.changeset/rich-lemons-speak.md
+++ b/.changeset/rich-lemons-speak.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Uploads now support aborting the entire visible page of active uploads.

--- a/apps/renterd/components/Uploads/UploadsStatsMenu/index.tsx
+++ b/apps/renterd/components/Uploads/UploadsStatsMenu/index.tsx
@@ -1,11 +1,13 @@
-import { PaginatorMarker } from '@siafoundation/design-system'
+import { Button, PaginatorMarker } from '@siafoundation/design-system'
 import { useUploads } from '../../../contexts/uploads'
 
 export function UploadsStatsMenu() {
-  const { limit, pageCount, dataState, nextMarker, hasMore } = useUploads()
+  const { abortAll, limit, pageCount, dataState, nextMarker, hasMore } =
+    useUploads()
   return (
     <div className="flex gap-3 w-full">
       <div className="flex-1" />
+      {pageCount > 0 && <Button onClick={abortAll}>Abort ({pageCount})</Button>}
       <PaginatorMarker
         marker={nextMarker}
         isMore={hasMore}

--- a/apps/renterd/contexts/filesDirectory/columns.tsx
+++ b/apps/renterd/contexts/filesDirectory/columns.tsx
@@ -1,15 +1,10 @@
-import {
-  Button,
-  LoadingDots,
-  Text,
-  Tooltip,
-  ValueNum,
-} from '@siafoundation/design-system'
+import { Button, Text, Tooltip, ValueNum } from '@siafoundation/design-system'
 import {
   Document16,
   Earth16,
   FolderIcon,
   Locked16,
+  Upload16,
 } from '@siafoundation/react-icons'
 import { humanBytes } from '@siafoundation/units'
 import { FileContextMenu } from '../../components/Files/FileContextMenu'
@@ -158,12 +153,9 @@ export const columns: FilesTableColumn[] = [
     id: 'size',
     label: 'size',
     contentClassName: 'justify-end',
-    render: function SizeColumn({ data: { type, name, size, isUploading } }) {
+    render: function SizeColumn({ data: { type, name, size } }) {
       if (type === 'bucket') {
         return null
-      }
-      if (isUploading) {
-        return <LoadingDots />
       }
 
       if (name === '..') {
@@ -187,8 +179,26 @@ export const columns: FilesTableColumn[] = [
     label: 'health',
     contentClassName: 'justify-center',
     render: function HealthColumn({ data }) {
-      if (data.type === 'bucket') {
+      const { type, isUploading, loaded, size } = data
+      if (type === 'bucket') {
         return null
+      }
+      if (isUploading) {
+        const displayPercent = ((loaded / size) * 100).toFixed(0) + '%'
+        return (
+          <Tooltip
+            content={`Uploaded ${humanBytes(loaded)}/${humanBytes(size)}`}
+          >
+            <div className="flex items-center gap-1 cursor-pointer">
+              <Text color="subtle">
+                <Upload16 className="scale-75" />
+              </Text>
+              <Text color="subtle" size="12">
+                {displayPercent}
+              </Text>
+            </div>
+          </Tooltip>
+        )
       }
       return <FilesHealthColumn {...data} />
     },

--- a/apps/renterd/contexts/filesDirectory/dataset.tsx
+++ b/apps/renterd/contexts/filesDirectory/dataset.tsx
@@ -56,11 +56,17 @@ export function useDataset() {
     },
   })
 
-  const d = useDatasetGeneric({
-    objects: {
+  const objects = useMemo(
+    () => ({
       isValidating: response.isValidating,
       data: response.data?.entries,
-    },
+    }),
+    [response.isValidating, response.data?.entries]
+  )
+
+  const d = useDatasetGeneric({
+    id: 'filesDirectory',
+    objects,
   })
 
   return {

--- a/apps/renterd/contexts/filesFlat/columns.tsx
+++ b/apps/renterd/contexts/filesFlat/columns.tsx
@@ -1,11 +1,10 @@
+import { Button, Text, Tooltip, ValueNum } from '@siafoundation/design-system'
 import {
-  Button,
-  LoadingDots,
-  Text,
-  Tooltip,
-  ValueNum,
-} from '@siafoundation/design-system'
-import { Document16, Earth16, Locked16 } from '@siafoundation/react-icons'
+  Document16,
+  Earth16,
+  Locked16,
+  Upload16,
+} from '@siafoundation/react-icons'
 import { humanBytes } from '@siafoundation/units'
 import { FileContextMenu } from '../../components/Files/FileContextMenu'
 import { DirectoryContextMenu } from '../../components/Files/DirectoryContextMenu'
@@ -126,12 +125,9 @@ export const columns: FilesTableColumn[] = [
     id: 'size',
     label: 'size',
     contentClassName: 'justify-end',
-    render: function SizeColumn({ data: { type, name, size, isUploading } }) {
+    render: function SizeColumn({ data: { type, name, size } }) {
       if (type === 'bucket') {
         return null
-      }
-      if (isUploading) {
-        return <LoadingDots />
       }
 
       if (name === '..') {
@@ -155,8 +151,26 @@ export const columns: FilesTableColumn[] = [
     label: 'health',
     contentClassName: 'justify-center',
     render: function HealthColumn({ data }) {
-      if (data.type === 'bucket') {
+      const { type, isUploading, loaded, size } = data
+      if (type === 'bucket') {
         return null
+      }
+      if (isUploading) {
+        const displayPercent = ((loaded / size) * 100).toFixed(0) + '%'
+        return (
+          <Tooltip
+            content={`Uploaded ${humanBytes(loaded)}/${humanBytes(size)}`}
+          >
+            <div className="flex items-center gap-1 cursor-pointer">
+              <Text color="subtle">
+                <Upload16 className="scale-75" />
+              </Text>
+              <Text color="subtle" size="12">
+                {displayPercent}
+              </Text>
+            </div>
+          </Tooltip>
+        )
       }
       return <FilesHealthColumn {...data} />
     },

--- a/apps/renterd/contexts/filesFlat/dataset.tsx
+++ b/apps/renterd/contexts/filesFlat/dataset.tsx
@@ -52,11 +52,17 @@ export function useDataset({ sortDirection, sortField }: Props) {
     },
   })
 
-  const d = useDatasetGeneric({
-    objects: {
+  const objects = useMemo(
+    () => ({
       isValidating: response.isValidating,
       data: response.data?.objects,
-    },
+    }),
+    [response.isValidating, response.data]
+  )
+
+  const d = useDatasetGeneric({
+    id: 'filesFlat',
+    objects,
   })
 
   return {


### PR DESCRIPTION
- Fixed a slow memory leak that became especially apparent during long running large uploads, memory usage is now minimal and stable over time.
- Uploads now support aborting the entire visible page of active uploads.
- Directory and global file explorers now show upload progress inline.
