### PR TITLE
Use path instead of filepath for UI assets

### DIFF
--- a/hostd/hostd_test.go
+++ b/hostd/hostd_test.go
@@ -1,0 +1,30 @@
+package hostd
+
+import (
+	"io/fs"
+	"testing"
+
+	"go.sia.tech/web/internal/nextjs"
+)
+
+func TestRouter(t *testing.T) {
+	err := fs.WalkDir(assets, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(path)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assetFS, err := fs.Sub(assets, "assets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = nextjs.NewRouter(assetFS.(fs.ReadDirFS))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/nextjs/nextjs.go
+++ b/internal/nextjs/nextjs.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"net/http"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 )
@@ -114,9 +113,9 @@ func traverse(fs fs.ReadDirFS, fp string, segments []string, parent *node) error
 	}
 
 	for _, child := range dir {
-		childPath := filepath.Join(fp, child.Name())
+		childPath := path.Join(fp, child.Name())
 		name := child.Name()
-		ext := filepath.Ext(name)
+		ext := path.Ext(name)
 		name = strings.TrimSuffix(name, ext)
 
 		if !child.IsDir() && ext != ".html" {

--- a/renterd/renterd_test.go
+++ b/renterd/renterd_test.go
@@ -1,0 +1,30 @@
+package renterd
+
+import (
+	"io/fs"
+	"testing"
+
+	"go.sia.tech/web/internal/nextjs"
+)
+
+func TestRouter(t *testing.T) {
+	err := fs.WalkDir(assets, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(path)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assetFS, err := fs.Sub(assets, "assets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = nextjs.NewRouter(assetFS.(fs.ReadDirFS))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/walletd/walletd_test.go
+++ b/walletd/walletd_test.go
@@ -1,0 +1,30 @@
+package walletd
+
+import (
+	"io/fs"
+	"testing"
+
+	"go.sia.tech/web/internal/nextjs"
+)
+
+func TestRouter(t *testing.T) {
+	err := fs.WalkDir(assets, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(path)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assetFS, err := fs.Sub(assets, "assets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = nextjs.NewRouter(assetFS.(fs.ReadDirFS))
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Switches the nextjs Go router to use `path` instead of `filepath` to prevent issues on Windows. Also adds a few sanity tests to make sure the routers initialize correctly.