### PR TITLE
feat: renterd min protocol version

### DIFF
--- a/.changeset/large-buckets-talk.md
+++ b/.changeset/large-buckets-talk.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The configuration now includes the min protocol version option, the value defaults to 1.6.0 when using simple configuration mode. Closes https://github.com/SiaFoundation/renterd/issues/1141 Closes https://github.com/SiaFoundation/web/issues/573

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -290,6 +290,32 @@ export function getFields({
             }
           : {},
     },
+    minProtocolVersion: {
+      type: 'text',
+      category: 'hosts',
+      title: 'Min protocol version',
+      description: (
+        <>
+          The minimum protocol version that autopilot will consider when forming
+          contracts with hosts.
+        </>
+      ),
+      suggestion: advancedDefaults?.minProtocolVersion,
+      suggestionTip: `Defaults to ${advancedDefaults?.minProtocolVersion}.`,
+      hidden: !isAutopilotEnabled || !showAdvanced,
+      validation:
+        isAutopilotEnabled && showAdvanced
+          ? {
+              required: 'required',
+              validate: {
+                version: (value: string) => {
+                  const regex = /^\d+\.\d+\.\d+$/
+                  return regex.test(value) || 'must be a valid version number'
+                },
+              },
+            }
+          : {},
+    },
 
     // contract
     defaultContractSet: {

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -28,6 +28,7 @@ describe('tansforms', () => {
               maxDowntimeHours: 1440,
               minRecentScanFailures: 10,
               scoreOverrides: null,
+              minProtocolVersion: null,
             },
             contracts: {
               set: 'autopilot',
@@ -73,6 +74,7 @@ describe('tansforms', () => {
         allowRedundantIPs: false,
         maxDowntimeHours: new BigNumber('1440'),
         minRecentScanFailures: new BigNumber('10'),
+        minProtocolVersion: '',
         defaultContractSet: 'myset',
         uploadPackingEnabled: true,
         hostBlockHeightLeeway: new BigNumber(4),
@@ -178,6 +180,7 @@ describe('tansforms', () => {
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
+            minProtocolVersion: '',
           },
           undefined
         )
@@ -187,6 +190,7 @@ describe('tansforms', () => {
           maxDowntimeHours: 1440,
           minRecentScanFailures: 10,
           scoreOverrides: null,
+          minProtocolVersion: '1.6.0',
         },
         contracts: {
           set: 'autopilot',
@@ -218,6 +222,7 @@ describe('tansforms', () => {
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
+            minProtocolVersion: '1.7.0',
           },
           {
             foobar1: 'value',
@@ -239,6 +244,7 @@ describe('tansforms', () => {
           maxDowntimeHours: 1440,
           minRecentScanFailures: 10,
           scoreOverrides: null,
+          minProtocolVersion: '1.7.0',
         },
         contracts: {
           foobar: 'value',
@@ -271,6 +277,7 @@ describe('tansforms', () => {
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
+            minProtocolVersion: '1.7.0',
           },
           {
             contracts: {
@@ -286,6 +293,7 @@ describe('tansforms', () => {
           maxDowntimeHours: 1440,
           minRecentScanFailures: 10,
           scoreOverrides: null,
+          minProtocolVersion: '1.7.0',
         },
         contracts: {
           set: 'autopilot',
@@ -335,6 +343,7 @@ describe('tansforms', () => {
             allowRedundantIPs: false,
             maxDowntimeHours: new BigNumber('1440'),
             minRecentScanFailures: new BigNumber('10'),
+            minProtocolVersion: '1.7.0',
             defaultContractSet: 'myset',
             uploadPackingEnabled: false,
             hostBlockHeightLeeway: new BigNumber(4),
@@ -487,6 +496,7 @@ function buildAllResponses() {
         maxDowntimeHours: 1440,
         minRecentScanFailures: 10,
         scoreOverrides: null,
+        minProtocolVersion: '1.7.0',
       },
       contracts: {
         set: 'autopilot',

--- a/apps/renterd/contexts/config/transform.ts
+++ b/apps/renterd/contexts/config/transform.ts
@@ -91,6 +91,7 @@ export function transformUpAutopilot(
       minRecentScanFailures: v.minRecentScanFailures.toNumber(),
       allowRedundantIPs: v.allowRedundantIPs,
       scoreOverrides: existingValues?.hosts.scoreOverrides || null,
+      minProtocolVersion: v.minProtocolVersion,
     },
   }
 }
@@ -219,6 +220,7 @@ export function transformDownAutopilot(
     allowRedundantIPs: config.hosts.allowRedundantIPs,
     maxDowntimeHours: new BigNumber(config.hosts.maxDowntimeHours),
     minRecentScanFailures: new BigNumber(config.hosts.minRecentScanFailures),
+    minProtocolVersion: config.hosts.minProtocolVersion || '',
   }
 }
 

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -18,6 +18,7 @@ export const defaultAutopilot = {
   allowRedundantIPs: false,
   maxDowntimeHours: undefined as BigNumber | undefined,
   minRecentScanFailures: undefined as BigNumber | undefined,
+  minProtocolVersion: '',
 }
 
 export const defaultContractSet = {
@@ -87,6 +88,7 @@ export function getAdvancedDefaultAutopilot(
           allowRedundantIPs: false,
           maxDowntimeHours: new BigNumber(336),
           minRecentScanFailures: new BigNumber(10),
+          minProtocolVersion: '1.6.0',
           prune: true,
         }
       : {
@@ -97,6 +99,7 @@ export function getAdvancedDefaultAutopilot(
           allowRedundantIPs: false,
           maxDowntimeHours: new BigNumber(336),
           minRecentScanFailures: new BigNumber(10),
+          minProtocolVersion: '1.6.0',
           prune: true,
         }),
   }

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -211,6 +211,7 @@ export type AutopilotHostsConfig = {
   scoreOverrides: { [key: PublicKey]: number }
   maxDowntimeHours: number
   minRecentScanFailures: number
+  minProtocolVersion: string
 }
 
 export type AutopilotContractsConfig = {


### PR DESCRIPTION
- The configuration now includes the min protocol version option.
- The value is automatically set to 1.6.0 for new users when using the simple configuration mode.
- Input field validates that value is a version string with 3 numeric segments, eg 1.6.11.

<img width="1148" alt="Screenshot 2024-04-15 at 3 07 09 PM" src="https://github.com/SiaFoundation/web/assets/1412796/e16d2459-86aa-4dd0-9dc3-239fd6d14d7a">
