### PR TITLE
fix: renterd and hostd refine config

### DIFF
--- a/.changeset/breezy-knives-cover.md
+++ b/.changeset/breezy-knives-cover.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Allowance now has a field-specific option to auto-calculate its value. Closes https://github.com/SiaFoundation/web/issues/628

--- a/.changeset/brown-wolves-chew.md
+++ b/.changeset/brown-wolves-chew.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where first-time configuration would not show the optimal recommendations.

--- a/.changeset/chilly-mugs-exercise.md
+++ b/.changeset/chilly-mugs-exercise.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed a bug where the churn alert would display NaN for the percentage when the total size was zero.

--- a/.changeset/lemon-timers-turn.md
+++ b/.changeset/lemon-timers-turn.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Fields now have better support and styling for readOnly.

--- a/.changeset/popular-timers-tan.md
+++ b/.changeset/popular-timers-tan.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where toggling between basic and advanced modes would sometimes not revalidate all configuration fields.

--- a/.changeset/rich-houses-exist.md
+++ b/.changeset/rich-houses-exist.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Max collateral now has a field-specific option to auto-calculate its value. Closes https://github.com/SiaFoundation/web/issues/628

--- a/.changeset/thirty-peaches-switch.md
+++ b/.changeset/thirty-peaches-switch.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+The configuration page now has a view menu in the action bar that is consistent with all other feature pages.

--- a/.changeset/weak-cherries-press.md
+++ b/.changeset/weak-cherries-press.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+Basic configuration mode no longer sets certain fields in the background. Closes https://github.com/SiaFoundation/web/issues/628

--- a/apps/hostd/components/CmdRoot/ConfigCmdGroup.tsx
+++ b/apps/hostd/components/CmdRoot/ConfigCmdGroup.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 export function ConfigCmdGroup({ currentPage, parentPage, pushPage }: Props) {
   const router = useRouter()
-  const { showAdvanced } = useConfig()
+  const { configViewMode } = useConfig()
   const { closeDialog } = useDialog()
   return (
     <CommandGroup currentPage={currentPage} commandPage={commandPage}>
@@ -82,7 +82,7 @@ export function ConfigCmdGroup({ currentPage, parentPage, pushPage }: Props) {
       >
         Configure bandwidth
       </CommandItemSearch>
-      {showAdvanced && (
+      {configViewMode === 'advanced' && (
         <>
           <CommandItemSearch
             currentPage={currentPage}

--- a/apps/hostd/components/Config/ConfigActions.tsx
+++ b/apps/hostd/components/Config/ConfigActions.tsx
@@ -3,6 +3,7 @@ import { Reset16, Save16 } from '@siafoundation/react-icons'
 import { AnnounceButton } from './AnnounceButton'
 import { useConfig } from '../../contexts/config'
 import { ConfigContextMenu } from './ConfigContextMenu'
+import { ConfigViewDropdownMenu } from './ConfigViewDropdownMenu'
 
 export function ConfigActions() {
   const { changeCount, revalidateAndResetForm, form, onSubmit } = useConfig()
@@ -32,6 +33,7 @@ export function ConfigActions() {
       </Button>
       <AnnounceButton />
       <ConfigContextMenu />
+      <ConfigViewDropdownMenu />
     </div>
   )
 }

--- a/apps/hostd/components/Config/ConfigNav.tsx
+++ b/apps/hostd/components/Config/ConfigNav.tsx
@@ -1,22 +1,3 @@
-import { Text, Switch, Tooltip } from '@siafoundation/design-system'
-import { useConfig } from '../../contexts/config'
-
 export function ConfigNav() {
-  const { showAdvanced, setShowAdvanced } = useConfig()
-
-  return (
-    <div className="pl-1">
-      <Tooltip content={showAdvanced ? 'Hide advanced' : 'Show advanced'}>
-        <div className="flex gap-1 items-center">
-          <Switch
-            checked={showAdvanced}
-            onCheckedChange={(checked) => setShowAdvanced(checked)}
-          />
-          <Text size="12" color="subtle">
-            Advanced
-          </Text>
-        </div>
-      </Tooltip>
-    </div>
-  )
+  return <div className="pl-1"></div>
 }

--- a/apps/hostd/components/Config/ConfigViewDropdownMenu.tsx
+++ b/apps/hostd/components/Config/ConfigViewDropdownMenu.tsx
@@ -1,0 +1,34 @@
+import {
+  Button,
+  Label,
+  Popover,
+  MenuItemRightSlot,
+  BaseMenuItem,
+} from '@siafoundation/design-system'
+import { CaretDown16, SettingsAdjust16 } from '@siafoundation/react-icons'
+import { ViewModeToggle } from './ViewModeToggle'
+
+export function ConfigViewDropdownMenu() {
+  return (
+    <Popover
+      trigger={
+        <Button size="small" tip="Configure view" tipAlign="end">
+          <SettingsAdjust16 />
+          View
+          <CaretDown16 />
+        </Button>
+      }
+      contentProps={{
+        align: 'end',
+        className: 'max-w-[300px]',
+      }}
+    >
+      <BaseMenuItem>
+        <Label>Show advanced settings</Label>
+        <MenuItemRightSlot>
+          <ViewModeToggle />
+        </MenuItemRightSlot>
+      </BaseMenuItem>
+    </Popover>
+  )
+}

--- a/apps/hostd/components/Config/ViewModeToggle.tsx
+++ b/apps/hostd/components/Config/ViewModeToggle.tsx
@@ -1,0 +1,28 @@
+import { Switch, Tooltip } from '@siafoundation/design-system'
+import { useConfig } from '../../contexts/config'
+
+export function ViewModeToggle() {
+  const { configViewMode, setConfigViewMode } = useConfig()
+
+  return (
+    <div className="pl-1">
+      <Tooltip
+        content={
+          configViewMode === 'advanced'
+            ? 'Show advanced settings'
+            : 'Hide advanced settings'
+        }
+      >
+        <div>
+          <Switch
+            aria-label="configViewMode"
+            checked={configViewMode === 'advanced'}
+            onCheckedChange={(checked) =>
+              setConfigViewMode(checked ? 'advanced' : 'basic')
+            }
+          />
+        </div>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/hostd/components/Config/index.tsx
+++ b/apps/hostd/components/Config/index.tsx
@@ -10,6 +10,8 @@ import {
   FieldError,
   ConfigurationPanelSetting,
   shouldShowField,
+  Tooltip,
+  Switch,
 } from '@siafoundation/design-system'
 import { Warning16, CheckmarkFilled16 } from '@siafoundation/react-icons'
 import { HostdSidenav } from '../HostdSidenav'
@@ -23,8 +25,16 @@ import { ConfigActions } from './ConfigActions'
 
 export function Config() {
   const { openDialog } = useDialog()
-  const { fields, settings, dynDNSCheck, form, remoteError, configRef } =
-    useConfig()
+  const {
+    fields,
+    settings,
+    dynDNSCheck,
+    form,
+    remoteError,
+    configRef,
+    autoMaxCollateral,
+    setAutoMaxCollateral,
+  } = useConfig()
   const shouldPinStoragePrice = form.watch('shouldPinStoragePrice')
   const shouldPinEgressPrice = form.watch('shouldPinEgressPrice')
   const shouldPinIngressPrice = form.watch('shouldPinIngressPrice')
@@ -104,29 +114,23 @@ export function Config() {
                     fields,
                     name: 'shouldPinStoragePrice',
                   }) && (
-                    <div className="flex w-full justify-between">
-                      <Text weight="medium" color="verySubtle" size="14">
-                        Storage price
-                      </Text>
-                      <FieldSwitch
-                        name="shouldPinStoragePrice"
-                        form={form}
-                        fields={fields}
-                        size="small"
-                        group={false}
-                        before={
-                          <Text
-                            weight="medium"
-                            color={
-                              shouldPinStoragePrice ? 'contrast' : 'subtle'
-                            }
-                            size="14"
-                          >
-                            pinned
-                          </Text>
-                        }
-                      />
-                    </div>
+                    <Tooltip
+                      align="end"
+                      content="Pin the value to a fixed fiat amount. The daemon will automatically keep the value in sync."
+                    >
+                      <div className="flex w-full justify-between">
+                        <Text weight="medium" color="verySubtle" size="14">
+                          Pin
+                        </Text>
+                        <FieldSwitch
+                          name="shouldPinStoragePrice"
+                          form={form}
+                          fields={fields}
+                          size="small"
+                          group={false}
+                        />
+                      </div>
+                    </Tooltip>
                   )}
                   {shouldShowField({
                     form,
@@ -169,27 +173,23 @@ export function Config() {
                     fields,
                     name: 'shouldPinEgressPrice',
                   }) && (
-                    <div className="flex w-full justify-between">
-                      <Text weight="medium" color="verySubtle" size="14">
-                        Egress price
-                      </Text>
-                      <FieldSwitch
-                        name="shouldPinEgressPrice"
-                        form={form}
-                        fields={fields}
-                        size="small"
-                        group={false}
-                        before={
-                          <Text
-                            weight="medium"
-                            color={shouldPinEgressPrice ? 'contrast' : 'subtle'}
-                            size="14"
-                          >
-                            pinned
-                          </Text>
-                        }
-                      />
-                    </div>
+                    <Tooltip
+                      align="end"
+                      content="Pin the value to a fixed fiat amount. The daemon will automatically keep the value in sync."
+                    >
+                      <div className="flex w-full justify-between">
+                        <Text weight="medium" color="verySubtle" size="14">
+                          Pin
+                        </Text>
+                        <FieldSwitch
+                          name="shouldPinEgressPrice"
+                          form={form}
+                          fields={fields}
+                          size="small"
+                          group={false}
+                        />
+                      </div>
+                    </Tooltip>
                   )}
                   {shouldShowField({
                     form,
@@ -232,29 +232,23 @@ export function Config() {
                     fields,
                     name: 'shouldPinIngressPrice',
                   }) && (
-                    <div className="flex w-full justify-between">
-                      <Text weight="medium" color="verySubtle" size="14">
-                        Ingress price
-                      </Text>
-                      <FieldSwitch
-                        name="shouldPinIngressPrice"
-                        form={form}
-                        fields={fields}
-                        size="small"
-                        group={false}
-                        before={
-                          <Text
-                            weight="medium"
-                            color={
-                              shouldPinIngressPrice ? 'contrast' : 'subtle'
-                            }
-                            size="14"
-                          >
-                            pinned
-                          </Text>
-                        }
-                      />
-                    </div>
+                    <Tooltip
+                      align="end"
+                      content="Pin the value to a fixed fiat amount. The daemon will automatically keep the value in sync."
+                    >
+                      <div className="flex w-full justify-between">
+                        <Text weight="medium" color="verySubtle" size="14">
+                          Pin
+                        </Text>
+                        <FieldSwitch
+                          name="shouldPinIngressPrice"
+                          form={form}
+                          fields={fields}
+                          size="small"
+                          group={false}
+                        />
+                      </div>
+                    </Tooltip>
                   )}
                   {shouldShowField({
                     form,
@@ -309,29 +303,41 @@ export function Config() {
                         fields,
                         name: 'shouldPinMaxCollateral',
                       }) && (
-                        <div className="flex w-full justify-between">
-                          <Text weight="medium" color="verySubtle" size="14">
-                            Max collateral
-                          </Text>
-                          <FieldSwitch
-                            name="shouldPinMaxCollateral"
-                            form={form}
-                            fields={fields}
-                            size="small"
-                            group={false}
-                            before={
-                              <Text
-                                weight="medium"
-                                color={
-                                  shouldPinMaxCollateral ? 'contrast' : 'subtle'
-                                }
-                                size="14"
-                              >
-                                pinned
-                              </Text>
-                            }
-                          />
-                        </div>
+                        <Tooltip
+                          align="end"
+                          content="Pin the value to a fixed fiat amount. The daemon will automatically keep the value in sync."
+                        >
+                          <div className="flex w-full justify-between">
+                            <Text weight="medium" color="verySubtle" size="14">
+                              Pin
+                            </Text>
+                            <FieldSwitch
+                              name="shouldPinMaxCollateral"
+                              form={form}
+                              fields={fields}
+                              size="small"
+                              group={false}
+                            />
+                          </div>
+                        </Tooltip>
+                      )}
+                      {!shouldPinMaxCollateral && (
+                        <Tooltip
+                          align="end"
+                          content="Calculate value based on storage price and collateral multiplier."
+                        >
+                          <div className="flex w-full justify-between">
+                            <Text weight="medium" color="verySubtle" size="14">
+                              Calculate
+                            </Text>
+                            <Switch
+                              aria-label="autoMaxCollateral"
+                              size="small"
+                              checked={autoMaxCollateral}
+                              onCheckedChange={setAutoMaxCollateral}
+                            />
+                          </div>
+                        </Tooltip>
                       )}
                       {shouldShowField({
                         form,
@@ -361,6 +367,20 @@ export function Config() {
                       )}
                     </div>
                   }
+                />
+              </>
+            )}
+            {shouldShowField({
+              form,
+              fields,
+              name: 'contractPrice',
+            }) && (
+              <>
+                <Separator className="w-full my-3" />
+                <ConfigurationPanelSetting
+                  form={form}
+                  fields={fields}
+                  name="contractPrice"
                 />
               </>
             )}

--- a/apps/hostd/contexts/config/index.tsx
+++ b/apps/hostd/contexts/config/index.tsx
@@ -22,7 +22,14 @@ import { useStateHost } from '@siafoundation/hostd-react'
 export function useConfigMain() {
   const { settings, settingsPinned, dynDNSCheck } = useResources()
 
-  const { form, fields, setShowAdvanced, showAdvanced } = useForm()
+  const {
+    form,
+    fields,
+    configViewMode,
+    setConfigViewMode,
+    autoMaxCollateral,
+    setAutoMaxCollateral,
+  } = useForm()
 
   // Resources required to intialize form.
   const resources: Resources = useMemo(
@@ -85,7 +92,6 @@ export function useConfigMain() {
 
   const onValid = useOnValid({
     resources,
-    showAdvanced,
     revalidateAndResetForm,
   })
 
@@ -117,12 +123,14 @@ export function useConfigMain() {
     revalidateAndResetForm,
     form,
     onSubmit,
-    showAdvanced,
-    setShowAdvanced,
+    setConfigViewMode,
+    configViewMode,
     remoteError,
     takeScreenshot,
     configRef,
     pinningEnabled,
+    autoMaxCollateral,
+    setAutoMaxCollateral,
   }
 }
 

--- a/apps/hostd/contexts/config/transform.ts
+++ b/apps/hostd/contexts/config/transform.ts
@@ -127,6 +127,25 @@ export function transformUpSettings(
   }
 }
 
+export function getCalculatedValues({
+  storagePrice,
+  collateralMultiplier,
+  autoMaxCollateral,
+}: {
+  storagePrice: BigNumber
+  collateralMultiplier: BigNumber
+  autoMaxCollateral: boolean
+}) {
+  const calculatedValues: Partial<SettingsData> = {}
+  if (autoMaxCollateral && storagePrice && collateralMultiplier) {
+    calculatedValues.maxCollateral = calculateMaxCollateral(
+      storagePrice,
+      collateralMultiplier
+    )
+  }
+  return calculatedValues
+}
+
 export function transformUpSettingsPinned(
   values: SettingsData,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/hostd/contexts/config/types.ts
+++ b/apps/hostd/contexts/config/types.ts
@@ -2,6 +2,8 @@ import { DNSProvider } from '@siafoundation/hostd-types'
 import { SiaCentralCurrency } from '@siafoundation/sia-central-types'
 import BigNumber from 'bignumber.js'
 
+export type ConfigViewMode = 'basic' | 'advanced'
+
 export const scDecimalPlaces = 6
 export const dnsProviderOptions: { value: DNSProvider; label: string }[] = [
   {

--- a/apps/hostd/contexts/config/useAutoCalculatedFields.tsx
+++ b/apps/hostd/contexts/config/useAutoCalculatedFields.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useMemo } from 'react'
+import { SettingsData } from './types'
+import { UseFormReturn } from 'react-hook-form'
+import useLocalStorageState from 'use-local-storage-state'
+import { getCalculatedValues } from './transform'
+import BigNumber from 'bignumber.js'
+
+export function useAutoCalculatedFields({
+  form,
+  storagePrice,
+  collateralMultiplier,
+}: {
+  form: UseFormReturn<SettingsData>
+  storagePrice: BigNumber
+  collateralMultiplier: BigNumber
+}) {
+  const [autoMaxCollateral, setAutoMaxCollateral] =
+    useLocalStorageState<boolean>('v0/config/auto/maxCollateral', {
+      defaultValue: true,
+    })
+
+  // Sync calculated values if applicable.
+  const calculatedValues = useMemo(
+    () =>
+      getCalculatedValues({
+        storagePrice,
+        collateralMultiplier,
+        autoMaxCollateral,
+      }),
+    [storagePrice, collateralMultiplier, autoMaxCollateral]
+  )
+
+  useEffect(() => {
+    for (const [key, value] of Object.entries(calculatedValues)) {
+      form.setValue(key as keyof SettingsData, value, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      })
+    }
+  }, [form, calculatedValues])
+
+  return {
+    autoMaxCollateral,
+    setAutoMaxCollateral,
+  }
+}

--- a/apps/hostd/contexts/config/useOnValid.tsx
+++ b/apps/hostd/contexts/config/useOnValid.tsx
@@ -5,11 +5,7 @@ import {
 } from '@siafoundation/design-system'
 import { useCallback } from 'react'
 import { SettingsData } from './types'
-import {
-  calculateMaxCollateral,
-  transformUpSettings,
-  transformUpSettingsPinned,
-} from './transform'
+import { transformUpSettings, transformUpSettingsPinned } from './transform'
 import { Resources } from './resources'
 import {
   useSettingsPinnedUpdate,
@@ -19,11 +15,9 @@ import {
 
 export function useOnValid({
   resources,
-  showAdvanced,
   revalidateAndResetForm,
 }: {
   resources: Resources
-  showAdvanced: boolean
   revalidateAndResetForm: () => Promise<void>
 }) {
   const state = useStateHost()
@@ -42,21 +36,10 @@ export function useOnValid({
         return
       }
       try {
-        const calculatedValues: Partial<SettingsData> = {}
-        if (!showAdvanced) {
-          calculatedValues.maxCollateral = calculateMaxCollateral(
-            values.storagePrice,
-            values.collateralMultiplier
-          )
-        }
-
-        const finalValues = {
-          ...values,
-          ...calculatedValues,
-        }
+        const payload = transformUpSettings(values, resources.settings.data)
 
         const settings = await settingsUpdate.patch({
-          payload: transformUpSettings(finalValues, resources.settings.data),
+          payload,
         })
 
         if (settings.error) {
@@ -66,7 +49,7 @@ export function useOnValid({
         if (state.data?.explorer.enabled) {
           const settingsPinned = await settingsPinnedUpdate.put({
             payload: transformUpSettingsPinned(
-              finalValues,
+              values,
               resources.settingsPinned.data
             ),
           })
@@ -99,7 +82,6 @@ export function useOnValid({
       }
     },
     [
-      showAdvanced,
       resources,
       settingsUpdate,
       settingsPinnedUpdate,

--- a/apps/renterd/components/CmdRoot/ConfigCmdGroup.tsx
+++ b/apps/renterd/components/CmdRoot/ConfigCmdGroup.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export function ConfigCmdGroup({ currentPage, parentPage, pushPage }: Props) {
   const router = useRouter()
-  const { showAdvanced } = useConfig()
+  const { configViewMode } = useConfig()
   const { closeDialog } = useDialog()
   const { autopilot } = useApp()
   return (
@@ -66,7 +66,7 @@ export function ConfigCmdGroup({ currentPage, parentPage, pushPage }: Props) {
       >
         Configure pricing
       </CommandItemSearch>
-      {showAdvanced && (
+      {configViewMode === 'advanced' && (
         <>
           {autopilot.status === 'on' && (
             <>

--- a/apps/renterd/components/Config/ConfigActions.tsx
+++ b/apps/renterd/components/Config/ConfigActions.tsx
@@ -10,6 +10,7 @@ import {
 import { Reset16, Save16, Settings16 } from '@siafoundation/react-icons'
 import { useConfig } from '../../contexts/config'
 import { ConfigContextMenu } from './ConfigContextMenu'
+import { ConfigViewDropdownMenu } from './ConfigViewDropdownMenu'
 
 export function ConfigActions() {
   const {
@@ -74,6 +75,7 @@ export function ConfigActions() {
         </Popover>
       </ControlGroup>
       <ConfigContextMenu />
+      <ConfigViewDropdownMenu />
     </div>
   )
 }

--- a/apps/renterd/components/Config/ConfigNav.tsx
+++ b/apps/renterd/components/Config/ConfigNav.tsx
@@ -1,22 +1,3 @@
-import { Text, Switch, Tooltip } from '@siafoundation/design-system'
-import { useConfig } from '../../contexts/config'
-
 export function ConfigNav() {
-  const { showAdvanced, setShowAdvanced } = useConfig()
-
-  return (
-    <div className="pl-1">
-      <Tooltip content={showAdvanced ? 'Hide advanced' : 'Show advanced'}>
-        <div className="flex gap-1 items-center">
-          <Switch
-            checked={showAdvanced}
-            onCheckedChange={(checked) => setShowAdvanced(checked)}
-          />
-          <Text size="12" color="subtle">
-            Advanced
-          </Text>
-        </div>
-      </Tooltip>
-    </div>
-  )
+  return <div className="pl-1"></div>
 }

--- a/apps/renterd/components/Config/ConfigStats.tsx
+++ b/apps/renterd/components/Config/ConfigStats.tsx
@@ -11,7 +11,7 @@ import { useApp } from '../../contexts/app'
 
 export function ConfigStats() {
   const { autopilot } = useApp()
-  const { estimates, redundancyMultiplier, storageTB, showAdvanced } =
+  const { estimates, redundancyMultiplier, storageTB, configViewMode } =
     useConfig()
 
   const { canEstimate, estimatedSpendingPerMonth, estimatedSpendingPerTB } =
@@ -25,7 +25,7 @@ export function ConfigStats() {
 
   return !canEstimate ? (
     <Text size="12" font="mono" weight="medium">
-      {showAdvanced
+      {configViewMode === 'advanced'
         ? 'Enter expected storage, period, and allowance values to estimate monthly spending.'
         : 'Enter expected storage and max price to estimate monthly spending.'}
     </Text>

--- a/apps/renterd/components/Config/ConfigViewDropdownMenu.tsx
+++ b/apps/renterd/components/Config/ConfigViewDropdownMenu.tsx
@@ -1,0 +1,34 @@
+import {
+  Button,
+  Label,
+  Popover,
+  MenuItemRightSlot,
+  BaseMenuItem,
+} from '@siafoundation/design-system'
+import { CaretDown16, SettingsAdjust16 } from '@siafoundation/react-icons'
+import { ViewModeToggle } from './ViewModeToggle'
+
+export function ConfigViewDropdownMenu() {
+  return (
+    <Popover
+      trigger={
+        <Button size="small" tip="Configure view" tipAlign="end">
+          <SettingsAdjust16 />
+          View
+          <CaretDown16 />
+        </Button>
+      }
+      contentProps={{
+        align: 'end',
+        className: 'max-w-[300px]',
+      }}
+    >
+      <BaseMenuItem>
+        <Label>Show advanced settings</Label>
+        <MenuItemRightSlot>
+          <ViewModeToggle />
+        </MenuItemRightSlot>
+      </BaseMenuItem>
+    </Popover>
+  )
+}

--- a/apps/renterd/components/Config/Recommendations.tsx
+++ b/apps/renterd/components/Config/Recommendations.tsx
@@ -80,7 +80,7 @@ export function Recommendations() {
           {usableHostsCurrent} hosts
         </Text>
       </div>
-      {needsRecommendations && (
+      {needsRecommendations && foundRecommendation ? (
         <>
           <div className="flex justify-between items-center">
             <Text size="14" color="subtle">
@@ -91,25 +91,26 @@ export function Recommendations() {
             </Text>
           </div>
           <Separator className="w-full my-1" />
-          {foundRecommendation ? (
-            usableHostsAfterRecommendation < hostTarget50 ? (
-              <Text size="14" color="subtle">
-                The system found recommendations that would increase the number
-                of usable hosts from {usableHostsCurrent} to{' '}
-                {usableHostsAfterRecommendation} of the ideal {hostTarget50}.
-              </Text>
-            ) : (
-              <Text size="14" color="subtle">
-                Follow these recommendations to match with{' '}
-                {usableHostsAfterRecommendation} hosts.
-              </Text>
-            )
+          {usableHostsAfterRecommendation < hostTarget50 ? (
+            <Text size="14" color="subtle">
+              The system found recommendations that would increase the number of
+              usable hosts from {usableHostsCurrent} to{' '}
+              {usableHostsAfterRecommendation} of the ideal {hostTarget50}.
+            </Text>
           ) : (
             <Text size="14" color="subtle">
-              The system could not find recommendations that would increase the
-              usable host count.
+              Follow these recommendations to match with{' '}
+              {usableHostsAfterRecommendation} hosts.
             </Text>
           )}
+        </>
+      ) : (
+        <>
+          <Separator className="w-full my-1" />
+          <Text size="14" color="subtle">
+            The system could not find recommendations that would increase the
+            usable host count.
+          </Text>
         </>
       )}
     </div>

--- a/apps/renterd/components/Config/ViewModeToggle.tsx
+++ b/apps/renterd/components/Config/ViewModeToggle.tsx
@@ -1,0 +1,28 @@
+import { Switch, Tooltip } from '@siafoundation/design-system'
+import { useConfig } from '../../contexts/config'
+
+export function ViewModeToggle() {
+  const { configViewMode, setConfigViewMode } = useConfig()
+
+  return (
+    <div className="pl-1">
+      <Tooltip
+        content={
+          configViewMode === 'advanced'
+            ? 'Show advanced settings'
+            : 'Hide advanced settings'
+        }
+      >
+        <div>
+          <Switch
+            aria-label="configViewMode"
+            checked={configViewMode === 'advanced'}
+            onCheckedChange={(checked) =>
+              setConfigViewMode(checked ? 'advanced' : 'basic')
+            }
+          />
+        </div>
+      </Tooltip>
+    </div>
+  )
+}

--- a/apps/renterd/contexts/alerts/SetChange.tsx
+++ b/apps/renterd/contexts/alerts/SetChange.tsx
@@ -102,7 +102,7 @@ export function SetChangesField({
     [removals]
   )
   const churn = useMemo(
-    () => (removedSize / totalSize) * 100,
+    () => (totalSize > 0 ? (removedSize / totalSize) * 100 : 0),
     [removedSize, totalSize]
   )
 

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -96,8 +96,10 @@ export function useConfigMain() {
     evaluation,
     redundancyMultiplier,
     fields,
-    showAdvanced,
-    setShowAdvanced,
+    configViewMode,
+    setConfigViewMode,
+    autoAllowance,
+    setAutoAllowance,
   } = useForm({ resources })
 
   const remoteValues: SettingsData = useMemo(() => {
@@ -168,7 +170,6 @@ export function useConfigMain() {
   const onValid = useOnValid({
     resources,
     estimatedSpendingPerMonth: estimates.estimatedSpendingPerMonth,
-    showAdvanced,
     isAutopilotEnabled,
     revalidateAndResetForm,
   })
@@ -204,12 +205,14 @@ export function useConfigMain() {
     storageTB,
     shouldSyncDefaultContractSet,
     setShouldSyncDefaultContractSet,
-    showAdvanced,
-    setShowAdvanced,
+    configViewMode,
+    setConfigViewMode,
     remoteError,
     configRef,
     takeScreenshot,
     evaluation,
+    autoAllowance,
+    setAutoAllowance,
   }
 }
 

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -153,51 +153,31 @@ export function transformUp({
   resources,
   renterdState,
   isAutopilotEnabled,
-  showAdvanced,
-  estimatedSpendingPerMonth,
   values,
 }: {
   resources: Resources
   renterdState: BusStateResponse
   isAutopilotEnabled: boolean
-  showAdvanced: boolean
   estimatedSpendingPerMonth: BigNumber
   values: SettingsData
 }) {
-  const calculatedValues: Partial<SettingsData> = {}
-  if (isAutopilotEnabled && !showAdvanced) {
-    calculatedValues.allowanceMonth = estimatedSpendingPerMonth
-  }
-
-  const finalValues = {
-    ...values,
-    ...calculatedValues,
-  }
-
   const autopilot = isAutopilotEnabled
     ? transformUpAutopilot(
         renterdState.network,
-        finalValues,
+        values,
         resources.autopilot.data
       )
     : undefined
 
-  const contractSet = transformUpContractSet(
-    finalValues,
-    resources.contractSet.data
-  )
+  const contractSet = transformUpContractSet(values, resources.contractSet.data)
   const uploadPacking = transformUpUploadPacking(
-    finalValues,
+    values,
     resources.uploadPacking.data
   )
-  const gouging = transformUpGouging(finalValues, resources.gouging.data)
-  const redundancy = transformUpRedundancy(
-    finalValues,
-    resources.redundancy.data
-  )
+  const gouging = transformUpGouging(values, resources.gouging.data)
+  const redundancy = transformUpRedundancy(values, resources.redundancy.data)
 
   return {
-    finalValues,
     payloads: {
       autopilot,
       contractSet,
@@ -214,4 +194,20 @@ function filterUndefinedKeys(obj: Record<string, unknown>) {
       ([key, value]) => value !== undefined && value !== ''
     )
   )
+}
+
+export function getCalculatedValues({
+  estimatedSpendingPerMonth,
+  isAutopilotEnabled,
+  autoAllowance,
+}: {
+  estimatedSpendingPerMonth: BigNumber
+  isAutopilotEnabled: boolean
+  autoAllowance: boolean
+}) {
+  const calculatedValues: Partial<SettingsData> = {}
+  if (isAutopilotEnabled && autoAllowance && estimatedSpendingPerMonth?.gt(0)) {
+    calculatedValues.allowanceMonth = estimatedSpendingPerMonth
+  }
+  return calculatedValues
 }

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -1,5 +1,7 @@
 import BigNumber from 'bignumber.js'
 
+export type ConfigViewMode = 'basic' | 'advanced'
+
 export const scDecimalPlaces = 6
 
 // form defaults

--- a/apps/renterd/contexts/config/useAutoCalculatedFields.tsx
+++ b/apps/renterd/contexts/config/useAutoCalculatedFields.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useMemo } from 'react'
+import { SettingsData } from './types'
+import { UseFormReturn } from 'react-hook-form'
+import useLocalStorageState from 'use-local-storage-state'
+import { getCalculatedValues } from './transformUp'
+import BigNumber from 'bignumber.js'
+
+export function useAutoCalculatedFields({
+  form,
+  estimatedSpendingPerMonth,
+  isAutopilotEnabled,
+}: {
+  form: UseFormReturn<SettingsData>
+  estimatedSpendingPerMonth: BigNumber
+  isAutopilotEnabled: boolean
+}) {
+  const [autoAllowance, setAutoAllowance] = useLocalStorageState<boolean>(
+    'v0/config/auto/allowance',
+    {
+      defaultValue: true,
+    }
+  )
+
+  // Sync calculated values if applicable.
+  const calculatedValues = useMemo(
+    () =>
+      getCalculatedValues({
+        estimatedSpendingPerMonth,
+        isAutopilotEnabled,
+        autoAllowance,
+      }),
+    [estimatedSpendingPerMonth, isAutopilotEnabled, autoAllowance]
+  )
+
+  useEffect(() => {
+    for (const [key, value] of Object.entries(calculatedValues)) {
+      form.setValue(key as keyof SettingsData, value, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      })
+    }
+  }, [form, calculatedValues])
+
+  return {
+    autoAllowance,
+    setAutoAllowance,
+  }
+}

--- a/apps/renterd/contexts/config/useOnValid.tsx
+++ b/apps/renterd/contexts/config/useOnValid.tsx
@@ -21,20 +21,18 @@ export function useOnValid({
   resources,
   estimatedSpendingPerMonth,
   isAutopilotEnabled,
-  showAdvanced,
   revalidateAndResetForm,
 }: {
   resources: Resources
   estimatedSpendingPerMonth: BigNumber
   isAutopilotEnabled: boolean
-  showAdvanced: boolean
   revalidateAndResetForm: () => Promise<void>
 }) {
   const autopilotTrigger = useAutopilotTrigger()
   const autopilotUpdate = useAutopilotConfigUpdate()
   const settingUpdate = useSettingUpdate()
   const renterdState = useBusState()
-  const { syncDefaultContractSet } = useSyncContractSet()
+  const { maybeSyncDefaultContractSet } = useSyncContractSet()
   const mutate = useMutate()
   const onValid = useCallback(
     async (values: typeof defaultValues) => {
@@ -48,11 +46,10 @@ export function useOnValid({
       const firstTimeSettingConfig =
         isAutopilotEnabled && !resources.autopilot.data
       try {
-        const { finalValues, payloads } = transformUp({
+        const { payloads } = transformUp({
           resources,
           renterdState: renterdState.data,
           isAutopilotEnabled,
-          showAdvanced,
           estimatedSpendingPerMonth,
           values,
         })
@@ -112,13 +109,8 @@ export function useOnValid({
         }
 
         if (isAutopilotEnabled) {
-          // Sync default contract set if necessary. Only syncs if the setting
-          // is enabled in case the user changes in advanced mode and then
-          // goes back to simple mode.
-          // Might be simpler nice to just override in simple mode without a
-          // special setting since this is how other settings like allowance
-          // behave - but leaving for now.
-          syncDefaultContractSet(finalValues.autopilotContractSet)
+          // Sync default contract set if the setting is enabled.
+          maybeSyncDefaultContractSet(values.autopilotContractSet)
 
           // Trigger the autopilot loop with new settings applied.
           autopilotTrigger.post({
@@ -154,11 +146,10 @@ export function useOnValid({
     [
       renterdState.data,
       estimatedSpendingPerMonth,
-      showAdvanced,
       isAutopilotEnabled,
       autopilotUpdate,
       revalidateAndResetForm,
-      syncDefaultContractSet,
+      maybeSyncDefaultContractSet,
       mutate,
       settingUpdate,
       resources,

--- a/apps/renterd/contexts/config/useResources.tsx
+++ b/apps/renterd/contexts/config/useResources.tsx
@@ -63,7 +63,7 @@ export function useResources() {
   const {
     shouldSyncDefaultContractSet,
     setShouldSyncDefaultContractSet,
-    syncDefaultContractSet,
+    maybeSyncDefaultContractSet,
   } = useSyncContractSet()
 
   const appSettings = useAppSettings()
@@ -78,7 +78,7 @@ export function useResources() {
     averages,
     shouldSyncDefaultContractSet,
     setShouldSyncDefaultContractSet,
-    syncDefaultContractSet,
+    maybeSyncDefaultContractSet,
     appSettings,
     isAutopilotEnabled,
   }

--- a/apps/renterd/contexts/config/useSyncContractSet.tsx
+++ b/apps/renterd/contexts/config/useSyncContractSet.tsx
@@ -25,7 +25,7 @@ export function useSyncContractSet() {
   })
   const settingUpdate = useSettingUpdate()
 
-  const syncDefaultContractSet = useCallback(
+  const maybeSyncDefaultContractSet = useCallback(
     async (autopilotContractSet: string) => {
       const csd = contractSet.data || { default: '' }
       try {
@@ -70,6 +70,6 @@ export function useSyncContractSet() {
   return {
     shouldSyncDefaultContractSet,
     setShouldSyncDefaultContractSet,
-    syncDefaultContractSet,
+    maybeSyncDefaultContractSet,
   }
 }

--- a/apps/walletd-e2e/src/fixtures/sendSiacoinDialog.ts
+++ b/apps/walletd-e2e/src/fixtures/sendSiacoinDialog.ts
@@ -11,9 +11,12 @@ export async function fillComposeTransactionSiacoin({
   changeAddress: string
   amount: string
 }) {
+  await page.locator('input[name=receiveAddress]').click()
   await page.locator('input[name=receiveAddress]').fill(receiveAddress)
   await page.getByLabel('customChangeAddress').click()
+  await page.locator('input[name=changeAddress]').click()
   await page.locator('input[name=changeAddress]').fill(changeAddress)
+  await page.locator('input[name=siacoin]').click()
   await page.locator('input[name=siacoin]').fill(amount)
   await page.getByRole('button', { name: 'Generate transaction' }).click()
 }

--- a/apps/walletd-e2e/src/specs/seedGenerateAddresses.spec.ts
+++ b/apps/walletd-e2e/src/specs/seedGenerateAddresses.spec.ts
@@ -7,7 +7,7 @@ import {
   mockApiDefaults,
   getMockRescanResponse,
 } from '@siafoundation/walletd-mock'
-import { WalletAddressesResponse } from '@siafoundation/walletd-react'
+import { WalletAddressesResponse } from '@siafoundation/walletd-types'
 
 function getMockWalletAddressesResponse(): WalletAddressesResponse {
   return []

--- a/libs/design-system/src/app/AppNavbar.tsx
+++ b/libs/design-system/src/app/AppNavbar.tsx
@@ -13,7 +13,10 @@ export const navbarAppHeight = 60
 export function AppNavbar({ title, nav, stats, actions, after }: Props) {
   return (
     <>
-      <div className="flex items-center gap-2 px-6 h-14 z-10 bg-white dark:bg-graydark-50 border-b border-gray-500 dark:border-graydark-500">
+      <div
+        id="navbar"
+        className="flex items-center gap-2 px-6 h-14 z-10 bg-white dark:bg-graydark-50 border-b border-gray-500 dark:border-graydark-500"
+      >
         {title ? (
           typeof title === 'string' ? (
             <Text

--- a/libs/design-system/src/core/SiacoinField.spec.tsx
+++ b/libs/design-system/src/core/SiacoinField.spec.tsx
@@ -125,17 +125,7 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('4.444,55')
     expect(fiatInput.value).toBe('$4.444,55')
     expectOnChangeValues(
-      [
-        '3333',
-        undefined,
-        '4',
-        '44',
-        '444',
-        '4444',
-        '4444',
-        '4444.5',
-        '4444.55',
-      ],
+      [undefined, '4', '44', '444', '4444', '4444', '4444.5', '4444.55'],
       onChange
     )
   })
@@ -163,17 +153,7 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('4.444,55')
     expect(fiatInput.value).toBe('₽4.444,55')
     expectOnChangeValues(
-      [
-        '3333',
-        undefined,
-        '4',
-        '44',
-        '444',
-        '4444',
-        '4444',
-        '4444.5',
-        '4444.55',
-      ],
+      [undefined, '4', '44', '444', '4444', '4444', '4444.5', '4444.55'],
       onChange
     )
   })
@@ -201,17 +181,7 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('4.444,55')
     expect(fiatInput.value).toBe('₽4.444,55')
     expectOnChangeValues(
-      [
-        '3333',
-        undefined,
-        '4',
-        '44',
-        '444',
-        '4444',
-        '4444',
-        '4444.5',
-        '4444.55',
-      ],
+      [undefined, '4', '44', '444', '4444', '4444', '4444.5', '4444.55'],
       onChange
     )
   })

--- a/libs/design-system/src/core/SiacoinField.tsx
+++ b/libs/design-system/src/core/SiacoinField.tsx
@@ -94,9 +94,11 @@ export function SiacoinField({
   const onScChange = useCallback(
     (sc: string) => {
       setLocalSc(sc)
-      updateExternalSc(sc)
+      if (active) {
+        updateExternalSc(sc)
+      }
     },
-    [setLocalSc, updateExternalSc]
+    [active, setLocalSc, updateExternalSc]
   )
 
   const syncFiatToSc = useCallback(
@@ -159,10 +161,16 @@ export function SiacoinField({
   return (
     <div
       className={cx(
-        'flex flex-col bg-white dark:bg-graydark-50',
+        'flex flex-col',
         'focus-within:ring ring-blue-500 dark:ring-blue-200',
         'border',
-        error
+        props.readOnly
+          ? 'bg-gray-200 dark:bg-graydark-300'
+          : 'bg-white dark:bg-graydark-50',
+        props.readOnly ? 'pointer-events-none' : '',
+        props.readOnly
+          ? 'border-blue-400 dark:border-blue-400'
+          : error
           ? 'border-red-500 dark:border-red-400'
           : changed
           ? 'border-green-500 dark:border-green-400'

--- a/libs/design-system/src/core/TextField.tsx
+++ b/libs/design-system/src/core/TextField.tsx
@@ -7,6 +7,7 @@ export const textFieldStyles = cva(
     'font-sans [type=number]:font-mono',
     'outline-none m-0 p-0 w-full',
     'disabled:pointer-events-none',
+    'read-only:pointer-events-none',
     'tabular-nums',
     'rounded',
     'text-gray-1100 dark:text-white',
@@ -28,6 +29,7 @@ export const textFieldStyles = cva(
           'bg-white dark:bg-graydark-50',
           'autofill:bg-white autofill:dark:bg-graydark-50',
           'autofill:shadow-fill-white autofill:dark:shadow-fill-graydark-50',
+          'read-only:bg-gray-200 dark:read-only:bg-graydark-300',
         ],
         ghost: 'bg-transparent',
       },
@@ -35,6 +37,7 @@ export const textFieldStyles = cva(
         default: [
           'border-gray-400 dark:border-graydark-400',
           'enabled:hover:border-gray-500 enabled:hover:dark:border-graydark-500',
+          'read-only:border-gray-200 dark:read-only:border-graydark-200',
         ],
         invalid: ['border-red-500 dark:border-red-400'],
         valid: ['border-green-500 dark:border-green-400'],

--- a/libs/design-system/src/form/ConfigurationControl.tsx
+++ b/libs/design-system/src/form/ConfigurationControl.tsx
@@ -12,7 +12,9 @@ export function ConfigurationControl<
 >({ name, form, fields }: FieldProps<Values, Categories>) {
   const field = fields[name]
   const Custom = field.custom || (() => null)
-  return field.type === 'number' ? (
+  return field.type === 'custom' ? (
+    <Custom form={form} name={name} fields={fields} />
+  ) : field.type === 'number' ? (
     <ConfigurationNumber form={form} name={name} fields={fields} />
   ) : field.type === 'siacoin' ? (
     <ConfigurationSiacoin form={form} name={name} fields={fields} />
@@ -29,7 +31,5 @@ export function ConfigurationControl<
     <ConfigurationSwitch form={form} name={name} fields={fields} />
   ) : field.type === 'select' ? (
     <ConfigurationSelect form={form} name={name} fields={fields} />
-  ) : field.type === 'custom' ? (
-    <Custom form={form} name={name} fields={fields} />
   ) : null
 }

--- a/libs/design-system/src/form/ConfigurationSiacoin.tsx
+++ b/libs/design-system/src/form/ConfigurationSiacoin.tsx
@@ -19,6 +19,7 @@ export function ConfigurationSiacoin<
     units,
     suggestionTip,
     averageTip,
+    before,
     after,
     decimalsLimitSc = 6,
     decimalsLimitFiat = 6,
@@ -29,6 +30,7 @@ export function ConfigurationSiacoin<
     field,
     form,
   })
+  const Before = before || (() => null)
   const After = after || (() => null)
   const placeholder = useMemo(
     () =>
@@ -41,49 +43,53 @@ export function ConfigurationSiacoin<
   )
   return (
     <div className="flex flex-col gap-3 items-end">
-      <div className="flex flex-col gap-3 w-[250px]">
-        <SiacoinField
-          name={name}
-          size="small"
-          sc={value}
-          units={units}
-          decimalsLimitSc={decimalsLimitSc}
-          decimalsLimitFiat={decimalsLimitFiat}
-          error={error}
-          changed={form.formState.dirtyFields[name]}
-          placeholder={placeholder}
-          onChange={(val) => {
-            setValue(val as PathValue<Values, Path<Values>>, true)
-          }}
-          onBlur={() => {
-            setValue(value, true)
-          }}
-        />
-        {average && (
-          <ConfigurationTipNumber
-            type="siacoin"
-            label="Network average"
-            tip={averageTip || 'Averages provided by Sia Central.'}
-            decimalsLimit={tipsDecimalsLimitSc}
-            value={toHastings(average as BigNumber)}
-            onClick={() => {
-              setValue(average as PathValue<Values, Path<Values>>, true)
+      <div className="flex flex-col w-[250px]">
+        <Before name={name} form={form} fields={fields} />
+        <div className="flex flex-col gap-3 w-[250px]">
+          <SiacoinField
+            name={name}
+            size="small"
+            sc={value}
+            units={units}
+            decimalsLimitSc={decimalsLimitSc}
+            decimalsLimitFiat={decimalsLimitFiat}
+            readOnly={field.readOnly}
+            error={error}
+            changed={form.formState.dirtyFields[name]}
+            placeholder={placeholder}
+            onChange={(val) => {
+              setValue(val as PathValue<Values, Path<Values>>, true)
+            }}
+            onBlur={() => {
+              setValue(value, true)
             }}
           />
-        )}
-        {suggestion && suggestionTip && (
-          <ConfigurationTipNumber
-            type="siacoin"
-            label="Suggestion"
-            tip={suggestionTip}
-            decimalsLimit={tipsDecimalsLimitSc}
-            value={toHastings(suggestion as BigNumber)}
-            onClick={() => {
-              setValue(suggestion as PathValue<Values, Path<Values>>, true)
-            }}
-          />
-        )}
-        <After name={name} form={form} fields={fields} />
+          {average && (
+            <ConfigurationTipNumber
+              type="siacoin"
+              label="Network average"
+              tip={averageTip || 'Averages provided by Sia Central.'}
+              decimalsLimit={tipsDecimalsLimitSc}
+              value={toHastings(average as BigNumber)}
+              onClick={() => {
+                setValue(average as PathValue<Values, Path<Values>>, true)
+              }}
+            />
+          )}
+          {suggestion && suggestionTip && (
+            <ConfigurationTipNumber
+              type="siacoin"
+              label="Suggestion"
+              tip={suggestionTip}
+              decimalsLimit={tipsDecimalsLimitSc}
+              value={toHastings(suggestion as BigNumber)}
+              onClick={() => {
+                setValue(suggestion as PathValue<Values, Path<Values>>, true)
+              }}
+            />
+          )}
+          <After name={name} form={form} fields={fields} />
+        </div>
       </div>
       <div className="h-[20px]">
         <FieldLabelAndError form={form} name={name} />

--- a/libs/design-system/src/form/FieldSiacoin.tsx
+++ b/libs/design-system/src/form/FieldSiacoin.tsx
@@ -39,6 +39,7 @@ export function FieldSiacoin<
       units={units}
       decimalsLimitSc={decimalsLimitSc}
       decimalsLimitFiat={decimalsLimitFiat}
+      readOnly={field.readOnly}
       error={error}
       changed={form.formState.dirtyFields[name]}
       placeholder={(suggestion as BigNumber) || (average as BigNumber)}

--- a/libs/design-system/src/form/configurationFields.ts
+++ b/libs/design-system/src/form/configurationFields.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { entries } from '@technically/lodash'
-import React, { MouseEvent, useCallback } from 'react'
+import React, { MouseEvent, useCallback, useMemo } from 'react'
 import {
   FieldErrors,
   FieldValues,
@@ -38,6 +38,11 @@ export type ConfigField<
   suggestion?: BigNumber | string | boolean
   average?: BigNumber | string | boolean
   averageTip?: React.ReactNode
+  before?: React.FC<{
+    name: Path<Values>
+    form: UseFormReturn<Values>
+    fields: ConfigFields<Values, Categories>
+  }>
   after?: React.FC<{
     name: Path<Values>
     form: UseFormReturn<Values>
@@ -92,7 +97,10 @@ export function useRegisterForm<
     ref,
     onChange: _onChange,
     onBlur,
-  } = form.register(name, field.validation)
+  } = useMemo(
+    () => form.register(name, field.validation),
+    [form, name, field.validation]
+  )
 
   const onChange = useCallback(
     (e: { target: unknown; type: unknown }) => {

--- a/libs/walletd-mock/src/mocks/defaults.ts
+++ b/libs/walletd-mock/src/mocks/defaults.ts
@@ -9,6 +9,7 @@ import { mockApiTxPoolBroadcast } from './txPoolBroadcast'
 import { mockApiWallet } from './wallet'
 import { mockApiRescan } from './rescan'
 import { RescanResponse } from '@siafoundation/walletd-types'
+import { mockApiState } from './state'
 
 type Responses = {
   rescan?: RescanResponse
@@ -21,6 +22,7 @@ export async function mockApiDefaults({
   page: Page
   responses?: Responses
 }) {
+  await mockApiState({ page })
   await mockApiSiaCentralExchangeRates({ page })
   await mockApiSyncerPeers({ page })
   await mockApiConsensusTip({ page })

--- a/libs/walletd-mock/src/mocks/state.ts
+++ b/libs/walletd-mock/src/mocks/state.ts
@@ -1,0 +1,20 @@
+import { StateResponse } from '@siafoundation/walletd-types'
+import { Page } from 'playwright'
+
+export function getMockState(): StateResponse {
+  return {
+    buildTime: '2023-01-01T00:00:00Z',
+    commit: 'commit',
+    os: 'os',
+    startTime: '2023-01-01T00:00:00Z',
+    version: 'version',
+  }
+}
+
+export async function mockApiState({ page }: { page: Page }) {
+  const json = getMockState()
+  await page.route('**/api/state*', async (route) => {
+    await route.fulfill({ json })
+  })
+  return json
+}


### PR DESCRIPTION
Set of refinements to configuration that remove confusing implicit behaviour. Now the basic/advanced toggle only affects the fields in-view, and there are separate field-specific toggles for auto calculating allowance and max collateral. Allowance and max collateral now both show in the basic view mode.

- Basic configuration mode no longer sets certain fields in the background.
- renterd: Allowance now has a field-specific option to auto-calculate its value.
- hostd: Max collateral now has a field-specific option to auto-calculate its value.
- The configuration page now has a view menu in the action bar that is consistent with all other feature pages.
- Fixed an issue where first-time configuration would not show the optimal recommendations.
- Fixed a bug where the churn alert would display NaN for the percentage when the total size was zero.
- Fields now have better support and styling for readOnly.
- Fixed an issue where toggling between basic and advanced modes would sometimes not revalidate all configuration fields.

<img width="439" alt="Screenshot 2024-06-04 at 1 02 19 PM" src="https://github.com/SiaFoundation/web/assets/1412796/8ec0e51b-b7ab-438f-900d-142ffa0b0328">
<img width="1057" alt="Screenshot 2024-06-04 at 1 02 12 PM" src="https://github.com/SiaFoundation/web/assets/1412796/7a0827ff-43d8-403d-8588-6a3ba7f6b4fd">
<img width="1036" alt="Screenshot 2024-06-04 at 12 51 54 PM" src="https://github.com/SiaFoundation/web/assets/1412796/b2c19dd0-c033-4033-81b1-d2a052ead3a2">
<img width="1036" alt="Screenshot 2024-06-04 at 12 51 45 PM" src="https://github.com/SiaFoundation/web/assets/1412796/fc1a655d-9258-469a-8e5b-dae67125b6d9">
