### PR TITLE
ci: speed up release workflow by 2x

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -13,7 +13,7 @@ env:
 concurrency: commits-to-main
 
 jobs:
-  release-main:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
@@ -25,15 +25,6 @@ jobs:
         with:
           node_version: 20.10.0
           go_version: 1.21.7
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Lint TypeScript
-        shell: bash
-        run: npx nx run-many --target=lint --all --parallel=5
       # The SDK is referenced via dist in the tsconfig.base.json
       # because the next executor does not actually support
       # buildLibsFromSource=false
@@ -42,32 +33,9 @@ jobs:
       - name: Force build SDK
         shell: bash
         run: npx nx run sdk:build
-      - name: Test TypeScript
-        shell: bash
-        run: npx nx run-many --target=test --all --parallel=5
-      - name: Install playwright deps for e2e
-        shell: bash
-        run: npx playwright install-deps
-      - name: Test e2e
-        shell: bash
-        run: npx nx run-many --target=e2e --all --parallel=5
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build for publishing
         shell: bash
         run: npx nx run-many --target=build --configuration=production --all --parallel=5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-      - name: Containers
-        shell: bash
-        run: npx nx run-many --target=container --configuration=production -all --parallel=5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
-      - name: Containers zen
-        shell: bash
-        run: npx nx run-many --target=container --configuration=production-testnet-zen -all --parallel=5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
@@ -104,10 +72,86 @@ jobs:
           token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}
           repository: siafoundation/web
           event-type: release-go
+  release-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout all commits
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup
+        uses: ./.github/actions/setup-all
+        with:
+          node_version: 20.10.0
+          go_version: 1.21.7
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # The SDK is referenced via dist in the tsconfig.base.json
+      # because the next executor does not actually support
+      # buildLibsFromSource=false
+      # With this configuration NX does not build the SDK as expected
+      # when it is an app dependency
+      - name: Force build SDK
+        shell: bash
+        run: npx nx run sdk:build
+      - name: Containers
+        shell: bash
+        run: npx nx run-many --target=container --configuration=production -all --parallel=5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      - name: Containers zen
+        shell: bash
+        run: npx nx run-many --target=container --configuration=production-testnet-zen -all --parallel=5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
   # This job should always pass because the workflow is running run against code that
   # was already linted and tested in PR.
   # This runs in parallel to the build and release process as an extra check but does
-  # not actually block the release if the Go tests fail.
+  # not actually block the release if job fails.
+  test-js:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout all commits
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup
+        uses: ./.github/actions/setup-all
+        with:
+          node_version: 20.10.0
+          go_version: 1.21.7
+      - name: Lint TypeScript
+        shell: bash
+        run: npx nx run-many --target=lint --all --parallel=5
+      # The SDK is referenced via dist in the tsconfig.base.json
+      # because the next executor does not actually support
+      # buildLibsFromSource=false
+      # With this configuration NX does not build the SDK as expected
+      # when it is an app dependency
+      - name: Force build SDK
+        shell: bash
+        run: npx nx run sdk:build
+      - name: Test TypeScript
+        shell: bash
+        run: npx nx run-many --target=test --all --parallel=5
+      - name: Install playwright deps for e2e
+        shell: bash
+        run: npx playwright install-deps
+      - name: Test e2e
+        shell: bash
+        run: npx nx run-many --target=e2e --all --parallel=5
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  # This job should always pass because the workflow is running run against code that
+  # was already linted and tested in PR.
+  # This runs in parallel to the build and release process as an extra check but does
+  # not actually block the release if job fails.
   test-go:
     # Run matrix since Go modules are used across all platforms
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- 8 min - Moves JS linting, testing, e2e testing out to a parallel job
- 3 min - Moves docker container build and publish out to a parallel job