### PR TITLE
Add block hash display case, using middle ellipsis, to ValueCopyable

### DIFF
--- a/.changeset/thin-doors-notice.md
+++ b/.changeset/thin-doors-notice.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Block hashes now show both leading and ending characters to improve legibility. Closes https://github.com/SiaFoundation/web/issues/451

--- a/apps/explorer/components/Block/index.tsx
+++ b/apps/explorer/components/Block/index.tsx
@@ -16,7 +16,8 @@ export function Block({ block }: Props) {
     const list: DatumProps[] = [
       {
         label: 'Block hash',
-        value: block.id,
+        entityType: 'blockHash',
+        entityValue: block.id,
       },
       {
         label: 'Miner payout address',
@@ -64,6 +65,7 @@ export function Block({ block }: Props) {
       <EntityList
         title={`Transactions (${block.transactions?.length || 0})`}
         dataset={block.transactions?.map((tx) => ({
+          type: 'transaction',
           hash: tx.id,
           label: 'transaction',
           initials: 'T',

--- a/apps/explorer/components/ExplorerDatum.tsx
+++ b/apps/explorer/components/ExplorerDatum.tsx
@@ -50,13 +50,7 @@ export function ExplorerDatum({
             <ValueCopyable
               scaleSize="18"
               label={entityType}
-              href={
-                // We hit error boundary wihtout this avoidance due
-                // to getHref routes expectation.
-                entityType !== 'blockHash'
-                  ? getHref(entityType, entityValue)
-                  : null
-              }
+              href={getHref(entityType, entityValue)}
               value={entityValue}
               type={entityType}
               displayValue={displayValue}

--- a/apps/explorer/components/ExplorerDatum.tsx
+++ b/apps/explorer/components/ExplorerDatum.tsx
@@ -13,6 +13,7 @@ import { getHref } from '../lib/utils'
 export type DatumProps = {
   label: string
   value?: React.ReactNode
+  displayValue?: string
   entityType?: EntityType
   entityValue?: string
   sc?: BigNumber
@@ -27,6 +28,7 @@ export function ExplorerDatum({
   entityValue,
   copyable = true,
   value,
+  displayValue,
   sc,
   sf,
   comment,
@@ -48,13 +50,16 @@ export function ExplorerDatum({
             <ValueCopyable
               scaleSize="18"
               label={entityType}
-              href={getHref(entityType, entityValue)}
-              value={entityValue}
-              displayValue={
-                entityType === 'block' && entityValue
-                  ? Number(entityValue).toLocaleString()
-                  : entityValue
+              href={
+                // We hit error boundary wihtout this avoidance due
+                // to getHref routes expectation.
+                entityType !== 'blockHash'
+                  ? getHref(entityType, entityValue)
+                  : null
               }
+              value={entityValue}
+              type={entityType}
+              displayValue={displayValue}
               // className="relative top-0.5"
             />
           ) : (

--- a/apps/explorer/components/ExplorerDatum.tsx
+++ b/apps/explorer/components/ExplorerDatum.tsx
@@ -49,7 +49,6 @@ export function ExplorerDatum({
           (entityValue ? (
             <ValueCopyable
               scaleSize="18"
-              label={entityType}
               href={getHref(entityType, entityValue)}
               value={entityValue}
               type={entityType}

--- a/apps/explorer/lib/utils.ts
+++ b/apps/explorer/lib/utils.ts
@@ -4,7 +4,9 @@ import { Metadata } from 'next'
 import { siteName } from '../config'
 
 export function getHref(type: EntityType, value: string) {
-  return routes[type].view.replace(':id', value)
+  // block accepts blockhash as a value.
+  const coercedType = type === 'blockHash' ? 'block' : type
+  return routes[coercedType].view.replace(':id', value)
 }
 
 export function buildMetadata({

--- a/libs/design-system/src/components/ValueCopyable.tsx
+++ b/libs/design-system/src/components/ValueCopyable.tsx
@@ -12,6 +12,8 @@ import {
   getEntityDisplayLength,
   getEntitySiascanUrl,
   getEntityTypeCopyLabel,
+  formatEntityValue,
+  defaultFormatValue,
 } from '../lib/entityTypes'
 import { cx } from 'class-variance-authority'
 import {
@@ -56,11 +58,11 @@ export function ValueCopyable({
   const label = customLabel || getEntityTypeCopyLabel(type)
   const maxLength = customMaxLength || getEntityDisplayLength(type)
   const cleanValue = stripPrefix(value)
-  const renderValue = displayValue || cleanValue
-
-  const text = `${renderValue?.slice(0, maxLength)}${
-    (renderValue?.length || 0) > maxLength ? '...' : ''
-  }`
+  // If we pass a defaultValue, use it. An entityType? Format it.
+  const renderValue =
+    displayValue || (type && formatEntityValue(type, cleanValue, maxLength))
+  // If we don't yet have a renderValue, apply some general formatting.
+  const text = renderValue || defaultFormatValue(cleanValue, maxLength)
 
   return (
     <div className={cx('flex items-center', className)}>

--- a/libs/design-system/src/lib/entityTypes.ts
+++ b/libs/design-system/src/lib/entityTypes.ts
@@ -11,6 +11,7 @@ export type EntityType =
   | 'hostIp'
   | 'hostPublicKey'
   | 'contract'
+  | 'blockHash'
 
 export type TxType =
   | 'siacoin'
@@ -119,6 +120,7 @@ const entityLabels: Record<EntityType, string> = {
   hostIp: 'host',
   hostPublicKey: 'host',
   ip: 'IP',
+  blockHash: 'block hash',
 }
 
 const entityCopyLabels: Record<EntityType, string> = {
@@ -130,6 +132,7 @@ const entityCopyLabels: Record<EntityType, string> = {
   hostIp: 'host address',
   hostPublicKey: 'host public key',
   ip: 'IP',
+  blockHash: 'block hash',
 }
 
 const txTypeMap: Record<TxType, string> = {
@@ -198,5 +201,33 @@ export function getEntitySiascanUrl(
       return `${baseUrl}/block/${value}`
     default:
       return ''
+  }
+}
+
+export function defaultFormatValue(text: string, maxLength: number) {
+  return `${text?.slice(0, maxLength)}${
+    (text?.length || 0) > maxLength ? '...' : ''
+  }`
+}
+
+export function formatEntityValue(
+  type: EntityType,
+  text: string,
+  maxLength: number
+) {
+  switch (type) {
+    case 'blockHash': {
+      const halfMax = maxLength / 2
+      // Floor and ceil here to handle odd maxLengths.
+      // .slice() will round down on floats.
+      const firstHalf = text.slice(0, Math.floor(halfMax))
+      const lastHalf = text.slice(text.length - Math.ceil(halfMax))
+      return firstHalf + '...' + lastHalf
+    }
+    default: {
+      // We could also return null here, forcing the issue of defining
+      // formats for the missing cases in the switch above.
+      return defaultFormatValue(text, maxLength)
+    }
   }
 }


### PR DESCRIPTION
fixes #451 

Hello! I've been looking at this codebase for a couple of days now and saw a task I thought was approachable for a first PR. This change addresses the issue by modifying the following files:

1. `ExplorerDatum.tsx`
2. `ValueCopyable.tsx`
3. `Block/index.ts`

These are backward-compatible changes, as far as I know, given the optional nature of the props and how the text value in ValueCopyable is calculated.

Issue: `ValueCopyable`, via `ExplorerDatum`, displays the Block hash's first 12 characters, which are typically 0s, with a trailing ellipsis.

Solution: Display the last 12 characters instead, adding the ellipsis at the front. 

How: Add optional maxLength and ellipsisDir props to `ExplorerDatum`, pass them to `ValueCopyable` (adding the optional ellipsisDir prop here), and rewrite the rendered text variable to take advantage of these props, if they exist. When `ellipsisDir="left"` is passed to `ExplorerDatum`, the **last** [maxLength] characters are displayed with an ellipsis in front. When `maxLength={#}` is passed, it overwrites the default maxLength, displaying that many characters before or after the ellipsis. The default ellipsis direction is on the right, as it exists elsewhere today, and the maxLength prop in `ValueCopyable` was already set up well to work without the prop. Now, anywhere `ExplorerDatum` and `ValueCopyable`  or only `ValueCopyable` are used, there are these optional properties to provide more granular display control.

Further considerations (optional): 

1. In `Block/index.ts`, I have only added the ellipsisDir prop set "left". I didn't extend maxLength, but one certainly could, now. I think there are some design questions to ponder in terms of display at < ~500px widths.
2. With the ellipsis on the left, allowing one to display the final characters of very long text, which I'm guessing are more important than the front characters, there aren't a lot of options out there, in terms of a straight CSS solution. Usually, they consist of hacks with non-typical elements. Other javascript solutions could revolve around logic based on `window.clientWidth` or `window.getBoundingClientRect()`, but I've seen some of these solutions and, in my experience, they can be a bit unreliable (the latter function reading 0 for the first milliseconds, for example) and unwieldy in terms of working from hard numerical value breakpoints.
3. One solution to extend the displayed characters could be to flex-col `ExplorerDatum` when it reaches a certain breakpoint (depending on how long you want to go), and, at that point, you *might* want to center `ValueCopyable`. Maybe not, though. It's not something I **explorer**ed.
4. I added this ellipsis left functionality in `Block/index.ts` for both the 'Block hash' and 'Miner payout address' values, only so they would match. You could certainly pull the index out of the map here and apply it only to the block hash.
5. I think the Tooltip component could be useful here, but it would require a more thorough refactor of `ExplorerDatum` which I felt might be beyond the scope of this request. You would probably want to move the logical operator render logic inside the return up above the return, perhaps in a `useCallback`, and then optionally wrap the result of that logic in a Tooltip, if necessary. Figuring out the key for the value you want to display is a barrier.
6. Finally, I added props and imports to the end of things to keep a cleaner diff, but I would probably move maxLength and ellipsisDir next to each other in props and move an import like `useMemo` to the top. Just wanted to keep things simple to review.

Happy to edit anything to your satisfaction. Thanks!