### PR TITLE
refactor: renterd libs extract route variables

### DIFF
--- a/apps/renterd/config/routes.ts
+++ b/apps/renterd/config/routes.ts
@@ -1,4 +1,4 @@
-import { busStateKey } from '@siafoundation/renterd-react'
+import { busStateRoute } from '@siafoundation/renterd-types'
 
 export const routes = {
   home: '/',
@@ -38,4 +38,4 @@ export const routes = {
   login: '/login',
 }
 
-export const connectivityRoute = busStateKey
+export const connectivityRoute = busStateRoute

--- a/apps/renterd/contexts/config/useOnValid.tsx
+++ b/apps/renterd/contexts/config/useOnValid.tsx
@@ -4,7 +4,6 @@ import {
 } from '@siafoundation/design-system'
 import { useCallback } from 'react'
 import {
-  autopilotHostsKey,
   useAutopilotConfigUpdate,
   useAutopilotTrigger,
   useBusState,
@@ -22,6 +21,7 @@ import { delay, useMutate } from '@siafoundation/react-core'
 import { Resources } from './resources'
 import { useSyncContractSet } from './useSyncContractSet'
 import BigNumber from 'bignumber.js'
+import { autopilotHostsRoute } from '@siafoundation/renterd-types'
 
 export function useOnValid({
   resources,
@@ -155,9 +155,9 @@ export function useOnValid({
         if (firstTimeSettingConfig) {
           const refreshHostsAfterDelay = async () => {
             await delay(5_000)
-            mutate((key) => key.startsWith(autopilotHostsKey))
+            mutate((key) => key.startsWith(autopilotHostsRoute))
             await delay(5_000)
-            mutate((key) => key.startsWith(autopilotHostsKey))
+            mutate((key) => key.startsWith(autopilotHostsRoute))
           }
           refreshHostsAfterDelay()
         }

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -20,11 +20,12 @@ import { HostContext, HostData, TableColumnId } from './types'
 import { format, formatDistance, formatRelative } from 'date-fns'
 import { HostContextMenu } from '../../components/Hosts/HostContextMenu'
 import { useWorkflows } from '@siafoundation/react-core'
-import { AutopilotHost, RhpScanPayload } from '@siafoundation/renterd-types'
 import {
-  useHostsAllowlist,
+  AutopilotHost,
+  RhpScanPayload,
   workerRhpScanRoute,
-} from '@siafoundation/renterd-react'
+} from '@siafoundation/renterd-types'
+import { useHostsAllowlist } from '@siafoundation/renterd-react'
 import BigNumber from 'bignumber.js'
 import React, { memo } from 'react'
 

--- a/libs/react-core/package.json
+++ b/libs/react-core/package.json
@@ -4,14 +4,14 @@
   "version": "1.1.0",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^18.2.0",
+    "react": "^18.2.0"
+  },
+  "dependencies": {
+    "@siafoundation/next": "^0.1.3",
+    "@siafoundation/request": "0.0.0",
     "swr": "^2.1.1",
     "axios": "^0.27.2",
     "use-local-storage-state": "^18.3.3",
-    "@siafoundation/next": "^0.1.3",
-    "@siafoundation/request": "0.0.0"
-  },
-  "dependencies": {
     "detect-gpu": "^5.0.34"
   },
   "types": "./src/index.d.ts"

--- a/libs/renterd-react/src/autopilot.ts
+++ b/libs/renterd-react/src/autopilot.ts
@@ -22,26 +22,27 @@ import {
   AutopilotTriggerParams,
   AutopilotTriggerPayload,
   AutopilotTriggerResponse,
+  autopilotConfigRoute,
+  autopilotHostsRoute,
+  autopilotStateRoute,
+  autopilotTriggerRoute,
 } from '@siafoundation/renterd-types'
-
-const autopilotStateKey = '/autopilot/state'
 
 export function useAutopilotState(
   args?: HookArgsSwr<AutopilotStateParams, AutopilotStateResponse>
 ) {
   return useGetSwr({
     ...args,
-    route: autopilotStateKey,
+    route: autopilotStateRoute,
   })
 }
 
-const autopilotConfigKey = '/autopilot/config'
 export function useAutopilotConfig(
   args?: HookArgsSwr<AutopilotConfigParams, AutopilotConfigResponse>
 ) {
   return useGetSwr({
     ...args,
-    route: autopilotConfigKey,
+    route: autopilotConfigRoute,
   })
 }
 
@@ -52,19 +53,20 @@ export function useAutopilotConfigUpdate(
     AutopilotConfigUpdateResponse
   >
 ) {
-  return usePutFunc({ ...args, route: autopilotConfigKey }, async (mutate) => {
-    mutate((key) => key === autopilotConfigKey)
-    // might need a delay before revalidating status which returns whether
-    // or not autopilot is configured
-    const func = async () => {
-      await delay(1000)
-      mutate((key) => key === autopilotStateKey)
+  return usePutFunc(
+    { ...args, route: autopilotConfigRoute },
+    async (mutate) => {
+      mutate((key) => key === autopilotConfigRoute)
+      // might need a delay before revalidating status which returns whether
+      // or not autopilot is configured
+      const func = async () => {
+        await delay(1000)
+        mutate((key) => key === autopilotStateRoute)
+      }
+      func()
     }
-    func()
-  })
+  )
 }
-
-export const autopilotHostsKey = '/autopilot/hosts'
 
 export function useAutopilotHostsSearch(
   args?: HookArgsWithPayloadSwr<
@@ -75,7 +77,7 @@ export function useAutopilotHostsSearch(
 ) {
   return usePostSwr({
     ...args,
-    route: autopilotHostsKey,
+    route: autopilotHostsRoute,
   })
 }
 
@@ -88,6 +90,6 @@ export function useAutopilotTrigger(
 ) {
   return usePostFunc({
     ...args,
-    route: '/autopilot/trigger',
+    route: autopilotTriggerRoute,
   })
 }

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -185,18 +185,79 @@ import {
   WalletTransactionsResponse,
   WalletUtxoParams,
   WalletUtxoResponse,
+  busAccountIdResetdriftRoute,
+  busBucketRoute,
+  busBucketNamePolicyRoute,
+  busBucketNameRoute,
+  busBucketsRoute,
+  busConsensusAcceptblockRoute,
+  busConsensusStateRoute,
+  busContractRoute,
+  busContractIdAcquireRoute,
+  busContractIdNewRoute,
+  busContractIdReleaseRoute,
+  busContractIdRenewedRoute,
+  busContractIdRoute,
+  busContractsRoute,
+  busContractsSetsRoute,
+  busContractsSetsSetRoute,
+  busHostHostKeyRoute,
+  busHostPublicKeyResetlostsectorsRoute,
+  busHostsAllowlistRoute,
+  busHostsBlocklistRoute,
+  busHostsHostKeyRoute,
+  busHostsRoute,
+  busObjectsRoute,
+  busObjectsKeyRoute,
+  busObjectsListRoute,
+  busObjectsRenameRoute,
+  busSearchHostsRoute,
+  busSearchObjectsRoute,
+  busSettingKeyRoute,
+  busSettingsRoute,
+  busStateRoute,
+  busStatsObjectsRoute,
+  busSyncerAddrRoute,
+  busSyncerConnectRoute,
+  busSyncerPeersRoute,
+  busTxpoolBroadcastRoute,
+  busTxpoolFeeRoute,
+  busTxpoolTransactionsRoute,
+  busWalletAddressesRoute,
+  busWalletDiscardRoute,
+  busWalletFundRoute,
+  busWalletOutputsRoute,
+  busWalletPendingRoute,
+  busWalletPrepareFormRoute,
+  busWalletPrepareRenewRoute,
+  busWalletRedistributeRoute,
+  busWalletRoute,
+  busWalletSignRoute,
+  busWalletTransactionsRoute,
+  busAlertsRoute,
+  busAlertsDismissRoute,
+  busSlabKeyObjectsRoute,
+  busMetricContractRoute,
+  busMetricContractsetRoute,
+  busMetricChurnRoute,
+  busMetricWalletRoute,
+  busMultipartCreateRoute,
+  busMultipartRoute,
+  busMultipartCompleteRoute,
+  busMultipartAbortRoute,
+  busMultipartListpartsRoute,
+  busMultipartListuploadsRoute,
+  busMultipartPartRoute,
 } from '@siafoundation/renterd-types'
 
 // state
-
-export const busStateKey = '/bus/state'
 
 export function useBusState(
   args?: HookArgsSwr<BusStateParams, BusStateResponse>
 ) {
   return useGetSwr({
     ...args,
-    route: busStateKey,
+    route: busStateRoute,
   })
 }
 
@@ -207,7 +268,7 @@ export function useConsensusState(
 ) {
   return useGetSwr({
     ...args,
-    route: '/bus/consensus/state',
+    route: busConsensusStateRoute,
   })
 }
 
@@ -242,19 +303,17 @@ export function useConsensusAcceptBlock(
     ConsensusAcceptBlockResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/consensus/acceptblock' })
+  return usePostFunc({ ...args, route: busConsensusAcceptblockRoute })
 }
 
 // syncer
-
-const syncerPeers = '/bus/syncer/peers'
 
 export function useSyncerPeers(
   args?: HookArgsSwr<SyncerPeersParams, SyncerPeersResponse>
 ) {
   return useGetSwr({
     ...args,
-    route: syncerPeers,
+    route: busSyncerPeersRoute,
   })
 }
 
@@ -268,10 +327,10 @@ export function useSyncerConnect(
   return usePostFunc(
     {
       ...args,
-      route: '/bus/syncer/connect',
+      route: busSyncerConnectRoute,
     },
     async (mutate) => {
-      mutate((key) => key === syncerPeers)
+      mutate((key) => key === busSyncerPeersRoute)
     }
   )
 }
@@ -279,7 +338,7 @@ export function useSyncerConnect(
 export function useSyncerAddress(
   args?: HookArgsSwr<SyncerAddressParams, SyncerAddressResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/syncer/addr' })
+  return useGetSwr({ ...args, route: busSyncerAddrRoute })
 }
 
 // txpool
@@ -287,14 +346,13 @@ export function useSyncerAddress(
 export function useTxPoolFee(
   args?: HookArgsSwr<TxPoolFeeParams, TxPoolFeeResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/txpool/fee' })
+  return useGetSwr({ ...args, route: busTxpoolFeeRoute })
 }
 
-const txPoolTransactionsRoute = '/bus/txpool/transactions'
 export function useTxPoolTransactions(
   args?: HookArgsSwr<TxPoolTransactionsParams, TxPoolTransactionsResponse>
 ) {
-  return useGetSwr({ ...args, route: txPoolTransactionsRoute })
+  return useGetSwr({ ...args, route: busTxpoolTransactionsRoute })
 }
 
 export function useTxPoolBroadcast(
@@ -307,14 +365,14 @@ export function useTxPoolBroadcast(
   return usePostFunc(
     {
       ...args,
-      route: '/bus/txpool/broadcast',
+      route: busTxpoolBroadcastRoute,
     },
     async (mutate) => {
       await delay(2_000)
       mutate((key) => {
         return (
-          key.startsWith(txPoolTransactionsRoute) ||
-          key.startsWith(walletPendingRoute)
+          key.startsWith(busTxpoolTransactionsRoute) ||
+          key.startsWith(busWalletPendingRoute)
         )
       })
     }
@@ -324,13 +382,13 @@ export function useTxPoolBroadcast(
 // wallet
 
 export function useWallet(args?: HookArgsSwr<WalletParams, WalletResponse>) {
-  return useGetSwr({ ...args, route: '/bus/wallet' })
+  return useGetSwr({ ...args, route: busWalletRoute })
 }
 
 export function useWalletAddresses(
   args?: HookArgsSwr<WalletAddressesParams, WalletAddressesResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/wallet/addresses' })
+  return useGetSwr({ ...args, route: busWalletAddressesRoute })
 }
 
 export function useWalletTransactions(
@@ -338,14 +396,14 @@ export function useWalletTransactions(
 ) {
   return useGetSwr({
     ...args,
-    route: '/bus/wallet/transactions',
+    route: busWalletTransactionsRoute,
   })
 }
 
 export function useWalletUtxos(
   args?: HookArgsSwr<WalletUtxoParams, WalletUtxoResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/wallet/outputs' })
+  return useGetSwr({ ...args, route: busWalletOutputsRoute })
 }
 
 export function useWalletFund(
@@ -355,7 +413,7 @@ export function useWalletFund(
     WalletFundResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/wallet/fund' })
+  return usePostFunc({ ...args, route: busWalletFundRoute })
 }
 
 export function useWalletSign(
@@ -365,7 +423,7 @@ export function useWalletSign(
     WalletSignResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/wallet/sign' })
+  return usePostFunc({ ...args, route: busWalletSignRoute })
 }
 
 export function useWalletRedistribute(
@@ -375,7 +433,7 @@ export function useWalletRedistribute(
     WalletRedistributeResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/wallet/redistribute' })
+  return usePostFunc({ ...args, route: busWalletRedistributeRoute })
 }
 
 export function useWalletDiscard(
@@ -385,7 +443,7 @@ export function useWalletDiscard(
     WalletDiscardResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/wallet/discard' })
+  return usePostFunc({ ...args, route: busWalletDiscardRoute })
 }
 
 export function useWalletPrepareForm(
@@ -395,7 +453,7 @@ export function useWalletPrepareForm(
     WalletPrepareFormResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/wallet/prepare/form' })
+  return usePostFunc({ ...args, route: busWalletPrepareFormRoute })
 }
 
 export function useWalletPrepareRenew(
@@ -405,24 +463,22 @@ export function useWalletPrepareRenew(
     WalletPrepareRenewResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/wallet/prepare/form' })
+  return usePostFunc({ ...args, route: busWalletPrepareRenewRoute })
 }
 
-const walletPendingRoute = '/bus/wallet/pending'
 export function useWalletPending(
   args?: HookArgsSwr<WalletPendingParams, WalletPendingResponse>
 ) {
-  return useGetSwr({ ...args, route: walletPendingRoute })
+  return useGetSwr({ ...args, route: busWalletPendingRoute })
 }
 
 export function useHosts(args: HookArgsSwr<HostsParams, HostsResponse>) {
   return useGetSwr({
     ...args,
-    route: '/bus/hosts',
+    route: busHostsRoute,
   })
 }
 
-const hostsSearchRoute = '/bus/search/hosts'
 export function useHostsSearch(
   args: HookArgsWithPayloadSwr<
     HostsSearchParams,
@@ -432,12 +488,12 @@ export function useHostsSearch(
 ) {
   return usePostSwr({
     ...args,
-    route: hostsSearchRoute,
+    route: busSearchHostsRoute,
   })
 }
 
 export function useHost(args: HookArgsSwr<HostParams, HostResponse>) {
-  return useGetSwr({ ...args, route: '/bus/host/:hostKey' })
+  return useGetSwr({ ...args, route: busHostHostKeyRoute })
 }
 
 export function useHostsInteractionAdd(
@@ -449,21 +505,19 @@ export function useHostsInteractionAdd(
 ) {
   return usePostFunc({
     ...args,
-    route: '/bus/hosts/:hostKey',
+    route: busHostsHostKeyRoute,
   })
 }
-const hostsBlocklistRoute = '/bus/hosts/blocklist'
 export function useHostsBlocklist(
   args?: HookArgsSwr<HostsBlocklistParams, HostsBlocklistResponse>
 ) {
-  return useGetSwr({ ...args, route: hostsBlocklistRoute })
+  return useGetSwr({ ...args, route: busHostsBlocklistRoute })
 }
 
-const hostsAllowlistRoute = '/bus/hosts/allowlist'
 export function useHostsAllowlist(
   args?: HookArgsSwr<HostsAllowlistParams, HostsAllowlistResponse>
 ) {
-  return useGetSwr({ ...args, route: hostsAllowlistRoute })
+  return useGetSwr({ ...args, route: busHostsAllowlistRoute })
 }
 
 export function useHostsAllowlistUpdate(
@@ -474,13 +528,13 @@ export function useHostsAllowlistUpdate(
   >
 ) {
   return usePutFunc(
-    { ...args, route: '/bus/hosts/allowlist' },
+    { ...args, route: busHostsAllowlistRoute },
     async (mutate) => {
       mutate((key) => {
         const matches = [
-          hostsSearchRoute,
-          hostsAllowlistRoute,
-          contractsActiveRoute,
+          busSearchHostsRoute,
+          busHostsAllowlistRoute,
+          busContractsRoute,
         ]
         return !!matches.find((match) => key.startsWith(match))
       })
@@ -496,13 +550,13 @@ export function useHostsBlocklistUpdate(
   >
 ) {
   return usePutFunc(
-    { ...args, route: '/bus/hosts/blocklist' },
+    { ...args, route: busHostsBlocklistRoute },
     async (mutate) => {
       mutate((key) => {
         const matches = [
-          hostsSearchRoute,
-          hostsBlocklistRoute,
-          contractsActiveRoute,
+          busSearchHostsRoute,
+          busHostsBlocklistRoute,
+          busContractsRoute,
         ]
         return !!matches.find((match) => key.startsWith(match))
       })
@@ -519,7 +573,7 @@ export function useHostResetLostSectorCount(
 ) {
   return usePostFunc({
     ...args,
-    route: '/bus/host/:publicKey/resetlostsectors',
+    route: busHostPublicKeyResetlostsectorsRoute,
   })
 }
 
@@ -534,17 +588,16 @@ export function useAccountResetDrift(
 ) {
   return usePostFunc({
     ...args,
-    route: '/bus/account/:id/resetdrift',
+    route: busAccountIdResetdriftRoute,
   })
 }
 
 // contracts
 
-const contractsActiveRoute = '/bus/contracts'
 export function useContracts(
   args?: HookArgsSwr<ContractsParams, ContractsResponse>
 ) {
-  return useGetSwr({ ...args, route: contractsActiveRoute })
+  return useGetSwr({ ...args, route: busContractsRoute })
 }
 
 export function useContractsAcquire(
@@ -554,7 +607,7 @@ export function useContractsAcquire(
     ContractAcquireResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/contract/:id/acquire' })
+  return usePostFunc({ ...args, route: busContractIdAcquireRoute })
 }
 
 export function useContractsRelease(
@@ -564,13 +617,13 @@ export function useContractsRelease(
     ContractsReleaseResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/contract/:id/release' })
+  return usePostFunc({ ...args, route: busContractIdReleaseRoute })
 }
 
 export function useContract(
   args: HookArgsSwr<ContractParams, ContractResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/contract/:id' })
+  return useGetSwr({ ...args, route: busContractIdRoute })
 }
 
 export function useContractAdd(
@@ -580,7 +633,7 @@ export function useContractAdd(
     ContractsAddResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/contract/:id/new' })
+  return usePostFunc({ ...args, route: busContractIdNewRoute })
 }
 
 export function useContractRenew(
@@ -590,7 +643,7 @@ export function useContractRenew(
     ContractRenewedResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/contract/:id/renewed' })
+  return usePostFunc({ ...args, route: busContractIdRenewedRoute })
 }
 
 export function useContractDelete(
@@ -601,9 +654,9 @@ export function useContractDelete(
   >
 ) {
   return useDeleteFunc(
-    { ...args, route: '/bus/contract/:id' },
+    { ...args, route: busContractIdRoute },
     async (mutate) => {
-      mutate((key) => key.startsWith('/bus/contract'))
+      mutate((key) => key.startsWith(busContractRoute))
     }
   )
 }
@@ -611,7 +664,7 @@ export function useContractDelete(
 export function useContractSets(
   args?: HookArgsSwr<ContractSetsParams, ContractSetsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/contracts/sets' })
+  return useGetSwr({ ...args, route: busContractsSetsRoute })
 }
 
 export function useContractSetUpdate(
@@ -621,17 +674,17 @@ export function useContractSetUpdate(
     ContractSetUpdateResponse
   >
 ) {
-  return usePutFunc({ ...args, route: '/bus/contracts/sets/:set' })
+  return usePutFunc({ ...args, route: busContractsSetsSetRoute })
 }
 
 // objects
 
 export function useBuckets(args?: HookArgsSwr<BucketsParams, BucketsResponse>) {
-  return useGetSwr({ ...args, route: '/bus/buckets' })
+  return useGetSwr({ ...args, route: busBucketsRoute })
 }
 
 export function useBucket(args: HookArgsSwr<BucketParams, BucketResponse>) {
-  return useGetSwr({ ...args, route: '/bus/bucket/:name' })
+  return useGetSwr({ ...args, route: busBucketNameRoute })
 }
 
 export function useBucketCreate(
@@ -641,8 +694,8 @@ export function useBucketCreate(
     BucketCreateResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/buckets' }, async (mutate) => {
-    mutate((key) => key.startsWith('/bus/buckets'))
+  return usePostFunc({ ...args, route: busBucketsRoute }, async (mutate) => {
+    mutate((key) => key.startsWith(busBucketsRoute))
   })
 }
 
@@ -654,9 +707,9 @@ export function useBucketPolicyUpdate(
   >
 ) {
   return usePutFunc(
-    { ...args, route: '/bus/bucket/:name/policy' },
+    { ...args, route: busBucketNamePolicyRoute },
     async (mutate) => {
-      mutate((key) => key.startsWith('/bus/bucket'))
+      mutate((key) => key.startsWith(busBucketRoute))
     }
   )
 }
@@ -669,9 +722,9 @@ export function useBucketDelete(
   >
 ) {
   return useDeleteFunc(
-    { ...args, route: '/bus/bucket/:name' },
+    { ...args, route: busBucketNameRoute },
     async (mutate) => {
-      mutate((key) => key.startsWith('/bus/bucket'))
+      mutate((key) => key.startsWith(busBucketRoute))
     }
   )
 }
@@ -679,7 +732,7 @@ export function useBucketDelete(
 export function useObjectDirectory(
   args: HookArgsSwr<ObjectDirectoryParams, ObjectDirectoryResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/objects/:key' })
+  return useGetSwr({ ...args, route: busObjectsKeyRoute })
 }
 
 export function useObjectList(
@@ -689,23 +742,23 @@ export function useObjectList(
     ObjectListResponse
   >
 ) {
-  return usePostSwr({ ...args, route: '/bus/objects/list' })
+  return usePostSwr({ ...args, route: busObjectsListRoute })
 }
 
 export function useObject(args: HookArgsSwr<ObjectParams, ObjectResponse>) {
-  return useGetSwr({ ...args, route: '/bus/objects/:key' })
+  return useGetSwr({ ...args, route: busObjectsKeyRoute })
 }
 
 export function useObjectSearch(
   args: HookArgsSwr<ObjectSearchParams, ObjectSearchResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/search/objects' })
+  return useGetSwr({ ...args, route: busSearchObjectsRoute })
 }
 
 export function useObjectAdd(
   args: HookArgsCallback<ObjectAddParams, ObjectAddPayload, ObjectAddResponse>
 ) {
-  return usePutFunc({ ...args, route: '/bus/objects/:key' })
+  return usePutFunc({ ...args, route: busObjectsKeyRoute })
 }
 
 export function useObjectRename(
@@ -715,7 +768,7 @@ export function useObjectRename(
     ObjectRenameResponse
   >
 ) {
-  return usePostFunc({ ...args, route: '/bus/objects/rename' })
+  return usePostFunc({ ...args, route: busObjectsRenameRoute })
 }
 
 export function useObjectDelete(
@@ -726,9 +779,9 @@ export function useObjectDelete(
   >
 ) {
   return useDeleteFunc(
-    { ...args, route: '/bus/objects/:key' },
+    { ...args, route: busObjectsKeyRoute },
     async (mutate) => {
-      mutate((key) => key.startsWith('/bus/objects/'))
+      mutate((key) => key.startsWith(busObjectsRoute))
     }
   )
 }
@@ -736,7 +789,7 @@ export function useObjectDelete(
 export function useObjectStats(
   args?: HookArgsSwr<ObjectsStatsParams, ObjectsStatsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/stats/objects' })
+  return useGetSwr({ ...args, route: busStatsObjectsRoute })
 }
 
 type Setting = Record<string, unknown> | string
@@ -744,13 +797,13 @@ type Setting = Record<string, unknown> | string
 export function useSettings(
   args?: HookArgsSwr<SettingsParams, SettingsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/settings' })
+  return useGetSwr({ ...args, route: busSettingsRoute })
 }
 
 export function useSetting<T extends Setting>(
   args: HookArgsSwr<SettingParams, SettingResponse<T>>
 ) {
-  return useGetSwr({ ...args, route: '/bus/setting/:key' })
+  return useGetSwr({ ...args, route: busSettingKeyRoute })
 }
 
 export function useSettingUpdate(
@@ -763,18 +816,19 @@ export function useSettingUpdate(
   return usePutFunc(
     {
       ...args,
-      route: '/bus/setting/:key',
+      route: busSettingKeyRoute,
     },
     async (mutate, args) => {
-      mutate((key) => key.startsWith(`/bus/setting/${args.params.key}`))
+      mutate((key) =>
+        key.startsWith(busSettingKeyRoute.replace(':key', args.params.key))
+      )
     }
   )
 }
 
-const alertsRoute = '/bus/alerts'
 // params are required because omitting them returns a deprecated response structure
 export function useAlerts(args: HookArgsSwr<AlertsParams, AlertsResponse>) {
-  return useGetSwr({ ...args, route: alertsRoute })
+  return useGetSwr({ ...args, route: busAlertsRoute })
 }
 
 export function useAlertsDismiss(
@@ -785,10 +839,10 @@ export function useAlertsDismiss(
   >
 ) {
   return usePostFunc(
-    { ...args, route: '/bus/alerts/dismiss' },
+    { ...args, route: busAlertsDismissRoute },
     async (mutate) => {
       mutate((key) => {
-        return key.startsWith(alertsRoute)
+        return key.startsWith(busAlertsRoute)
       })
     }
   )
@@ -799,7 +853,7 @@ export function useAlertsDismiss(
 export function useSlabObjects(
   args: HookArgsSwr<SlabObjectsParams, SlabObjectsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/slab/:key/objects' })
+  return useGetSwr({ ...args, route: busSlabKeyObjectsRoute })
 }
 
 // metrics
@@ -807,13 +861,13 @@ export function useSlabObjects(
 export function useMetricsContract(
   args: HookArgsSwr<ContractMetricsParams, ContractMetricsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/metric/contract' })
+  return useGetSwr({ ...args, route: busMetricContractRoute })
 }
 
 export function useMetricsContractSet(
   args: HookArgsSwr<ContractSetMetricsParams, ContractSetMetricsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/metric/contractset' })
+  return useGetSwr({ ...args, route: busMetricContractsetRoute })
 }
 
 export function useMetricsContractSetChurn(
@@ -822,13 +876,13 @@ export function useMetricsContractSetChurn(
     ContractSetChurnMetricsResponse
   >
 ) {
-  return useGetSwr({ ...args, route: '/bus/metric/churn' })
+  return useGetSwr({ ...args, route: busMetricChurnRoute })
 }
 
 export function useMetricsWallet(
   args: HookArgsSwr<WalletMetricsParams, WalletMetricsResponse>
 ) {
-  return useGetSwr({ ...args, route: '/bus/metric/wallet' })
+  return useGetSwr({ ...args, route: busMetricWalletRoute })
 }
 
 // multipart
@@ -841,10 +895,10 @@ export function useMultipartUploadCreate(
   >
 ) {
   return usePostFunc(
-    { ...args, route: '/bus/multipart/create' },
+    { ...args, route: busMultipartCreateRoute },
     async (mutate) => {
       mutate((key) => {
-        return key.startsWith('/bus/multipart')
+        return key.startsWith(busMultipartRoute)
       })
     }
   )
@@ -858,10 +912,10 @@ export function useMultipartUploadComplete(
   >
 ) {
   return usePostFunc(
-    { ...args, route: '/bus/multipart/complete' },
+    { ...args, route: busMultipartCompleteRoute },
     async (mutate) => {
       mutate((key) => {
-        return key.startsWith('/bus/multipart')
+        return key.startsWith(busMultipartRoute)
       })
     }
   )
@@ -875,10 +929,10 @@ export function useMultipartUploadAbort(
   >
 ) {
   return usePostFunc(
-    { ...args, route: '/bus/multipart/abort' },
+    { ...args, route: busMultipartAbortRoute },
     async (mutate) => {
       mutate((key) => {
-        return key.startsWith('/bus/multipart')
+        return key.startsWith(busMultipartRoute)
       })
     }
   )
@@ -893,7 +947,7 @@ export function useMultipartUploadListParts(
 ) {
   return usePostSwr({
     ...args,
-    route: '/bus/multipart/listparts',
+    route: busMultipartListpartsRoute,
   })
 }
 
@@ -906,7 +960,7 @@ export function useMultipartUploadListUploads(
 ) {
   return usePostSwr({
     ...args,
-    route: '/bus/multipart/listuploads',
+    route: busMultipartListuploadsRoute,
   })
 }
 
@@ -918,10 +972,10 @@ export function useMultipartUploadAddPart(
   >
 ) {
   return usePostFunc(
-    { ...args, route: '/bus/multipart/part' },
+    { ...args, route: busMultipartPartRoute },
     async (mutate) => {
       mutate((key) => {
-        return key.startsWith('/bus/multipart/listparts')
+        return key.startsWith(busMultipartListpartsRoute)
       })
     }
   )

--- a/libs/renterd-react/src/worker.ts
+++ b/libs/renterd-react/src/worker.ts
@@ -24,18 +24,23 @@ import {
   RhpScanResponse,
   WorkerStateParams,
   WorkerStateResponse,
+  autopilotHostsRoute,
+  busObjectsRoute,
+  busSearchHostsRoute,
+  workerMultipartKeyRoute,
+  workerObjectsKeyRoute,
+  workerRhpScanRoute,
+  workerStateRoute,
 } from '@siafoundation/renterd-types'
 
 // state
-
-const workerStateKey = '/worker/state'
 
 export function useWorkerState(
   args?: HookArgsSwr<WorkerStateParams, WorkerStateResponse>
 ) {
   return useGetSwr({
     ...args,
-    route: workerStateKey,
+    route: workerStateRoute,
   })
 }
 
@@ -46,7 +51,7 @@ export function useObjectDownloadFunc(
     ObjectDownloadResponse
   >
 ) {
-  return useGetDownloadFunc({ ...args, route: '/worker/objects/:key' })
+  return useGetDownloadFunc({ ...args, route: workerObjectsKeyRoute })
 }
 
 export function useObjectUpload(
@@ -68,10 +73,10 @@ export function useObjectUpload(
           },
         },
       },
-      route: '/worker/objects/:key',
+      route: workerObjectsKeyRoute,
     },
     async (mutate) => {
-      mutate((key) => key.startsWith('/bus/objects'))
+      mutate((key) => key.startsWith(busObjectsRoute))
     }
   )
 }
@@ -94,13 +99,12 @@ export function useMultipartUploadPart(
         },
       },
     },
-    route: '/worker/multipart/:key',
+    route: workerMultipartKeyRoute,
   })
 }
 
 const debouncedListRevalidate = debounce((func: () => void) => func(), 5_000)
 
-export const workerRhpScanRoute = '/worker/rhp/scan'
 export function useRhpScan(
   args?: HookArgsCallback<RhpScanParams, RhpScanPayload, RhpScanResponse>
 ) {
@@ -114,7 +118,7 @@ export function useRhpScan(
       // succession the list is optimistically updated n times followed
       // by a single network revalidate.
       mutate<AutopilotHost[]>(
-        (key) => key.startsWith('/autopilot/hosts'),
+        (key) => key.startsWith(autopilotHostsRoute),
         (data) =>
           data?.map((aph) => {
             if (aph.host.publicKey === hostKey) {
@@ -136,7 +140,7 @@ export function useRhpScan(
         false
       )
       mutate<Host[]>(
-        (key) => key.startsWith('/bus/search/hosts'),
+        (key) => key.startsWith(busSearchHostsRoute),
         (data) =>
           data?.map((host) => {
             if (host.publicKey === hostKey) {
@@ -157,8 +161,8 @@ export function useRhpScan(
       debouncedListRevalidate(() => {
         mutate(
           (key) =>
-            key.startsWith('/autopilot/hosts') ||
-            key.startsWith('/bus/search/hosts'),
+            key.startsWith(autopilotHostsRoute) ||
+            key.startsWith(busSearchHostsRoute),
           (d) => d,
           true
         )

--- a/libs/renterd-types/src/autopilot.ts
+++ b/libs/renterd-types/src/autopilot.ts
@@ -1,6 +1,11 @@
 import { AutopilotConfig, Host } from './types'
 import { HostsSearchPayload, BusStateResponse } from './bus'
 
+export const autopilotStateRoute = '/autopilot/state'
+export const autopilotConfigRoute = '/autopilot/config'
+export const autopilotHostsRoute = '/autopilot/hosts'
+export const autopilotTriggerRoute = '/autopilot/trigger'
+
 type AutopilotStatus = {
   configured: boolean
   migrating: boolean
@@ -14,9 +19,11 @@ type AutopilotStatus = {
 export type AutopilotState = AutopilotStatus & BusStateResponse
 
 export type AutopilotStateParams = void
+export type AutopilotStatePayload = void
 export type AutopilotStateResponse = AutopilotState
 
 export type AutopilotConfigParams = void
+export type AutopilotConfigPayload = void
 export type AutopilotConfigResponse = AutopilotConfig
 
 export type AutopilotConfigUpdateParams = void

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -21,6 +21,72 @@ import {
   WalletTransaction,
 } from './types'
 
+export const busStateRoute = '/bus/state'
+export const busConsensusStateRoute = '/bus/consensus/state'
+export const busConsensusAcceptblockRoute = '/bus/consensus/acceptblock'
+export const busSyncerPeersRoute = '/bus/syncer/peers'
+export const busSyncerConnectRoute = '/bus/syncer/connect'
+export const busSyncerAddrRoute = '/bus/syncer/addr'
+export const busTxpoolTransactionsRoute = '/bus/txpool/transactions'
+export const busTxpoolBroadcastRoute = '/bus/txpool/broadcast'
+export const busTxpoolFeeRoute = '/bus/txpool/fee'
+export const busWalletRoute = '/bus/wallet'
+export const busWalletAddressesRoute = '/bus/wallet/addresses'
+export const busWalletTransactionsRoute = '/bus/wallet/transactions'
+export const busWalletOutputsRoute = '/bus/wallet/outputs'
+export const busWalletFundRoute = '/bus/wallet/fund'
+export const busWalletSignRoute = '/bus/wallet/sign'
+export const busWalletRedistributeRoute = '/bus/wallet/redistribute'
+export const busWalletDiscardRoute = '/bus/wallet/discard'
+export const busWalletPrepareFormRoute = '/bus/wallet/prepare/form'
+export const busWalletPrepareRenewRoute = '/bus/wallet/prepare/renew'
+export const busWalletPendingRoute = '/bus/wallet/pending'
+export const busHostsRoute = '/bus/hosts'
+export const busSearchHostsRoute = '/bus/search/hosts'
+export const busHostHostKeyRoute = '/bus/host/:hostKey'
+export const busHostsHostKeyRoute = '/bus/hosts/:hostKey'
+export const busHostsBlocklistRoute = '/bus/hosts/blocklist'
+export const busHostsAllowlistRoute = '/bus/hosts/allowlist'
+export const busHostPublicKeyResetlostsectorsRoute =
+  '/bus/host/:publicKey/resetlostsectors'
+export const busAccountIdResetdriftRoute = '/bus/account/:id/resetdrift'
+export const busContractsRoute = '/bus/contracts'
+export const busContractIdAcquireRoute = '/bus/contract/:id/acquire'
+export const busContractIdReleaseRoute = '/bus/contract/:id/release'
+export const busContractRoute = '/bus/contract'
+export const busContractIdRoute = '/bus/contract/:id'
+export const busContractIdNewRoute = '/bus/contract/:id/new'
+export const busContractIdRenewedRoute = '/bus/contract/:id/renewed'
+export const busContractsSetsRoute = '/bus/contracts/sets'
+export const busContractsSetsSetRoute = '/bus/contracts/sets/:set'
+export const busBucketRoute = '/bus/bucket'
+export const busBucketsRoute = '/bus/buckets'
+export const busBucketNameRoute = '/bus/bucket/:name'
+export const busBucketNamePolicyRoute = '/bus/bucket/:name/policy'
+export const busObjectsRoute = '/bus/objects'
+export const busObjectsKeyRoute = '/bus/objects/:key'
+export const busObjectsListRoute = '/bus/objects/list'
+export const busSearchObjectsRoute = '/bus/search/objects'
+export const busObjectsRenameRoute = '/bus/objects/rename'
+export const busStatsObjectsRoute = '/bus/stats/objects'
+export const busSettingRoute = '/bus/setting'
+export const busSettingsRoute = '/bus/settings'
+export const busSettingKeyRoute = '/bus/setting/:key'
+export const busAlertsRoute = '/bus/alerts'
+export const busAlertsDismissRoute = '/bus/alerts/dismiss'
+export const busSlabKeyObjectsRoute = '/bus/slab/:key/objects'
+export const busMetricContractRoute = '/bus/metric/contract'
+export const busMetricContractsetRoute = '/bus/metric/contractset'
+export const busMetricChurnRoute = '/bus/metric/churn'
+export const busMetricWalletRoute = '/bus/metric/wallet'
+export const busMultipartRoute = '/bus/multipart'
+export const busMultipartCreateRoute = '/bus/multipart/create'
+export const busMultipartCompleteRoute = '/bus/multipart/complete'
+export const busMultipartAbortRoute = '/bus/multipart/abort'
+export const busMultipartListpartsRoute = '/bus/multipart/listparts'
+export const busMultipartListuploadsRoute = '/bus/multipart/listuploads'
+export const busMultipartPartRoute = '/bus/multipart/part'
+
 // state
 
 type BuildState = {
@@ -32,6 +98,7 @@ type BuildState = {
 }
 
 export type BusStateParams = void
+export type BusStatePayload = void
 export type BusStateResponse = BuildState & {
   startTime: number
 }
@@ -39,6 +106,7 @@ export type BusStateResponse = BuildState & {
 // consensus
 
 export type ConsensusStateParams = void
+export type ConsensusStatePayload = void
 export type ConsensusStateResponse = ConsensusState
 
 export type ConsensusAcceptBlockParams = void
@@ -48,21 +116,25 @@ export type ConsensusAcceptBlockResponse = void
 // syncer
 
 export type SyncerPeersParams = void
+export type SyncerPeersPayload = void
 export type SyncerPeersResponse = string[]
 
 export type SyncerConnectParams = void
 export type SyncerConnectPayload = string
-export type SyncerConnectResponse = never
+export type SyncerConnectResponse = void
 
 export type SyncerAddressParams = void
+export type SyncerAddressPayload = void
 export type SyncerAddressResponse = string
 
 // txpool
 
 export type TxPoolFeeParams = void
+export type TxPoolFeePayload = void
 export type TxPoolFeeResponse = Currency
 
 export type TxPoolTransactionsParams = void
+export type TxPoolTransactionsPayload = void
 export type TxPoolTransactionsResponse = Transaction[]
 
 export type TxPoolBroadcastParams = void
@@ -72,6 +144,7 @@ export type TxPoolBroadcastResponse = unknown
 // wallet
 
 export type WalletParams = void
+export type WalletPayload = void
 export type WalletResponse = {
   scanHeight: number
   address: string
@@ -81,15 +154,18 @@ export type WalletResponse = {
 }
 
 export type WalletAddressesParams = void
+export type WalletAddressesPayload = void
 export type WalletAddressesResponse = string[]
 
 export type WalletTransactionsParams = {
   offset?: number
   limit?: number
 }
+export type WalletTransactionsPayload = void
 export type WalletTransactionsResponse = WalletTransaction[]
 
 export type WalletUtxoParams = void
+export type WalletUtxoPayload = void
 export type WalletUtxoResponse = SiacoinElement[]
 
 export type WalletFundParams = void
@@ -120,7 +196,7 @@ export type WalletRedistributeResponse = Transaction
 
 export type WalletDiscardParams = void
 export type WalletDiscardPayload = Transaction
-export type WalletDiscardResponse = never
+export type WalletDiscardResponse = void
 
 export type WalletPrepareFormParams = void
 export type WalletPrepareFormPayload = {
@@ -150,6 +226,7 @@ export type WalletPrepareRenewResponse = {
 }
 
 export type WalletPendingParams = void
+export type WalletPendingPayload = void
 export type WalletPendingResponse = Transaction[]
 
 // hosts
@@ -158,6 +235,7 @@ export type HostsParams = {
   offset?: number
   limit?: number
 }
+export type HostsPayload = void
 export type HostsResponse = Host[]
 
 export type HostsSearchParams = void
@@ -174,6 +252,7 @@ export type HostsSearchPayload = {
 export type HostsSearchResponse = Host[]
 
 export type HostParams = { hostKey: string }
+export type HostPayload = Host
 export type HostResponse = Host
 
 export type HostInteractionParams = { hostKey: string }
@@ -182,12 +261,14 @@ export type HostInteractionPayload = {
   type: string
   result?: string
 }
-export type HostInteractionResponse = never
+export type HostInteractionResponse = void
 
 export type HostsBlocklistParams = void
+export type HostsBlocklistPayload = void
 export type HostsBlocklistResponse = string[]
 
 export type HostsAllowlistParams = void
+export type HostsAllowlistPayload = void
 export type HostsAllowlistResponse = PublicKey[]
 
 export type HostsAllowlistUpdateParams = void
@@ -219,6 +300,7 @@ export type AccountResetDriftResponse = void
 // contracts
 
 export type ContractsParams = void
+export type ContractsPayload = void
 export type ContractsResponse = Contract[]
 
 export type ContractAcquireParams = {
@@ -235,11 +317,12 @@ export type ContractsReleaseParams = {
   id: string
 }
 export type ContractsReleasePayload = void
-export type ContractsReleaseResponse = never
+export type ContractsReleaseResponse = void
 
 export type ContractParams = {
   id: string
 }
+export type ContractPayload = void
 export type ContractResponse = Contract
 
 export type ContractsAddParams = {
@@ -267,16 +350,17 @@ export type ContractDeleteParams = {
   id: string
 }
 export type ContractDeletePayload = void
-export type ContractDeleteResponse = never
+export type ContractDeleteResponse = void
 
 export type ContractSetsParams = void
+export type ContractSetsPayload = void
 export type ContractSetsResponse = string[]
 
 export type ContractSetUpdateParams = {
   name: string
 }
 export type ContractSetUpdatePayload = string[]
-export type ContractSetUpdateResponse = never
+export type ContractSetUpdateResponse = void
 
 // objects
 
@@ -289,14 +373,16 @@ export type Bucket = {
 }
 
 export type BucketsParams = void
+export type BucketsPayload = void
 export type BucketsResponse = Bucket[]
 
 export type BucketParams = { name: string }
+export type BucketPayload = void
 export type BucketResponse = Bucket
 
 export type BucketCreateParams = void
 export type BucketCreatePayload = { name: string }
-export type BucketCreateResponse = never
+export type BucketCreateResponse = void
 
 export type BucketPolicy = {
   publicReadAccess: boolean
@@ -304,11 +390,11 @@ export type BucketPolicy = {
 
 export type BucketPolicyUpdateParams = { name: string }
 export type BucketPolicyUpdatePayload = { policy: BucketPolicy }
-export type BucketPolicyUpdateResponse = never
+export type BucketPolicyUpdateResponse = void
 
 export type BucketDeleteParams = { name: string }
 export type BucketDeletePayload = void
-export type BucketDeleteResponse = never
+export type BucketDeleteResponse = void
 
 export type ObjEntry = {
   name: string
@@ -325,6 +411,7 @@ export type ObjectDirectoryParams = {
   sortBy?: 'name' | 'health' | 'size'
   sortDir?: 'asc' | 'desc'
 }
+export type ObjectDirectoryPayload = void
 export type ObjectDirectoryResponse = { hasMore: boolean; entries: ObjEntry[] }
 
 export type ObjectListParams = void
@@ -343,6 +430,7 @@ export type ObjectListResponse = {
 }
 
 export type ObjectParams = { key: string; bucket: string }
+export type ObjectPayload = void
 export type ObjectResponse = { object: Obj }
 
 export type ObjectSearchParams = {
@@ -351,6 +439,7 @@ export type ObjectSearchParams = {
   offset: number
   limit: number
 }
+export type ObjectSearchPayload = void
 export type ObjectSearchResponse = ObjEntry[]
 
 export type ObjectAddParams = { key: string; bucket: string }
@@ -358,7 +447,7 @@ export type ObjectAddPayload = {
   object: Obj
   usedContracts: { [key: PublicKey]: FileContractID }
 }
-export type ObjectAddResponse = never
+export type ObjectAddResponse = void
 
 export type ObjectRenameParams = void
 export type ObjectRenamePayload = {
@@ -368,7 +457,7 @@ export type ObjectRenamePayload = {
   to: string
   mode: 'single' | 'multi'
 }
-export type ObjectRenameResponse = never
+export type ObjectRenameResponse = void
 
 export type ObjectDeleteParams = {
   key: string
@@ -376,9 +465,10 @@ export type ObjectDeleteParams = {
   batch?: boolean
 }
 export type ObjectDeletePayload = void
-export type ObjectDeleteResponse = never
+export type ObjectDeleteResponse = void
 
 export type ObjectsStatsParams = void
+export type ObjectsStatsPayload = void
 export type ObjectsStatsResponse = {
   numObjects: number // number of objects
   numUnfinishedObjects: number // number of unfinished objects
@@ -392,9 +482,11 @@ export type ObjectsStatsResponse = {
 export type Setting = Record<string, unknown> | string
 
 export type SettingsParams = void
+export type SettingsPayload = void
 export type SettingsResponse = string[]
 
 export type SettingParams = { key: string }
+export type SettingPayload = void
 export type SettingResponse<T extends Setting> = T
 
 export type SettingUpdateParams = { key: string }
@@ -422,7 +514,7 @@ export type AlertsParams = {
   offset: number
   severity?: AlertSeverity
 }
-
+export type AlertsPayload = void
 export type AlertsResponse = {
   alerts?: Alert[]
   hasMore: boolean
@@ -436,6 +528,7 @@ export type AlertsDismissResponse = void
 // slabs
 
 export type SlabObjectsParams = { key: string }
+export type SlabObjectsPayload = void
 export type SlabObjectsResponse = ObjEntry[]
 
 // metrics
@@ -464,6 +557,7 @@ export type ContractMetricsParams = MetricsParams & {
   contractID?: string
   hostKey?: string
 }
+export type ContractMetricsPayload = void
 export type ContractMetricsResponse = ContractMetric[]
 
 export type ContractSetMetric = {
@@ -475,6 +569,7 @@ export type ContractSetMetric = {
 export type ContractSetMetricsParams = MetricsParams & {
   name: string
 }
+export type ContractSetMetricsPayload = void
 export type ContractSetMetricsResponse = ContractSetMetric[]
 
 export type ContractSetChurnMetric = {
@@ -490,6 +585,7 @@ export type ContractSetChurnMetricsParams = MetricsParams & {
   direction?: string
   reason?: string
 }
+export type ContractSetChurnMetricsPayload = void
 export type ContractSetChurnMetricsResponse = ContractSetChurnMetric[]
 
 export type WalletMetric = {
@@ -500,6 +596,7 @@ export type WalletMetric = {
 }
 
 export type WalletMetricsParams = MetricsParams
+export type WalletMetricsPayload = void
 export type WalletMetricsResponse = WalletMetric[]
 
 // export type PerformanceMetric = {

--- a/libs/renterd-types/src/worker.ts
+++ b/libs/renterd-types/src/worker.ts
@@ -1,9 +1,15 @@
 import { HostSettings } from './types'
 import { BusStateResponse } from './bus'
 
+export const workerStateRoute = '/worker/state'
+export const workerObjectsKeyRoute = '/worker/objects/:key'
+export const workerMultipartKeyRoute = '/worker/multipart/:key'
+export const workerRhpScanRoute = '/worker/rhp/scan'
+
 // state
 
 export type WorkerStateParams = void
+export type WorkerStatePayload = void
 export type WorkerStateResponse = BusStateResponse & {
   id: string
 }


### PR DESCRIPTION
This PR moves all renterd API route strings to shared constants that can be used across libraries. This makes updating all libraries at once easier and also avoids small string typos.

These strings are used for API routes and also data revalidation in react mutations and hooks.
