### PR TITLE
refactor: renterd allowance derived max pricing

### DIFF
--- a/.changeset/dirty-dodos-wave.md
+++ b/.changeset/dirty-dodos-wave.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The configuration no longer offers an option to auto-calculate the allowance.

--- a/.changeset/empty-jobs-accept.md
+++ b/.changeset/empty-jobs-accept.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The configuration now has an option to automatically calculate prices from the user-specified allowance. The prices are calculated to spend around the allowance while keeping upload, download, and storage prices proportionally fixed while also allocating based on estimated usage in each category. The max prices also include headroom so that variations in contract prices average out while avoiding host churn. Closes https://github.com/SiaFoundation/renterd/issues/1303

--- a/.changeset/shy-fans-explode.md
+++ b/.changeset/shy-fans-explode.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The estimates in the stats bar are now based directly off the configured allowance.

--- a/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
+++ b/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
@@ -7,7 +7,7 @@ import { clickIfEnabledAndWait } from './click'
 
 export async function configResetAllSettings({ page }: { page: Page }) {
   await setViewMode({ page, state: 'advanced' })
-  await setSwitchByLabel(page, 'autoAllowance', false)
+  await setSwitchByLabel(page, 'allowanceDerivedPricing', false)
 
   // storage
   await fillTextInputByName(page, 'storageTB', '1')

--- a/apps/renterd/contexts/config/derivePricesFromAllowance.spec.ts
+++ b/apps/renterd/contexts/config/derivePricesFromAllowance.spec.ts
@@ -1,0 +1,370 @@
+import BigNumber from 'bignumber.js'
+import { derivePricingFromAllowance } from './derivePricesFromAllowance'
+
+test('with estimates of 1 TB, standard weights, 1x redundancy, 1x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 1
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(1)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '500.00',
+    maxStoragePriceTBMonth: '400.00',
+    maxUploadPriceTB: '100.00',
+  })
+})
+
+test('with estimates of 1 TB, standard weights, 2x redundancy, 1x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 1
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(2)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '333.33',
+    maxStoragePriceTBMonth: '266.67',
+    maxUploadPriceTB: '66.67',
+  })
+})
+
+test('with estimates of 1 TB, standard weights, 3x redunancy, 1x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 1
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(3)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '250.00',
+    maxStoragePriceTBMonth: '200.00',
+    maxUploadPriceTB: '50.00',
+  })
+})
+
+test('with estimates of 1 TB, standard weights, 1x redundancy, 2x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 2
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(1)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '1000.00',
+    maxStoragePriceTBMonth: '800.00',
+    maxUploadPriceTB: '200.00',
+  })
+})
+
+test('with estimates of 1 TB, standard weights, 2x redundancy, 2x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 2
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(2)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '666.67',
+    maxStoragePriceTBMonth: '533.33',
+    maxUploadPriceTB: '133.33',
+  })
+})
+
+test('with estimates of 1 TB, standard weights, 3x redunancy, 2x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 2
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(3)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '500.00',
+    maxStoragePriceTBMonth: '400.00',
+    maxUploadPriceTB: '100.00',
+  })
+})
+
+test('with mostly storage, standard weights, 1x redunancy, 2x allowance factor', () => {
+  const allowanceMonth = new BigNumber(10_000)
+  const allowanceFactor = 2
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(20)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(1)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '952.38',
+    maxStoragePriceTBMonth: '761.90',
+    maxUploadPriceTB: '190.48',
+  })
+})
+
+test('with varied estimates, standard weights, 1x redunancy, 2x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const allowanceFactor = 2
+  const storageTB = new BigNumber(8)
+  const downloadTBMonth = new BigNumber(15)
+  const uploadTBMonth = new BigNumber(3)
+  const redundancyMultiplier = new BigNumber(1)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '90.91',
+    maxStoragePriceTBMonth: '72.73',
+    maxUploadPriceTB: '18.18',
+  })
+})
+
+test('with estimates of 1 TB, standard weights, 1x redundancy, 1.5x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const storageTB = new BigNumber(1)
+  const downloadTBMonth = new BigNumber(1)
+  const uploadTBMonth = new BigNumber(1)
+  const redundancyMultiplier = new BigNumber(1)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+  const allowanceFactor = 1.5
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '750.00',
+    maxStoragePriceTBMonth: '600.00',
+    maxUploadPriceTB: '150.00',
+  })
+})
+
+test('with varied estimates, standard weights, 1x redundancy, 1.5x allowance factor', () => {
+  const allowanceMonth = new BigNumber(1000)
+  const storageTB = new BigNumber(8)
+  const downloadTBMonth = new BigNumber(15)
+  const uploadTBMonth = new BigNumber(3)
+  const redundancyMultiplier = new BigNumber(1)
+  const storageWeight = 4
+  const downloadWeight = 5
+  const uploadWeight = 1
+  const allowanceFactor = 1.5
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    allowanceFactor,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+    storageWeight,
+    downloadWeight,
+    uploadWeight,
+  })
+
+  expect(prices).not.toBeNull()
+  expect({
+    maxStoragePriceTBMonth: prices.maxStoragePriceTBMonth.toFixed(2),
+    maxDownloadPriceTB: prices.maxDownloadPriceTB.toFixed(2),
+    maxUploadPriceTB: prices.maxUploadPriceTB.toFixed(2),
+  }).toEqual({
+    maxDownloadPriceTB: '68.18',
+    maxStoragePriceTBMonth: '54.55',
+    maxUploadPriceTB: '13.64',
+  })
+})
+
+test('with zero allowance returns null', () => {
+  const allowanceMonth = new BigNumber(0)
+  const storageTB = new BigNumber(8)
+  const downloadTBMonth = new BigNumber(15)
+  const uploadTBMonth = new BigNumber(3)
+  const redundancyMultiplier = new BigNumber(1)
+
+  const prices = derivePricingFromAllowance({
+    allowanceMonth,
+    storageTB,
+    downloadTBMonth,
+    uploadTBMonth,
+    redundancyMultiplier,
+  })
+
+  expect(prices).toBeNull()
+})

--- a/apps/renterd/contexts/config/derivePricesFromAllowance.ts
+++ b/apps/renterd/contexts/config/derivePricesFromAllowance.ts
@@ -1,0 +1,97 @@
+import BigNumber from 'bignumber.js'
+
+/**
+ * This function calculates the max price per TB for storage, download, and
+ * upload given a total spending allowance and estimated usage in TB for each
+ * type. The prices are kept proportional to each other using the weight factors
+ * provided as parameters. Storage and upload are also scaled by the redundancy
+ * multiplier.
+ *
+ * The total cost equation is:
+ * allowance * allowanceFactor = scaledAllowance =
+ *   storageTBWithRedundancy * storageWeight * unitCost +
+ *   downloadTBMonth * downloadWeight * unitCost +
+ *   uploadTBMonthWithRedundancy * uploadWeight * unitCost
+ *
+ * Once the unit cost is determined, the individual prices can be calculated:
+ * maxUploadPriceTB = unitCost * uploadWeight
+ * maxDownloadPriceTB = unitCost * downloadWeight
+ * maxStoragePriceTBMonth = unitCost * storageWeight
+ *
+ * The function also includes an allowance scaling factor to account for
+ * contract price variation. For example, if a user expects to pay $2 per TB,
+ * they should set the max value to $4 per TB because the optimal contracts may
+ * vary, eg: one contract at $1 and another at $3 which average to $2. The
+ * scaling factor helps avoid unnecessary churn.
+ *
+ * @param params - The parameters for the function.
+ * @param params.allowanceMonth - The total spending allowance per month.
+ * @param params.allowanceFactor - The scaling factor to apply to the allowance.
+ * @param params.storageTB - The estimated amount of storage in TB.
+ * @param params.downloadTBMonth - The estimated amount of download in TB per
+ * month.
+ * @param params.uploadTBMonth - The estimated amount of upload in TB per month.
+ * @param params.redundancyMultiplier - The redundancy multiplier.
+ * @param params.storageWeight - The weight factor for storage.
+ * @param params.downloadWeight - The weight factor for download.
+ * @param params.uploadWeight - The weight factor for upload.
+ * @returns An object containing the price per TB for storage, download, and
+ * upload.
+ */
+export function derivePricingFromAllowance({
+  allowanceMonth,
+  allowanceFactor = 1.5,
+  storageTB,
+  downloadTBMonth,
+  uploadTBMonth,
+  redundancyMultiplier,
+  storageWeight = 4,
+  downloadWeight = 5,
+  uploadWeight = 1,
+}: {
+  allowanceMonth: BigNumber
+  allowanceFactor?: number
+  storageTB: BigNumber
+  downloadTBMonth: BigNumber
+  uploadTBMonth: BigNumber
+  redundancyMultiplier: BigNumber
+  storageWeight?: number
+  downloadWeight?: number
+  uploadWeight?: number
+}) {
+  // Return null if zero values are provided.
+  if (
+    !allowanceMonth?.gt(0) ||
+    allowanceFactor <= 0 ||
+    !redundancyMultiplier?.gt(0) ||
+    !storageTB?.gt(0) ||
+    !downloadTBMonth?.gt(0) ||
+    !uploadTBMonth?.gt(0)
+  ) {
+    return null
+  }
+  // Apply scaling factor to allowance.
+  const scaledAllowance = allowanceMonth.times(allowanceFactor)
+
+  const storageTBWithRedundancy = storageTB.times(redundancyMultiplier)
+  const uploadTBMonthWithRedundancy = uploadTBMonth.times(redundancyMultiplier)
+
+  // Calculate the unit cost based on the provided allowance and usage estimates.
+  const unitCost = scaledAllowance.div(
+    storageTBWithRedundancy
+      .times(storageWeight)
+      .plus(downloadTBMonth.times(downloadWeight))
+      .plus(uploadTBMonthWithRedundancy.times(uploadWeight))
+  )
+
+  // Calculate the price per TB for each type of usage.
+  const maxUploadPriceTB = unitCost.times(uploadWeight)
+  const maxDownloadPriceTB = unitCost.times(downloadWeight)
+  const maxStoragePriceTBMonth = unitCost.times(storageWeight)
+
+  return {
+    maxUploadPriceTB,
+    maxDownloadPriceTB,
+    maxStoragePriceTBMonth,
+  }
+}

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -41,8 +41,8 @@ type GetFields = {
   isAutopilotEnabled: boolean
   configViewMode: ConfigViewMode
   recommendations: Partial<Record<keyof SettingsData, RecommendationItem>>
-  autoAllowance: boolean
-  setAutoAllowance: (value: boolean) => void
+  allowanceDerivedPricing: boolean
+  setAllowanceDerivedPricing: (value: boolean) => void
   validationContext: {
     isAutopilotEnabled: boolean
     configViewMode: ConfigViewMode
@@ -66,8 +66,8 @@ export function getFields({
   isAutopilotEnabled,
   configViewMode,
   validationContext,
-  autoAllowance,
-  setAutoAllowance,
+  allowanceDerivedPricing,
+  setAllowanceDerivedPricing,
 }: GetFields): ConfigFields<SettingsData, Categories> {
   return {
     // storage
@@ -125,23 +125,22 @@ export function getFields({
         <div className="pb-1">
           <Tooltip
             align="end"
-            content="Calculate value based on estimated spending per month."
+            content="Automatically calculate and set max storage, upload, and download prices based on the allowance."
           >
             <div className="flex w-full justify-between">
               <Text weight="medium" color="verySubtle" size="14">
-                Calculate
+                Calculate prices
               </Text>
               <Switch
-                aria-label="autoAllowance"
+                aria-label="allowanceDerivedPricing"
                 size="small"
-                checked={autoAllowance}
-                onCheckedChange={setAutoAllowance}
+                checked={allowanceDerivedPricing}
+                onCheckedChange={setAllowanceDerivedPricing}
               />
             </div>
           </Tooltip>
         </div>
       ),
-      readOnly: autoAllowance,
       units: 'SC/month',
       decimalsLimitSc: scDecimalPlaces,
       hidden: !isAutopilotEnabled,
@@ -402,6 +401,7 @@ export function getFields({
           of data per month.
         </>
       ),
+      readOnly: allowanceDerivedPricing,
       units: 'SC/TB/month',
       average: storageAverage,
       averageTip: 'Averages provided by Sia Central.',
@@ -461,6 +461,7 @@ export function getFields({
         </>
       ),
       units: 'SC/TB',
+      readOnly: allowanceDerivedPricing,
       average: uploadAverage,
       averageTip: 'Averages provided by Sia Central.',
       suggestion: recommendations.maxUploadPriceTB?.targetValue,
@@ -512,6 +513,7 @@ export function getFields({
       title: 'Max download price',
       description: <>The max allowed price to download 1 TB.</>,
       units: 'SC/TB',
+      readOnly: allowanceDerivedPricing,
       average: downloadAverage,
       averageTip: `Averages provided by Sia Central.`,
       suggestion: recommendations.maxDownloadPriceTB?.targetValue,

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -98,8 +98,8 @@ export function useConfigMain() {
     fields,
     configViewMode,
     setConfigViewMode,
-    autoAllowance,
-    setAutoAllowance,
+    allowanceDerivedPricing,
+    setAllowanceDerivedPricing,
   } = useForm({ resources })
 
   const remoteValues: SettingsData = useMemo(() => {
@@ -211,8 +211,8 @@ export function useConfigMain() {
     configRef,
     takeScreenshot,
     evaluation,
-    autoAllowance,
-    setAutoAllowance,
+    allowanceDerivedPricing,
+    setAllowanceDerivedPricing,
   }
 }
 

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -28,6 +28,7 @@ import {
 import { valuePerMonthToPerPeriod } from './utils'
 import { Resources } from './resources'
 import BigNumber from 'bignumber.js'
+import { derivePricingFromAllowance } from './derivePricesFromAllowance'
 
 // up
 export function transformUpAutopilot(
@@ -197,17 +198,39 @@ function filterUndefinedKeys(obj: Record<string, unknown>) {
 }
 
 export function getCalculatedValues({
-  estimatedSpendingPerMonth,
   isAutopilotEnabled,
-  autoAllowance,
+  allowanceDerivedPricing,
+  allowanceMonth,
+  storageTB,
+  downloadTBMonth,
+  uploadTBMonth,
+  redundancyMultiplier,
 }: {
-  estimatedSpendingPerMonth: BigNumber
+  allowanceMonth: BigNumber
+  storageTB: BigNumber
+  downloadTBMonth: BigNumber
+  uploadTBMonth: BigNumber
+  redundancyMultiplier: BigNumber
   isAutopilotEnabled: boolean
-  autoAllowance: boolean
+  allowanceDerivedPricing: boolean
 }) {
-  const calculatedValues: Partial<SettingsData> = {}
-  if (isAutopilotEnabled && autoAllowance && estimatedSpendingPerMonth?.gt(0)) {
-    calculatedValues.allowanceMonth = estimatedSpendingPerMonth
+  let calculatedValues: Partial<SettingsData> = {}
+  if (isAutopilotEnabled && allowanceDerivedPricing) {
+    const derivedPricing = derivePricingFromAllowance({
+      allowanceMonth,
+      allowanceFactor: 1.5,
+      storageTB,
+      downloadTBMonth,
+      uploadTBMonth,
+      redundancyMultiplier,
+      storageWeight: 4,
+      downloadWeight: 5,
+      uploadWeight: 1,
+    })
+    calculatedValues = {
+      ...calculatedValues,
+      ...derivedPricing,
+    }
   }
   return calculatedValues
 }

--- a/apps/renterd/contexts/config/useAutoCalculatedFields.tsx
+++ b/apps/renterd/contexts/config/useAutoCalculatedFields.tsx
@@ -7,29 +7,47 @@ import BigNumber from 'bignumber.js'
 
 export function useAutoCalculatedFields({
   form,
-  estimatedSpendingPerMonth,
+  allowanceMonth,
+  storageTB,
+  downloadTBMonth,
+  uploadTBMonth,
+  redundancyMultiplier,
   isAutopilotEnabled,
 }: {
   form: UseFormReturn<SettingsData>
-  estimatedSpendingPerMonth: BigNumber
+  allowanceMonth: BigNumber
+  storageTB: BigNumber
+  downloadTBMonth: BigNumber
+  uploadTBMonth: BigNumber
+  redundancyMultiplier: BigNumber
   isAutopilotEnabled: boolean
 }) {
-  const [autoAllowance, setAutoAllowance] = useLocalStorageState<boolean>(
-    'v0/config/auto/allowance',
-    {
+  const [allowanceDerivedPricing, setAllowanceDerivedPricing] =
+    useLocalStorageState<boolean>('v0/config/auto/allowance', {
       defaultValue: true,
-    }
-  )
+    })
 
   // Sync calculated values if applicable.
   const calculatedValues = useMemo(
     () =>
       getCalculatedValues({
-        estimatedSpendingPerMonth,
         isAutopilotEnabled,
-        autoAllowance,
+        allowanceDerivedPricing,
+        allowanceMonth,
+        storageTB,
+        downloadTBMonth,
+        uploadTBMonth,
+        redundancyMultiplier,
       }),
-    [estimatedSpendingPerMonth, isAutopilotEnabled, autoAllowance]
+    [
+      isAutopilotEnabled,
+      allowanceDerivedPricing,
+      allowanceMonth,
+      storageTB,
+      downloadTBMonth,
+      uploadTBMonth,
+      redundancyMultiplier,
+    ]
   )
 
   useEffect(() => {
@@ -43,7 +61,7 @@ export function useAutoCalculatedFields({
   }, [form, calculatedValues])
 
   return {
-    autoAllowance,
-    setAutoAllowance,
+    allowanceDerivedPricing,
+    setAllowanceDerivedPricing,
   }
 }

--- a/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
+++ b/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
@@ -298,8 +298,8 @@ const fields = getFields({
   minShards: new BigNumber(0),
   totalShards: new BigNumber(0),
   redundancyMultiplier: new BigNumber(0),
-  autoAllowance: false,
-  setAutoAllowance: () => null,
+  allowanceDerivedPricing: false,
+  setAllowanceDerivedPricing: () => null,
   recommendations: {},
 })
 

--- a/apps/renterd/contexts/config/useEstimates.tsx
+++ b/apps/renterd/contexts/config/useEstimates.tsx
@@ -3,84 +3,28 @@ import { useMemo } from 'react'
 
 export function useEstimates({
   isAutopilotEnabled,
-  redundancyMultiplier,
-  maxStoragePriceTBMonth,
+  allowanceMonth,
   storageTB,
-  maxDownloadPriceTB,
-  downloadTBMonth,
-  maxUploadPriceTB,
-  uploadTBMonth,
 }: {
   isAutopilotEnabled: boolean
-  redundancyMultiplier: BigNumber
-  maxStoragePriceTBMonth: BigNumber
+  allowanceMonth: BigNumber
   storageTB: BigNumber
-  maxDownloadPriceTB: BigNumber
-  downloadTBMonth: BigNumber
-  maxUploadPriceTB: BigNumber
-  uploadTBMonth: BigNumber
 }) {
   const canEstimate = useMemo(() => {
     if (!isAutopilotEnabled) {
       return false
     }
-    return (
-      maxStoragePriceTBMonth?.gt(0) &&
-      storageTB?.gt(0) &&
-      maxDownloadPriceTB?.gt(0) &&
-      maxUploadPriceTB?.gt(0)
-    )
-  }, [
-    isAutopilotEnabled,
-    maxStoragePriceTBMonth,
-    storageTB,
-    maxDownloadPriceTB,
-    maxUploadPriceTB,
-  ])
+    return !!allowanceMonth?.gt(0)
+  }, [isAutopilotEnabled, allowanceMonth])
+
+  console.log('canEstimate', canEstimate)
 
   const estimatedSpendingPerMonth = useMemo(() => {
     if (!canEstimate) {
       return new BigNumber(0)
     }
-    const _storageTB = storageTB?.gt(0) ? storageTB : new BigNumber(0)
-    const _downloadTBMonth = downloadTBMonth?.gt(0)
-      ? downloadTBMonth
-      : new BigNumber(0)
-    const _uploadTBMonth = uploadTBMonth?.gt(0)
-      ? uploadTBMonth
-      : new BigNumber(0)
-    const _maxStoragePriceTBMonth = maxStoragePriceTBMonth?.gt(0)
-      ? maxStoragePriceTBMonth
-      : new BigNumber(0)
-    const _maxUploadPriceTB = maxUploadPriceTB?.gt(0)
-      ? maxUploadPriceTB
-      : new BigNumber(0)
-    const _maxDownloadPriceTB = maxDownloadPriceTB?.gt(0)
-      ? maxDownloadPriceTB
-      : new BigNumber(0)
-
-    const storageCostPerMonth = _maxStoragePriceTBMonth
-      .times(redundancyMultiplier)
-      .times(_storageTB)
-    const downloadCostPerMonth = _maxDownloadPriceTB.times(_downloadTBMonth)
-    const uploadCostPerMonth = _maxUploadPriceTB
-      .times(redundancyMultiplier)
-      .times(_uploadTBMonth)
-
-    const totalCostPerMonth = storageCostPerMonth
-      .plus(downloadCostPerMonth)
-      .plus(uploadCostPerMonth)
-    return totalCostPerMonth
-  }, [
-    canEstimate,
-    redundancyMultiplier,
-    maxStoragePriceTBMonth,
-    storageTB,
-    maxDownloadPriceTB,
-    downloadTBMonth,
-    maxUploadPriceTB,
-    uploadTBMonth,
-  ])
+    return allowanceMonth
+  }, [canEstimate, allowanceMonth])
 
   const estimatedSpendingPerTB = useMemo(() => {
     if (!canEstimate) {

--- a/apps/renterd/contexts/config/useForm.tsx
+++ b/apps/renterd/contexts/config/useForm.tsx
@@ -17,6 +17,7 @@ export function useForm({ resources }: { resources: Resources }) {
     mode: 'all',
     defaultValues,
   })
+  const allowanceMonth = form.watch('allowanceMonth')
   const maxStoragePriceTBMonth = form.watch('maxStoragePriceTBMonth')
   const maxDownloadPriceTB = form.watch('maxDownloadPriceTB')
   const maxUploadPriceTB = form.watch('maxUploadPriceTB')
@@ -54,13 +55,8 @@ export function useForm({ resources }: { resources: Resources }) {
 
   const estimates = useEstimates({
     isAutopilotEnabled,
-    redundancyMultiplier,
-    maxStoragePriceTBMonth,
+    allowanceMonth,
     storageTB,
-    maxDownloadPriceTB,
-    downloadTBMonth,
-    maxUploadPriceTB,
-    uploadTBMonth,
   })
   const { estimatedSpendingPerMonth } = estimates
 
@@ -71,11 +67,16 @@ export function useForm({ resources }: { resources: Resources }) {
     estimatedSpendingPerMonth,
   })
 
-  const { autoAllowance, setAutoAllowance } = useAutoCalculatedFields({
-    form,
-    estimatedSpendingPerMonth,
-    isAutopilotEnabled,
-  })
+  const { allowanceDerivedPricing, setAllowanceDerivedPricing } =
+    useAutoCalculatedFields({
+      form,
+      allowanceMonth,
+      storageTB,
+      downloadTBMonth,
+      uploadTBMonth,
+      redundancyMultiplier,
+      isAutopilotEnabled,
+    })
 
   const renterdState = useBusState()
 
@@ -116,8 +117,8 @@ export function useForm({ resources }: { resources: Resources }) {
         minShards,
         totalShards,
         recommendations,
-        autoAllowance,
-        setAutoAllowance,
+        allowanceDerivedPricing,
+        setAllowanceDerivedPricing,
       })
     }
     return getFields({
@@ -131,8 +132,8 @@ export function useForm({ resources }: { resources: Resources }) {
       minShards,
       totalShards,
       recommendations,
-      autoAllowance,
-      setAutoAllowance,
+      allowanceDerivedPricing,
+      setAllowanceDerivedPricing,
     })
   }, [
     isAutopilotEnabled,
@@ -149,8 +150,8 @@ export function useForm({ resources }: { resources: Resources }) {
     minShards,
     totalShards,
     evaluation,
-    autoAllowance,
-    setAutoAllowance,
+    allowanceDerivedPricing,
+    setAllowanceDerivedPricing,
   ])
 
   return {
@@ -169,7 +170,7 @@ export function useForm({ resources }: { resources: Resources }) {
     redundancyMultiplier,
     configViewMode,
     setConfigViewMode,
-    autoAllowance,
-    setAutoAllowance,
+    allowanceDerivedPricing,
+    setAllowanceDerivedPricing,
   }
 }


### PR DESCRIPTION
Status: Ready for review

The PR adds a default option to automatically calculate max gouging prices from the user configured usage estimates and allowance.

I don't think the previous simpler `f(allowance, percents) => pricing` version really captured the intended behaviour so I expanded the equation to incorporate the user estimates, while proportionally fixing the prices according to configurable weights, default: 10% upload, 50% download, 40% storage. Let me know if this solution makes sense.

The `derivePricingFromAllowance` method calculates the max price per TB for storage, download, and upload given a total spending allowance and estimated usage in TB for each type. The prices are kept proportional to each other using the weight factors provided as parameters. Storage and upload are also scaled by the redundancy multiplier.

 The total cost equation is:
 ```
allowance * allowanceFactor = scaledAllowance =
   storageTBWithRedundancy * storageWeight * unitCost +
   downloadTBMonth * downloadWeight * unitCost +
   uploadTBMonthWithRedundancy * uploadWeight * unitCost
 ```
 
 Once the unit cost is determined, the individual prices can be calculated:
```
maxUploadPriceTB = unitCost * uploadWeight
maxDownloadPriceTB = unitCost * downloadWeight
maxStoragePriceTBMonth = unitCost * storageWeight
```

The function also includes an allowance scaling factor to account for contract price variation. For example, if a user expects to pay $2 per TB, they should set the max value to $4 per TB because the optimal contracts may vary, eg: one contract at $1 and another at $3 which average to $2. The scaling factor helps avoid unnecessary churn.

<img width="1072" alt="Screenshot 2024-07-01 at 5 01 05 PM" src="https://github.com/SiaFoundation/web/assets/1412796/de0daa01-8a15-4909-83bf-bde320edafd2">
<img width="1091" alt="Screenshot 2024-07-01 at 5 00 32 PM" src="https://github.com/SiaFoundation/web/assets/1412796/52f7d28c-7e1d-4da8-9545-5e1f41f8a8ef">

