### PR TITLE
fix: renterd file rename, add e2e tests

### DIFF
--- a/.changeset/gentle-countries-cry.md
+++ b/.changeset/gentle-countries-cry.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Updated react-hook-form.

--- a/.changeset/hip-turkeys-remember.md
+++ b/.changeset/hip-turkeys-remember.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where renaming a file would throw an error.

--- a/.changeset/short-bears-grab.md
+++ b/.changeset/short-bears-grab.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the empty directory state was showing an empty bucket message.

--- a/apps/renterd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/renterd-e2e/src/fixtures/beforeTest.ts
@@ -1,0 +1,16 @@
+import { mockApiSiaCentralExchangeRates } from '@siafoundation/sia-central-mock'
+import { login } from './login'
+import { navigateToConfig } from './navigate'
+import { configResetAllSettings } from './configResetAllSettings'
+import { setViewMode } from './configViewMode'
+import { Page } from 'playwright'
+
+export async function beforeTest(page: Page) {
+  await mockApiSiaCentralExchangeRates({ page })
+  await login({ page })
+
+  // Reset state.
+  await navigateToConfig({ page })
+  await configResetAllSettings({ page })
+  await setViewMode({ page, state: 'basic' })
+}

--- a/apps/renterd-e2e/src/fixtures/buckets.ts
+++ b/apps/renterd-e2e/src/fixtures/buckets.ts
@@ -2,6 +2,7 @@ import { Page, expect } from '@playwright/test'
 import { navigateToBuckets } from './navigate'
 import { fillTextInputByName } from './textInput'
 import { clearToasts } from './clearToasts'
+import { deleteDirectory, deleteFile } from './files'
 
 export async function createBucket(page: Page, name: string) {
   await navigateToBuckets({ page })
@@ -25,10 +26,36 @@ export async function deleteBucket(page: Page, name: string) {
 
 export async function deleteBucketIfExists(page: Page, name: string) {
   const doesBucketExist = await page
-    .getByRole('table')
+    .getByTestId('bucketsTable')
     .getByText(name)
     .isVisible()
   if (doesBucketExist) {
+    await openBucket(page, name)
+    // The list changes to filesTable and is still loading=false for a split second
+    // before the files start fetching - this is why we need to wait for 1000ms.
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(1000)
+    await expect(
+      page.locator('[data-testid=filesTable][data-loading=false]')
+    ).toBeVisible()
+    const tableRows = await page
+      .getByTestId('filesTable')
+      .getByTestId(new RegExp(`${name}.*`))
+      .all()
+    // First delete all top-level objects in the bucket, because a bucket
+    // can't be deleted if there are objects in it.
+    for (const row of tableRows) {
+      const id = await row.getAttribute('data-testid')
+      if (id === '..') {
+        continue
+      }
+      if (id?.endsWith('/')) {
+        await deleteDirectory(page, id)
+      } else {
+        await deleteFile(page, id)
+      }
+    }
+    await navigateToBuckets({ page })
     await deleteBucket(page, name)
   }
 }
@@ -37,10 +64,16 @@ export async function openBucketContextMenu(page: Page, name: string) {
   await page.getByRole('row', { name }).getByRole('button').first().click()
 }
 
+export async function openBucket(page: Page, name: string) {
+  await page.getByRole('row').getByText(name).click()
+  await expect(page.getByTestId('navbar').getByText(name)).toBeVisible()
+  await expect(page.getByLabel('Upload files')).toBeVisible()
+}
+
 export async function bucketInList(page: Page, name: string) {
-  await expect(page.getByRole('table').getByText(name)).toBeVisible()
+  await expect(page.getByTestId('bucketsTable').getByText(name)).toBeVisible()
 }
 
 export async function bucketNotInList(page: Page, name: string) {
-  await expect(page.getByRole('table').getByText(name)).toBeHidden()
+  await expect(page.getByTestId('bucketsTable').getByText(name)).toBeHidden()
 }

--- a/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
+++ b/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
@@ -13,7 +13,7 @@ export async function configResetAllSettings({ page }: { page: Page }) {
   await fillTextInputByName(page, 'storageTB', '1')
   await fillTextInputByName(page, 'uploadTBMonth', '1')
   await fillTextInputByName(page, 'downloadTBMonth', '1')
-  await fillTextInputByName(page, 'allowanceMonth', '1')
+  await fillTextInputByName(page, 'allowanceMonth', '21000')
   await fillTextInputByName(page, 'periodWeeks', '6')
   await fillTextInputByName(page, 'renewWindowWeeks', '2')
   await fillTextInputByName(page, 'amountHosts', '12')

--- a/apps/renterd-e2e/src/fixtures/files.ts
+++ b/apps/renterd-e2e/src/fixtures/files.ts
@@ -1,0 +1,115 @@
+import { Page, expect } from '@playwright/test'
+import { readFileSync } from 'fs'
+import { fillTextInputByName } from './textInput'
+
+export async function deleteFile(page: Page, path: string) {
+  await openFileContextMenu(page, path)
+  await page.getByRole('menuitem', { name: 'Delete file' }).click()
+  await expect(page.getByRole('dialog').getByText('Delete file')).toBeVisible()
+  await page.locator('form button[type=submit]').click()
+  await expect(page.getByRole('dialog')).toBeHidden()
+  await fileNotInList(page, path)
+}
+
+export async function deleteFileIfExists(page: Page, path: string) {
+  const exists = await page.getByRole('table').getByTestId(path).isVisible()
+  if (exists) {
+    await deleteFile(page, path)
+  }
+}
+
+export async function deleteDirectory(page: Page, path: string) {
+  await openDirectoryContextMenu(page, path)
+  const deleteDirectoryItem = page.getByRole('menuitem', {
+    name: 'Delete directory',
+  })
+  await expect(deleteDirectoryItem).toBeVisible()
+  await deleteDirectoryItem.click()
+  await expect(
+    page.getByRole('dialog').getByText('Delete directory')
+  ).toBeVisible()
+  await page.locator('form button[type=submit]').click()
+  await expect(page.getByRole('dialog')).toBeHidden()
+  await fileNotInList(page, path)
+}
+
+export async function deleteDirectoryIfExists(page: Page, path: string) {
+  const exists = await page.getByRole('table').getByTestId(path).isVisible()
+  if (exists) {
+    await deleteDirectory(page, path)
+  }
+}
+
+export async function openDirectoryContextMenu(page: Page, path: string) {
+  const selector = page.getByTestId(path).getByLabel('Directory context menu')
+  // Click doesn't work until animation is finished.
+  // eslint-disable-next-line playwright/no-wait-for-timeout
+  await page.waitForTimeout(100)
+  await expect(selector).toBeVisible()
+  await selector.click()
+}
+
+export async function openFileContextMenu(page: Page, path: string) {
+  const selector = page.getByTestId(path).getByLabel('File context menu')
+  await expect(selector).toBeVisible()
+  await selector.click()
+}
+
+export async function openDirectory(page: Page, path: string) {
+  await page.getByRole('table').getByTestId(path).click()
+  for (const dir of path.split('/').slice(0, -1)) {
+    await expect(page.getByTestId('navbar').getByText(dir)).toBeVisible()
+  }
+}
+
+export async function crateDirectory(page: Page, name: string) {
+  await expect(page.getByLabel('Create directory')).toBeVisible()
+  await page.getByLabel('Create directory').click()
+  await fillTextInputByName(page, 'name', name)
+  await page.locator('input[name=name]').press('Enter')
+  await expect(page.getByRole('dialog')).toBeHidden()
+}
+
+export async function createDirectoryIfNotExists(page: Page, name: string) {
+  const exists = await page.getByRole('table').getByTestId(name).isVisible()
+  if (!exists) {
+    await crateDirectory(page, name)
+  }
+}
+
+export async function fileInList(page: Page, path: string) {
+  await expect(page.getByRole('table').getByTestId(path)).toBeVisible()
+}
+
+export async function fileNotInList(page: Page, path: string) {
+  await expect(page.getByRole('table').getByTestId(path)).toBeHidden()
+}
+
+export async function dragAndDropFile(
+  page: Page,
+  selector: string,
+  filePath: string,
+  fileName: string,
+  fileType = ''
+) {
+  const buffer = readFileSync(filePath).toString('base64')
+
+  const dataTransfer = await page.evaluateHandle(
+    async ({ bufferData, localFileName, localFileType }) => {
+      const dt = new DataTransfer()
+
+      const blobData = await fetch(bufferData).then((res) => res.blob())
+
+      const file = new File([blobData], localFileName, { type: localFileType })
+      dt.items.add(file)
+      return dt
+    },
+    {
+      bufferData: `data:application/octet-stream;base64,${buffer}`,
+      localFileName: fileName,
+      localFileType: fileType,
+    }
+  )
+
+  await page.dispatchEvent(selector, 'drop', { dataTransfer })
+}

--- a/apps/renterd-e2e/src/fixtures/navigate.ts
+++ b/apps/renterd-e2e/src/fixtures/navigate.ts
@@ -1,12 +1,12 @@
 import { Page, expect } from '@playwright/test'
 
 export async function navigateToBuckets({ page }: { page: Page }) {
-  await page.getByLabel('Files').click()
+  await page.getByTestId('sidenav').getByLabel('Files').click()
   await expect(page.getByTestId('navbar').getByText('Buckets')).toBeVisible()
 }
 
 export async function navigateToConfig({ page }: { page: Page }) {
-  await page.getByLabel('Configuration').click()
+  await page.getByTestId('sidenav').getByLabel('Configuration').click()
   await expect(
     page.getByTestId('navbar').getByText('Configuration')
   ).toBeVisible()

--- a/apps/renterd-e2e/src/specs/buckets.spec.ts
+++ b/apps/renterd-e2e/src/specs/buckets.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test'
 import { navigateToBuckets } from '../fixtures/navigate'
-import { login } from '../fixtures/login'
 import {
   bucketInList,
   createBucket,
@@ -8,9 +7,13 @@ import {
   deleteBucketIfExists,
   openBucketContextMenu,
 } from '../fixtures/buckets'
+import { beforeTest } from '../fixtures/beforeTest'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page)
+})
 
 test('can change a buckets policy', async ({ page }) => {
-  await login({ page })
   await navigateToBuckets({ page })
   await openBucketContextMenu(page, 'default')
   await page.getByRole('menuitem', { name: 'Change policy' }).click()
@@ -22,7 +25,7 @@ test('can change a buckets policy', async ({ page }) => {
 })
 
 test('can create and delete a bucket', async ({ page }) => {
-  await login({ page })
+  await navigateToBuckets({ page })
   await deleteBucketIfExists(page, 'my-new-bucket')
   await createBucket(page, 'my-new-bucket')
   await deleteBucket(page, 'my-new-bucket')

--- a/apps/renterd-e2e/src/specs/config.spec.ts
+++ b/apps/renterd-e2e/src/specs/config.spec.ts
@@ -1,26 +1,23 @@
 import { test, expect } from '@playwright/test'
-import { login } from '../fixtures/login'
 import { expectSwitchByLabel, setSwitchByLabel } from '../fixtures/switchValue'
 import { setViewMode } from '../fixtures/configViewMode'
 import { navigateToConfig } from '../fixtures/navigate'
-import { mockApiSiaCentralExchangeRates } from '@siafoundation/sia-central-mock'
 import {
   expectTextInputByName,
   expectTextInputByNameAttribute,
   fillTextInputByName,
 } from '../fixtures/textInput'
-import { configResetAllSettings } from '../fixtures/configResetAllSettings'
 import { clearToasts } from '../fixtures/clearToasts'
 import { clickIfEnabledAndWait, clickIf } from '../fixtures/click'
+import { beforeTest } from '../fixtures/beforeTest'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page)
+})
 
 test('basic field change and save behaviour', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   // Reset state.
   await navigateToConfig({ page })
-  await configResetAllSettings({ page })
   await setViewMode({ page, state: 'basic' })
   await setSwitchByLabel(page, 'autoAllowance', true)
 
@@ -50,10 +47,6 @@ test('basic field change and save behaviour', async ({ page }) => {
 test('estimate based off storage, pricing, and redundancy', async ({
   page,
 }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   // Reset state.
   await navigateToConfig({ page })
   await setSwitchByLabel(page, 'autoAllowance', true)
@@ -84,10 +77,6 @@ test('estimate based off storage, pricing, and redundancy', async ({
 })
 
 test('configure with auto allowance', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   // Reset state.
   await navigateToConfig({ page })
   await setSwitchByLabel(page, 'autoAllowance', true)
@@ -108,13 +97,8 @@ test('configure with auto allowance', async ({ page }) => {
 })
 
 test('configure allowance manually', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   // Reset state.
   await navigateToConfig({ page })
-  await configResetAllSettings({ page })
   await setSwitchByLabel(page, 'autoAllowance', false)
   await setViewMode({ page, state: 'basic' })
   await fillTextInputByName(page, 'allowanceMonth', '777')
@@ -135,13 +119,8 @@ test('configure allowance manually', async ({ page }) => {
 })
 
 test('system offers recommendations', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   // Reset state.
   await navigateToConfig({ page })
-  await configResetAllSettings({ page })
   await setViewMode({ page, state: 'basic' })
   await setSwitchByLabel(page, 'autoAllowance', true)
 

--- a/apps/renterd-e2e/src/specs/files.spec.ts
+++ b/apps/renterd-e2e/src/specs/files.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test'
+import { navigateToBuckets } from '../fixtures/navigate'
+import {
+  createBucket,
+  deleteBucketIfExists,
+  openBucket,
+} from '../fixtures/buckets'
+import path from 'path'
+import {
+  createDirectoryIfNotExists,
+  deleteDirectoryIfExists,
+  deleteFileIfExists,
+  dragAndDropFile,
+  fileInList,
+  fileNotInList,
+  openDirectory,
+  openFileContextMenu,
+} from '../fixtures/files'
+import { fillTextInputByName } from '../fixtures/textInput'
+import { clearToasts } from '../fixtures/clearToasts'
+import { beforeTest } from '../fixtures/beforeTest'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page)
+})
+
+test('can create directory, upload file, rename file, navigate, delete a file, delete a directory', async ({
+  page,
+}) => {
+  test.setTimeout(80_000)
+  const bucketName = 'files-test'
+  const dirName = `test-dir-${Date.now()}`
+  const originalFileName = 'sample.txt'
+  const newFileName = 'renamed.txt'
+  const dirPath = `${bucketName}/${dirName}/`
+  const originalFilePath = `${bucketName}/${dirName}/${originalFileName}`
+  const newFilePath = `${bucketName}/${dirName}/${newFileName}`
+
+  await navigateToBuckets({ page })
+  await deleteBucketIfExists(page, bucketName)
+  await createBucket(page, bucketName)
+  await openBucket(page, bucketName)
+  await expect(
+    page.getByText('bucket does not contain any files')
+  ).toBeVisible()
+
+  // create directory
+  await createDirectoryIfNotExists(page, dirName)
+  await fileInList(page, dirPath)
+  await openDirectory(page, dirPath)
+  await expect(
+    page.getByText('The current directory does not contain any files yet')
+  ).toBeVisible()
+  await clearToasts({ page })
+
+  // upload
+  await dragAndDropFile(
+    page,
+    `[data-testid=filesDropzone]`,
+    path.join(__dirname, originalFileName),
+    originalFileName
+  )
+  await fileInList(page, originalFilePath)
+  await expect(page.getByText('100%')).toBeVisible()
+
+  // rename
+  await openFileContextMenu(page, originalFilePath)
+  await page.getByRole('menuitem', { name: 'Rename file' }).click()
+  await fillTextInputByName(page, 'name', 'renamed.txt')
+  await page.locator('input[name=name]').press('Enter')
+  await expect(page.getByRole('dialog')).toBeHidden()
+  await fileInList(page, newFilePath)
+
+  // delete
+  await deleteFileIfExists(page, newFilePath)
+  await fileNotInList(page, newFilePath)
+  await clearToasts({ page })
+
+  // upload again
+  await dragAndDropFile(
+    page,
+    `[data-testid=filesDropzone]`,
+    path.join(__dirname, originalFileName),
+    originalFileName
+  )
+  await fileInList(page, originalFilePath)
+  await expect(page.getByText('100%')).toBeVisible()
+
+  // navigate back to root
+  await page.getByRole('cell', { name: '..' }).click()
+  await fileInList(page, dirPath)
+
+  // delete directory
+  await deleteDirectoryIfExists(page, dirPath)
+  await fileNotInList(page, dirPath)
+
+  // delete bucket
+  await navigateToBuckets({ page })
+  await deleteBucketIfExists(page, bucketName)
+})

--- a/apps/renterd-e2e/src/specs/sample.txt
+++ b/apps/renterd-e2e/src/specs/sample.txt
@@ -1,0 +1,1 @@
+hello world

--- a/apps/renterd/components/Files/DirectoryContextMenu.tsx
+++ b/apps/renterd/components/Files/DirectoryContextMenu.tsx
@@ -21,7 +21,11 @@ export function DirectoryContextMenu({ path, size }: Props) {
   return (
     <DropdownMenu
       trigger={
-        <Button variant="ghost" icon="hover">
+        <Button
+          aria-label="Directory context menu"
+          variant="ghost"
+          icon="hover"
+        >
           <FolderIcon size={16} />
         </Button>
       }

--- a/apps/renterd/components/Files/FileContextMenu/index.tsx
+++ b/apps/renterd/components/Files/FileContextMenu/index.tsx
@@ -36,7 +36,7 @@ export function FileContextMenu({ path }: Props) {
   return (
     <DropdownMenu
       trigger={
-        <Button variant="ghost" icon="hover">
+        <Button aria-label="File context menu" variant="ghost" icon="hover">
           <Document16 />
         </Button>
       }

--- a/apps/renterd/components/FilesDirectory/EmptyState/StateNoneYet.tsx
+++ b/apps/renterd/components/FilesDirectory/EmptyState/StateNoneYet.tsx
@@ -1,10 +1,37 @@
-import { Code, LinkButton, Text } from '@siafoundation/design-system'
+import { Button, Code, LinkButton, Text } from '@siafoundation/design-system'
 import { CloudUpload32 } from '@siafoundation/react-icons'
 import { routes } from '../../../config/routes'
 import { useFilesManager } from '../../../contexts/filesManager'
 
 export function StateNoneYet() {
-  const { activeBucketName: activeBucket } = useFilesManager()
+  const {
+    activeBucketName: activeBucket,
+    activeDirectory,
+    setActiveDirectory,
+  } = useFilesManager()
+  if (activeDirectory.length > 1) {
+    return (
+      <div className="flex flex-col gap-10 justify-center items-center h-[400px] cursor-pointer">
+        <Text>
+          <CloudUpload32 className="scale-[200%]" />
+        </Text>
+        <div className="flex flex-col gap-3 items-center">
+          <Text color="subtle" className="text-center max-w-[500px]">
+            The current directory does not contain any files yet, drag and drop
+            files or click here to start uploading.
+          </Text>
+          <Button
+            onClick={(e) => {
+              e.stopPropagation()
+              setActiveDirectory((prev) => prev.slice(0, -1))
+            }}
+          >
+            Back
+          </Button>
+        </div>
+      </div>
+    )
+  }
   return (
     <div className="flex flex-col gap-10 justify-center items-center h-[400px] cursor-pointer">
       <Text>

--- a/apps/renterd/components/FilesDirectory/FilesActionsMenu.tsx
+++ b/apps/renterd/components/FilesDirectory/FilesActionsMenu.tsx
@@ -40,11 +40,17 @@ export function FilesActionsMenu() {
           <Button onClick={() => openDialog('filesSearch')} tip="Search files">
             <Search16 />
           </Button>
-          <Button {...getRootProps()} tip="Upload files" disabled={!canUpload}>
+          <Button
+            aria-label="Upload files"
+            {...getRootProps()}
+            tip="Upload files"
+            disabled={!canUpload}
+          >
             <input {...getInputProps()} />
             <CloudUpload16 />
           </Button>
           <Button
+            aria-label="Create directory"
             disabled={!canUpload}
             onClick={() => openDialog('filesCreateDirectory')}
             tip="Create directory"

--- a/apps/renterd/components/FilesDirectory/FilesExplorer.tsx
+++ b/apps/renterd/components/FilesDirectory/FilesExplorer.tsx
@@ -6,8 +6,14 @@ import { useFilesManager } from '../../contexts/filesManager'
 import { columns } from '../../contexts/filesDirectory/columns'
 
 export function FilesExplorer() {
-  const { uploadFiles, sortField, sortDirection, sortableColumns, toggleSort } =
-    useFilesManager()
+  const {
+    uploadFiles,
+    sortField,
+    sortDirection,
+    sortableColumns,
+    toggleSort,
+    isViewingBuckets,
+  } = useFilesManager()
   const {
     datasetPage,
     pageCount,
@@ -23,11 +29,13 @@ export function FilesExplorer() {
   return (
     <div className="relative">
       <Dropzone
+        testId="filesDropzone"
         onDrop={uploadFiles}
         noClick={!canUpload || pageCount > 0}
         noDrag={!canUpload}
       >
         <Table
+          testId={isViewingBuckets ? 'bucketsTable' : 'filesTable'}
           isLoading={dataState === 'loading'}
           emptyState={<EmptyState />}
           pageSize={10}

--- a/apps/renterd/contexts/dialog.tsx
+++ b/apps/renterd/contexts/dialog.tsx
@@ -121,7 +121,6 @@ export function DialogProvider({ children }: Props) {
 
 export function Dialogs() {
   const {
-    id,
     dialog,
     openDialog,
     onOpenChange,
@@ -182,7 +181,6 @@ export function Dialogs() {
         onOpenChange={onOpenChange}
       />
       <FileRenameDialog
-        id={id}
         open={dialog === 'fileRename'}
         onOpenChange={onOpenChange}
       />

--- a/apps/renterd/dialogs/FilesBucketDeleteDialog.tsx
+++ b/apps/renterd/dialogs/FilesBucketDeleteDialog.tsx
@@ -8,6 +8,7 @@ import {
   FormSubmitButton,
   FieldText,
   Code,
+  useDialogFormHelpers,
 } from '@siafoundation/design-system'
 import { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
@@ -18,7 +19,9 @@ const defaultValues = {
   name: '',
 }
 
-function getFields(name: string): ConfigFields<typeof defaultValues, never> {
+type Values = typeof defaultValues
+
+function getFields(name: string): ConfigFields<Values, never> {
   return {
     name: {
       type: 'text',
@@ -47,7 +50,7 @@ export function FilesBucketDeleteDialog({
   open,
   onOpenChange,
 }: Props) {
-  const { id: name, closeDialog } = useDialog()
+  const { id: name } = useDialog()
 
   const bucketDelete = useBucketDelete()
   const form = useForm({
@@ -55,8 +58,14 @@ export function FilesBucketDeleteDialog({
     defaultValues,
   })
 
+  const { handleOpenChange, closeAndReset } = useDialogFormHelpers({
+    form,
+    onOpenChange,
+    defaultValues,
+  })
+
   const onSubmit = useCallback(
-    async (values: typeof defaultValues) => {
+    async (values: Values) => {
       const response = await bucketDelete.delete({
         params: {
           name: values.name,
@@ -69,11 +78,10 @@ export function FilesBucketDeleteDialog({
         })
       } else {
         triggerSuccessToast({ title: 'Bucket permanently deleted' })
-        form.reset()
-        closeDialog()
+        closeAndReset()
       }
     },
-    [form, bucketDelete, closeDialog]
+    [bucketDelete, closeAndReset]
   )
 
   const fields = useMemo(() => getFields(name), [name])
@@ -85,12 +93,7 @@ export function FilesBucketDeleteDialog({
       title="Delete Bucket"
       trigger={trigger}
       open={open}
-      onOpenChange={(val) => {
-        if (!val) {
-          form.reset(defaultValues)
-        }
-        onOpenChange(val)
-      }}
+      onOpenChange={handleOpenChange}
       contentVariants={{
         className: 'w-[400px]',
       }}

--- a/libs/design-system/src/app/AppAuthedLayout/Sidenav.tsx
+++ b/libs/design-system/src/app/AppAuthedLayout/Sidenav.tsx
@@ -42,7 +42,10 @@ export function Sidenav({
   children,
 }: Props) {
   return (
-    <Panel className="relative overflow-hidden z-10 h-full w-[75px] rounded-none border-y-0">
+    <Panel
+      data-testid="sidenav"
+      className="relative overflow-hidden z-10 h-full w-[75px] rounded-none border-y-0"
+    >
       <div className="flex flex-col items-center h-full">
         <div
           className="flex items-center justify-center"

--- a/libs/design-system/src/components/Dropzone.tsx
+++ b/libs/design-system/src/components/Dropzone.tsx
@@ -11,6 +11,7 @@ type Props = {
   rootClassName?: string
   className?: string
   message?: boolean
+  testId?: string
   showBorderInactive?: boolean
 } & DropzoneOptions
 
@@ -21,12 +22,17 @@ export function Dropzone({
   className,
   message,
   showBorderInactive,
+  testId,
   ...props
 }: Props) {
   const { getRootProps, getInputProps, isDragActive } = useDropzone(props)
 
   return (
-    <div {...getRootProps()} className={cx('outline-none', rootClassName)}>
+    <div
+      data-testid={testId}
+      {...getRootProps()}
+      className={cx('outline-none', rootClassName)}
+    >
       <div
         className={cx(
           isDragActive ? 'z-20' : '',

--- a/libs/design-system/src/components/Table/TableRow.tsx
+++ b/libs/design-system/src/components/Table/TableRow.tsx
@@ -88,6 +88,7 @@ export function createTableRow<
           {...listeners}
           style={style}
           id={data.id}
+          data-testid={data.id}
           onClick={data.onClick}
           className={cx(
             'border-b border-gray-200/50 dark:border-graydark-100',

--- a/libs/design-system/src/components/Table/index.tsx
+++ b/libs/design-system/src/components/Table/index.tsx
@@ -76,6 +76,7 @@ type Props<
   onDragEnd?: (e: DragEndEvent) => void
   onDragCancel?: (e: DragCancelEvent) => void
   draggingDatum?: D
+  testId?: string
 }
 
 export function Table<
@@ -103,6 +104,7 @@ export function Table<
   onDragEnd,
   onDragCancel,
   draggingDatum,
+  testId,
 }: Props<Columns, SortField, D, Context>) {
   let show = 'emptyState'
 
@@ -183,7 +185,11 @@ export function Table<
         )}
       </DragOverlay>
       <Panel>
-        <table className="relative z-10 table-auto border-collapse w-full">
+        <table
+          data-testid={testId}
+          data-loading={show === 'skeleton'}
+          className="relative z-10 table-auto border-collapse w-full"
+        >
           <thead
             className={cx(
               'sticky top-0 z-20 bg-white dark:bg-graydark-100',

--- a/libs/design-system/src/form/configurationFields.ts
+++ b/libs/design-system/src/form/configurationFields.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { entries } from '@technically/lodash'
-import React, { MouseEvent, useCallback, useMemo } from 'react'
+import React, { MouseEvent, useCallback } from 'react'
 import {
   FieldErrors,
   FieldValues,
@@ -93,14 +93,13 @@ export function useRegisterForm<
   const error =
     form.formState.touchedFields[name] && !!form.formState.errors[name]
 
+  // Do not memoize this register call, for an unknown reason it sometimes
+  // causes form updates to stop working.
   const {
     ref,
     onChange: _onChange,
     onBlur,
-  } = useMemo(
-    () => form.register(name, field.validation),
-    [form, name, field.validation]
-  )
+  } = form.register(name, field.validation)
 
   const onChange = useCallback(
     (e: { target: unknown; type: unknown }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
         "react-dom": "18.2.0",
         "react-dropzone": "^14.2.3",
         "react-globe.gl": "^2.24.2",
-        "react-hook-form": "^7.43.9",
+        "react-hook-form": "^7.52.0",
         "react-hot-toast": "^2.2.0",
         "react-idle-timer": "^5.7.2",
         "react-intersection-observer": "^9.1.0",
@@ -22795,9 +22795,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.43.9",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
-      "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -22806,7 +22806,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-hot-toast": {
@@ -44868,9 +44868,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.43.9",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.9.tgz",
-      "integrity": "sha512-AUDN3Pz2NSeoxQ7Hs6OhQhDr6gtF9YRuutGDwPQqhSUAHJSgGl2VeY3qN19MG0SucpjgDiuMJ4iC5T5uB+eaNQ==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
       "requires": {}
     },
     "react-hot-toast": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",
     "react-globe.gl": "^2.24.2",
-    "react-hook-form": "^7.43.9",
+    "react-hook-form": "^7.52.0",
     "react-hot-toast": "^2.2.0",
     "react-idle-timer": "^5.7.2",
     "react-intersection-observer": "^9.1.0",


### PR DESCRIPTION
- Fixed an issue where renaming a file would throw an error.
- Fixed an issue where the empty directory state was showing an empty bucket message.
- Added e2e tests for:
  - can create directory
  - delete directory
  - drag and drop target uploads
  - upload file within directory
  - rename file
  - delete a file
  - re-upload same file
  - navigate up and down directories
  - delete bucket with contents, contents first, then bucket
