### PR TITLE
fix: walletd pending transaction sc amount

### DIFF
--- a/.changeset/tender-plants-live.md
+++ b/.changeset/tender-plants-live.md
@@ -1,0 +1,5 @@
+---
+'walletd': patch
+---
+
+Unconfirmed transactions rows now show their siacoin amount and fees. Closes https://github.com/SiaFoundation/walletd/issues/123

--- a/apps/walletd/contexts/events/index.tsx
+++ b/apps/walletd/contexts/events/index.tsx
@@ -58,14 +58,18 @@ export function useEventsMain() {
     if (!responseEvents.data || !responseTxPool.data) {
       return null
     }
-    const dataTxPool: EventData[] = responseTxPool.data.map((e) => ({
-      id: e.id,
-      timestamp: 0,
-      pending: true,
-      type: e.type,
-      isMature: false,
-      amount: new BigNumber(e.received).minus(e.sent),
-    }))
+    const dataTxPool: EventData[] = responseTxPool.data.map((e) => {
+      const event: EventData = {
+        id: e.id,
+        timestamp: 0,
+        pending: true,
+        type: e.type,
+        isMature: false,
+        amountSc: new BigNumber(e.received).minus(e.sent),
+        fee: e.raw.minerFees[0] ? new BigNumber(e.raw.minerFees[0]) : undefined,
+      }
+      return event
+    })
     const dataEvents: EventData[] = responseEvents.data.map((e, index) => {
       let amountSc = new BigNumber(0)
       let amountSf = 0


### PR DESCRIPTION
- Unconfirmed transactions rows now show their siacoin amount and fees.

<img width="1164" alt="Screenshot 2024-05-17 at 6 26 59 PM" src="https://github.com/SiaFoundation/web/assets/1412796/821394d8-8f36-4cc8-9b9a-956aca123d0c">
