### PR TITLE
refactor: peer dependencies

### DIFF
--- a/.changeset/nervous-timers-float.md
+++ b/.changeset/nervous-timers-float.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/design-system': minor
+'@siafoundation/fonts': minor
+'@siafoundation/react-core': minor
+---
+
+Peer dependencies now limited to react and next.

--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -4,13 +4,15 @@
   "version": "4.0.0",
   "license": "MIT",
   "peerDependencies": {
+    "react": "^18.2.0"
+  },
+  "dependencies": {
     "@siafoundation/react-icons": "^0.2.3",
     "@siafoundation/react-core": "^1.1.0",
     "@siafoundation/units": "^3.0.0",
     "@siafoundation/types": "^0.2.0",
     "@siafoundation/next": "^0.1.3",
     "@siafoundation/sia-central-react": "^3.0.0",
-    "react": "^18.2.0",
     "swr": "^2.1.1",
     "class-variance-authority": "^0.7.0",
     "bignumber.js": "^9.0.2",
@@ -22,9 +24,7 @@
     "tailwindcss-text-fill": "^0.2.0",
     "tailwindcss-shadow-fill": "^1.0.1",
     "@tailwindcss/container-queries": "^0.1.1",
-    "@technically/lodash": "^4.17.0"
-  },
-  "dependencies": {
+    "@technically/lodash": "^4.17.0",
     "@visx/group": "2.17.0",
     "@visx/react-spring": "2.18.0",
     "@visx/glyph": "2.17.0",

--- a/libs/fonts/package.json
+++ b/libs/fonts/package.json
@@ -4,8 +4,10 @@
   "version": "0.4.1",
   "license": "MIT",
   "peerDependencies": {
-    "class-variance-authority": "^0.7.0",
     "next": "^14.0.4"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0"
   },
   "types": "./src/index.d.ts"
 }


### PR DESCRIPTION
Moves everything besides `react` and `next` out of peer dependencies. This makes consuming the libraries a bit easier when using other package managers like `yarn` that require manually installing peers. 