### PR TITLE
fix: renterd-js objectUpload support more data types

### DIFF
--- a/.changeset/gentle-onions-report.md
+++ b/.changeset/gentle-onions-report.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/renterd-types': patch
+---
+
+Fixed an issue where objectUpload only supported the browser File data type. Closes https://github.com/SiaFoundation/web/issues/591

--- a/libs/renterd-types/src/worker.ts
+++ b/libs/renterd-types/src/worker.ts
@@ -19,7 +19,13 @@ export type ObjectDownloadPayload = void
 export type ObjectDownloadResponse = Blob
 
 export type ObjectUploadParams = { key: string; bucket: string }
-export type ObjectUploadPayload = File
+export type ObjectUploadPayload =
+  | File
+  | Blob
+  | Buffer
+  | ArrayBuffer
+  | string
+  | Record<string, unknown>
 export type ObjectUploadResponse = void
 
 export type MultipartUploadPartParams = {
@@ -32,7 +38,7 @@ export type MultipartUploadPartParams = {
   minshards?: number
   totalshards?: number
 }
-export type MultipartUploadPartPayload = Blob
+export type MultipartUploadPartPayload = Blob | Buffer | ArrayBuffer | string
 export type MultipartUploadPartResponse = void
 
 export type RhpScanParams = void


### PR DESCRIPTION
- `File` is only supported in browsers, widening these upload types to accept other data.