### PR TITLE
fix: hostd volume resize and delete dialogs

### DIFF
--- a/.changeset/smart-papayas-do.md
+++ b/.changeset/smart-papayas-do.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+Fixed an issue where volume resize and delete dialogs were not loading the volumes data. Closes https://github.com/SiaFoundation/hostd/issues/371

--- a/apps/hostd/contexts/dialog.tsx
+++ b/apps/hostd/contexts/dialog.tsx
@@ -129,7 +129,7 @@ export function Dialogs() {
         open={dialog === 'addressDetails'}
         address={wallet.data?.address}
         isValidating={wallet.isValidating}
-        onOpenChange={(val) => (val ? openDialog(dialog) : closeDialog())}
+        onOpenChange={onOpenChange}
       />
       <HostdTransactionDetailsDialog />
       <SyncerConnectPeerDialog
@@ -141,23 +141,23 @@ export function Dialogs() {
           })
         }
         open={dialog === 'connectPeer'}
-        onOpenChange={(val) => (val ? openDialog(dialog) : closeDialog())}
+        onOpenChange={onOpenChange}
       />
       <VolumeCreateDialog
         open={dialog === 'volumeCreate'}
-        onOpenChange={(val) => (val ? openDialog(dialog) : closeDialog())}
+        onOpenChange={onOpenChange}
       />
       <VolumeResizeDialog
         open={dialog === 'volumeResize'}
-        onOpenChange={(val) => (val ? openDialog(dialog) : closeDialog())}
+        onOpenChange={onOpenChange}
       />
       <VolumeDeleteDialog
         open={dialog === 'volumeDelete'}
-        onOpenChange={(val) => (val ? openDialog(dialog) : closeDialog())}
+        onOpenChange={onOpenChange}
       />
       <ContractsFilterContractIdDialog
         open={dialog === 'contractsFilterContractId'}
-        onOpenChange={(val) => (val ? openDialog(dialog) : closeDialog())}
+        onOpenChange={onOpenChange}
       />
       <ConfirmDialog
         open={dialog === 'confirm'}


### PR DESCRIPTION
- Fixed an issue where volume resize and delete dialogs were not loading the volumes data.
- Updated volume resize dialog to used shared helpers for consistency.


**Explanation**
- Recently fixed an issue where dialogs were not triggering onOpenChange(true) when initially opening, this combined with an incorrect handler that previously never was called caused the `id` passed to volume dialogs to get wiped out.