### PR TITLE
feat: renterd contract prunable size feature

### DIFF
--- a/.changeset/four-lies-knock.md
+++ b/.changeset/four-lies-knock.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contracts table can now be sorted on prunable size.

--- a/.changeset/hot-needles-move.md
+++ b/.changeset/hot-needles-move.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The file stats no longer show reclaimable space. Closes https://github.com/SiaFoundation/renterd/issues/1247

--- a/.changeset/kind-seahorses-think.md
+++ b/.changeset/kind-seahorses-think.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contracts table now allows the user to check the prunable and expiring data size for a specific contract, across all contracts, or a filtered set of contracts. Prunable means data that the autopilot sector pruning feature would prune, expiring means prunable data outside of autopilot contracts that will likely eventually expire. Closes https://github.com/SiaFoundation/renterd/issues/1247

--- a/.changeset/rich-yaks-tan.md
+++ b/.changeset/rich-yaks-tan.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contracts contract set column tags now more clearly show whether a set is the autopilot set, default set, or both.

--- a/.changeset/seven-glasses-shout.md
+++ b/.changeset/seven-glasses-shout.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+useClientFilteredDataset now supports sorting undefined values.

--- a/.changeset/silent-books-flash.md
+++ b/.changeset/silent-books-flash.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+All contract table financial columns now show a sum total across filtered contracts in the summary row.

--- a/.changeset/stupid-balloons-rest.md
+++ b/.changeset/stupid-balloons-rest.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/units': patch
+---
+
+Fixed variable name in TBToBytes.

--- a/.changeset/tricky-phones-sparkle.md
+++ b/.changeset/tricky-phones-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+The Table header now supports an optional sticky summary row. The row shows if at least one cell renders a summary value.

--- a/apps/renterd-e2e/src/fixtures/contracts.ts
+++ b/apps/renterd-e2e/src/fixtures/contracts.ts
@@ -1,0 +1,54 @@
+import { Page, expect } from '@playwright/test'
+
+export async function getContractRowById(page: Page, id: string) {
+  return page.getByTestId('contractsTable').getByTestId(id)
+}
+
+export async function getContractsSummaryRow(page: Page) {
+  return page
+    .getByTestId('contractsTable')
+    .locator('thead')
+    .getByRole('row')
+    .nth(1)
+}
+
+export async function getContractRowByIndex(page: Page, index: number) {
+  return page
+    .getByTestId('contractsTable')
+    .locator('tbody')
+    .getByRole('row')
+    .nth(index)
+}
+
+export async function getContractRows(page: Page) {
+  return page
+    .getByTestId('contractsTable')
+    .locator('tbody')
+    .getByRole('row')
+    .all()
+}
+
+export async function toggleColumnVisibility(
+  page: Page,
+  name: string,
+  visible: boolean
+) {
+  await page.getByLabel('configure view').click()
+  const configureView = page.getByRole('dialog')
+  const columnToggle = configureView.getByRole('checkbox', {
+    name,
+  })
+
+  if (visible) {
+    await expect(columnToggle).toBeVisible()
+    if (!(await columnToggle.isChecked())) {
+      await columnToggle.click()
+    }
+  } else {
+    await expect(columnToggle).toBeHidden()
+    if (await columnToggle.isChecked()) {
+      await columnToggle.click()
+    }
+  }
+  await page.getByLabel('configure view').click()
+}

--- a/apps/renterd-e2e/src/fixtures/navigate.ts
+++ b/apps/renterd-e2e/src/fixtures/navigate.ts
@@ -5,6 +5,13 @@ export async function navigateToBuckets({ page }: { page: Page }) {
   await expect(page.getByTestId('navbar').getByText('Buckets')).toBeVisible()
 }
 
+export async function navigateToContracts({ page }: { page: Page }) {
+  await page.getByTestId('sidenav').getByLabel('Contracts').click()
+  await expect(
+    page.getByTestId('navbar').getByText('Active contracts')
+  ).toBeVisible()
+}
+
 export async function navigateToConfig({ page }: { page: Page }) {
   await page.getByTestId('sidenav').getByLabel('Configuration').click()
   await expect(

--- a/apps/renterd-e2e/src/specs/contracts.spec.ts
+++ b/apps/renterd-e2e/src/specs/contracts.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { navigateToContracts } from '../fixtures/navigate'
+import { beforeTest } from '../fixtures/beforeTest'
+import {
+  getContractRowByIndex,
+  getContractRows,
+  getContractsSummaryRow,
+  toggleColumnVisibility,
+} from '../fixtures/contracts'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page)
+})
+
+test('contracts prunable size', async ({ page }) => {
+  await navigateToContracts({ page })
+
+  // Ensure the prunable size column is visible.
+  await toggleColumnVisibility(page, 'prunable size', true)
+
+  // Check that the prunable summary is not visible.
+  const summaryRow = await getContractsSummaryRow(page)
+  const summaryRowCell = summaryRow.getByTestId('prunableSize')
+  await expect(summaryRowCell).toBeVisible()
+  await expect(summaryRowCell.getByRole('button')).toBeVisible()
+  await expect(summaryRowCell.getByLabel('prunable sizes')).toBeHidden()
+
+  // Check that the prunable size is not visible on the first row.
+  const row1 = await getContractRowByIndex(page, 0)
+  const row1Cell = row1.getByTestId('prunableSize')
+  await expect(row1Cell).toBeVisible()
+  await expect(row1Cell.getByRole('button')).toBeVisible()
+  await expect(row1Cell.getByLabel('prunable sizes')).toBeHidden()
+
+  // Fetch prunable size on the first row.
+  await row1Cell.getByRole('button').click()
+
+  // Check that the prunable size is visible on the first row but not the summary.
+  await expect(row1Cell.getByLabel('prunable sizes')).toBeVisible()
+  await expect(summaryRowCell.getByLabel('prunable sizes')).toBeHidden()
+
+  // Fetch prunable size for all contracts.
+  await summaryRowCell.getByRole('button').click()
+
+  // Check that the prunable summary is visible.
+  const summarySizes = summaryRowCell.getByLabel('prunable sizes')
+  await expect(summarySizes).toBeVisible()
+  await expect(summarySizes.getByLabel('prunable')).toBeVisible()
+  await expect(summarySizes.getByLabel('expiring')).toBeVisible()
+
+  // Check that the prunable size is visible for all contracts.
+  const rows = await getContractRows(page)
+  for (const row of rows) {
+    const prunableSizes = row.getByLabel('prunable sizes')
+    await expect(prunableSizes).toBeVisible()
+    await expect(prunableSizes).toHaveAttribute(
+      'aria-label',
+      /prunable|expiring/
+    )
+  }
+})

--- a/apps/renterd/components/Contracts/ContractsFilterBar.tsx
+++ b/apps/renterd/components/Contracts/ContractsFilterBar.tsx
@@ -3,7 +3,8 @@ import { useContracts } from '../../contexts/contracts'
 import { ContractsFilterMenu } from './ContractsFilterMenu'
 
 export function ContractsFilterBar() {
-  const { dataState, offset, limit, datasetFilteredCount, pageCount } = useContracts()
+  const { dataState, offset, limit, datasetFilteredCount, pageCount } =
+    useContracts()
 
   return (
     <div className="flex gap-2 w-full">

--- a/apps/renterd/components/Contracts/ContractsViewDropdownMenu.tsx
+++ b/apps/renterd/components/Contracts/ContractsViewDropdownMenu.tsx
@@ -54,7 +54,12 @@ export function ContractsViewDropdownMenu() {
   return (
     <Popover
       trigger={
-        <Button size="small" tip="Configure view" tipAlign="end">
+        <Button
+          aria-label="configure view"
+          size="small"
+          tip="Configure view"
+          tipAlign="end"
+        >
           <SettingsAdjust16 />
           View
           <CaretDown16 />

--- a/apps/renterd/components/Contracts/index.tsx
+++ b/apps/renterd/components/Contracts/index.tsx
@@ -79,6 +79,7 @@ export function Contracts() {
               className={cx(showDetailView ? 'pb-6 px-6' : 'p-6', 'min-w-fit')}
             >
               <Table
+                testId="contractsTable"
                 context={cellContext}
                 isLoading={dataState === 'loading'}
                 emptyState={

--- a/apps/renterd/components/Files/FilesStatsMenuShared/FilesStatsMenuSize.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenuShared/FilesStatsMenuSize.tsx
@@ -3,6 +3,7 @@ import {
   Separator,
   Text,
   Tooltip,
+  minutesInMilliseconds,
 } from '@siafoundation/design-system'
 import { useObjectStats } from '@siafoundation/renterd-react'
 import { humanBytes } from '@siafoundation/units'
@@ -12,8 +13,7 @@ export function FilesStatsMenuSize() {
     config: {
       swr: {
         // slow operation
-        refreshInterval: 60_000,
-        keepPreviousData: true,
+        refreshInterval: minutesInMilliseconds(5),
         revalidateOnFocus: false,
       },
     },
@@ -52,9 +52,6 @@ export function FilesStatsMenuSize() {
             )}
             <Separator className="w-full my-1" />
             <Text size="12" color="subtle">
-              reclaimable space
-            </Text>
-            <Text size="12" color="subtle">
               total storage utilization
             </Text>
           </Text>
@@ -67,11 +64,6 @@ export function FilesStatsMenuSize() {
               </Text>
             )}
             <Separator className="w-full my-1" />
-            <Text size="12">
-              {humanBytes(
-                stats.data.totalUploadedSize - stats.data.totalSectorsSize
-              )}
-            </Text>
             <Text size="12">{humanBytes(stats.data.totalUploadedSize)}</Text>
           </Text>
         </Text>

--- a/apps/renterd/contexts/app/index.tsx
+++ b/apps/renterd/contexts/app/index.tsx
@@ -1,9 +1,13 @@
 import React, { createContext, useContext } from 'react'
 import { useAutopilot } from './useAutopilot'
+import { useBusSdk } from './useBusSdk'
 
 function useAppMain() {
   const autopilot = useAutopilot()
+  const bus = useBusSdk()
+
   return {
+    bus,
     autopilot,
   }
 }

--- a/apps/renterd/contexts/app/useBusSdk.tsx
+++ b/apps/renterd/contexts/app/useBusSdk.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { useAppSettings } from '@siafoundation/react-core'
+import { Bus } from '@siafoundation/renterd-js'
+
+export function useBusSdk() {
+  const [bus, setBus] = useState<ReturnType<typeof Bus>>(null)
+  const {
+    settings: { api, password },
+  } = useAppSettings()
+
+  useEffect(() => {
+    setBus(
+      Bus({
+        api: `${api}/api`,
+        password,
+      })
+    )
+  }, [api, password])
+
+  return bus
+}

--- a/apps/renterd/contexts/config/useEstimates.tsx
+++ b/apps/renterd/contexts/config/useEstimates.tsx
@@ -17,8 +17,6 @@ export function useEstimates({
     return !!allowanceMonth?.gt(0)
   }, [isAutopilotEnabled, allowanceMonth])
 
-  console.log('canEstimate', canEstimate)
-
   const estimatedSpendingPerMonth = useMemo(() => {
     if (!canEstimate) {
       return new BigNumber(0)

--- a/apps/renterd/contexts/contracts/dataset.tsx
+++ b/apps/renterd/contexts/contracts/dataset.tsx
@@ -1,0 +1,132 @@
+import { useContracts as useContractsData } from '@siafoundation/renterd-react'
+import { useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+import { ContractData, ContractDataWithoutPrunable } from './types'
+import { useSiaCentralHosts } from '@siafoundation/sia-central-react'
+import { useSyncStatus } from '../../hooks/useSyncStatus'
+import { blockHeightToTime } from '@siafoundation/units'
+import { defaultDatasetRefreshInterval } from '../../config/swr'
+import { usePrunableContractSizes } from './usePrunableContractSizes'
+
+export function useDataset({
+  selectContract,
+  autopilotContractSet,
+  defaultContractSet,
+}: {
+  selectContract: (id: string) => void
+  autopilotContractSet: string
+  defaultContractSet: string
+}) {
+  const response = useContractsData({
+    config: {
+      swr: {
+        refreshInterval: defaultDatasetRefreshInterval,
+      },
+    },
+  })
+  const geo = useSiaCentralHosts()
+  const geoHosts = useMemo(() => geo.data?.hosts || [], [geo.data])
+
+  const syncStatus = useSyncStatus()
+  const currentHeight = syncStatus.isSynced
+    ? syncStatus.nodeBlockHeight
+    : syncStatus.estimatedBlockHeight
+
+  const datasetWithoutPrunable = useMemo<
+    ContractDataWithoutPrunable[] | null
+  >(() => {
+    if (!response.data) {
+      return null
+    }
+    const datums =
+      response.data?.map((c) => {
+        const isRenewed =
+          c.renewedFrom !==
+          'fcid:0000000000000000000000000000000000000000000000000000000000000000'
+        const startTime = blockHeightToTime(currentHeight, c.startHeight)
+        const endHeight = c.windowStart
+        const endTime = blockHeightToTime(currentHeight, endHeight)
+        const datum: ContractDataWithoutPrunable = {
+          id: c.id,
+          onClick: () => selectContract(c.id),
+          state: c.state,
+          hostIp: c.hostIP,
+          hostKey: c.hostKey,
+          contractSets: c.contractSets || [],
+          inAutopilotSet: c.contractSets?.includes(autopilotContractSet),
+          inDefaultSet: c.contractSets?.includes(defaultContractSet),
+          location: geoHosts.find((h) => h.public_key === c.hostKey)?.location,
+          timeline: startTime,
+          startTime,
+          endTime,
+          contractHeightStart: c.startHeight,
+          contractHeightEnd: endHeight,
+          proofWindowHeightStart: c.windowStart,
+          proofWindowHeightEnd: c.windowEnd,
+          proofHeight: c.proofHeight,
+          revisionHeight: c.revisionHeight,
+          isRenewed,
+          renewedFrom: c.renewedFrom,
+          totalCost: new BigNumber(c.totalCost),
+          spendingUploads: new BigNumber(c.spending.uploads),
+          spendingDownloads: new BigNumber(c.spending.downloads),
+          spendingFundAccount: new BigNumber(c.spending.fundAccount),
+          size: new BigNumber(c.size),
+        }
+        return datum
+      }) || []
+    return datums
+  }, [
+    response.data,
+    geoHosts,
+    currentHeight,
+    selectContract,
+    autopilotContractSet,
+    defaultContractSet,
+  ])
+
+  const {
+    prunableSizes,
+    isFetchingPrunableSizeAll,
+    isFetchingPrunableSizeById,
+    fetchPrunableSize,
+    fetchPrunableSizeAll,
+  } = usePrunableContractSizes()
+
+  const dataset = useMemo(
+    () =>
+      datasetWithoutPrunable?.map((d) => {
+        const datum: ContractData = {
+          ...d,
+          hasFetchedPrunableSize: prunableSizes[d.id]?.prunable !== undefined,
+          prunableSize:
+            prunableSizes[d.id]?.prunable !== undefined
+              ? new BigNumber(prunableSizes[d.id].prunable)
+              : undefined,
+          isFetchingPrunableSize: isFetchingPrunableSizeById[d.id],
+          fetchPrunableSize: () => fetchPrunableSize(d.id),
+        }
+        return datum
+      }) || [],
+    [
+      datasetWithoutPrunable,
+      prunableSizes,
+      fetchPrunableSize,
+      isFetchingPrunableSizeById,
+    ]
+  )
+
+  const hasFetchedAllPrunableSize = useMemo(
+    () => dataset?.every((d) => d.hasFetchedPrunableSize),
+    [dataset]
+  )
+
+  return {
+    dataset,
+    isFetchingPrunableSizeAll,
+    isFetchingPrunableSizeById,
+    fetchPrunableSize,
+    fetchPrunableSizeAll,
+    hasFetchedAllPrunableSize,
+  }
+}

--- a/apps/renterd/contexts/contracts/types.ts
+++ b/apps/renterd/contexts/contracts/types.ts
@@ -1,7 +1,25 @@
 import { ContractState } from '@siafoundation/renterd-types'
 import BigNumber from 'bignumber.js'
+import { useFilteredStats } from './useFilteredStats'
 
-export type ContractData = {
+export type ContractTableContext = {
+  currentHeight: number
+  contractsTimeRange: {
+    startHeight: number
+    endHeight: number
+  }
+  defaultContractSet?: string
+  autopilotContractSet?: string
+  siascanUrl: string
+  // prunable
+  hasFetchedAllPrunableSize: boolean
+  fetchPrunableSizeAll: () => void
+  isFetchingPrunableSizeAll: boolean
+  // totals
+  filteredStats: ReturnType<typeof useFilteredStats>
+}
+
+export type ContractDataWithoutPrunable = {
   id: string
   onClick: () => void
   hostIp: string
@@ -9,6 +27,8 @@ export type ContractData = {
   state: ContractState
   location?: [number, number]
   contractSets?: string[]
+  inAutopilotSet: boolean
+  inDefaultSet: boolean
   isRenewed: boolean
   renewedFrom: string
   timeline: number
@@ -27,6 +47,13 @@ export type ContractData = {
   size: BigNumber
 }
 
+export type ContractData = ContractDataWithoutPrunable & {
+  prunableSize?: BigNumber
+  isFetchingPrunableSize: boolean
+  hasFetchedPrunableSize: boolean
+  fetchPrunableSize: () => void
+}
+
 export type TableColumnId =
   | 'actions'
   | 'contractId'
@@ -38,6 +65,7 @@ export type TableColumnId =
   | 'startTime'
   | 'endTime'
   | 'size'
+  | 'prunableSize'
   | 'totalCost'
   | 'spendingUploads'
   | 'spendingDownloads'
@@ -51,6 +79,7 @@ export const columnsDefaultVisible: TableColumnId[] = [
   'state',
   'timeline',
   'size',
+  'prunableSize',
   'totalCost',
   'spendingUploads',
   'spendingDownloads',
@@ -66,6 +95,7 @@ export type SortField =
   | 'startTime'
   | 'endTime'
   | 'size'
+  | 'prunableSize'
   | 'totalCost'
   | 'spendingUploads'
   | 'spendingDownloads'
@@ -116,6 +146,11 @@ export const sortOptions: {
   {
     id: 'size',
     label: 'size',
+    category: 'general',
+  },
+  {
+    id: 'prunableSize',
+    label: 'prunable size',
     category: 'general',
   },
   {

--- a/apps/renterd/contexts/contracts/useFilteredStats.tsx
+++ b/apps/renterd/contexts/contracts/useFilteredStats.tsx
@@ -1,0 +1,98 @@
+import BigNumber from 'bignumber.js'
+import { useMemo } from 'react'
+import { ContractData } from './types'
+
+export function useFilteredStats({
+  datasetFiltered,
+}: {
+  datasetFiltered: ContractData[] | null
+}) {
+  const sizeTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      return acc.plus(datum.size)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  const prunableSizeTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      if (!datum.inAutopilotSet) {
+        return acc
+      }
+      return acc.plus(datum.prunableSize)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  const expiringSizeTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      if (datum.inAutopilotSet) {
+        return acc
+      }
+      return acc.plus(datum.size).minus(datum.prunableSize)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  const totalCostTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      return acc.plus(datum.totalCost)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  const spendingUploadsTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      return acc.plus(datum.spendingUploads)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  const spendingDownloadsTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      return acc.plus(datum.spendingDownloads)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  const spendingFundAccountTotal = useMemo(() => {
+    if (!datasetFiltered) {
+      return undefined
+    }
+    return datasetFiltered.reduce((acc, datum) => {
+      return acc.plus(datum.spendingFundAccount)
+    }, new BigNumber(0))
+  }, [datasetFiltered])
+
+  return useMemo(() => {
+    return {
+      sizeTotal,
+      prunableSizeTotal,
+      expiringSizeTotal,
+      totalCostTotal,
+      spendingUploadsTotal,
+      spendingDownloadsTotal,
+      spendingFundAccountTotal,
+    }
+  }, [
+    sizeTotal,
+    prunableSizeTotal,
+    expiringSizeTotal,
+    totalCostTotal,
+    spendingUploadsTotal,
+    spendingDownloadsTotal,
+    spendingFundAccountTotal,
+  ])
+}

--- a/apps/renterd/contexts/contracts/usePrunableContractSizes.tsx
+++ b/apps/renterd/contexts/contracts/usePrunableContractSizes.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useState } from 'react'
+import { triggerErrorToast } from '@siafoundation/design-system'
+import { useApp } from '../app'
+import { FileContractID } from '@siafoundation/types'
+
+type PrunableSizeData = { id: FileContractID; size: number; prunable: number }
+type PrunableSizes = Record<FileContractID, PrunableSizeData>
+
+export function usePrunableContractSizes() {
+  const { bus } = useApp()
+
+  const [prunableSizes, setPrunableSizes] = useState<PrunableSizes>({})
+  const [isFetchingPrunableSizeById, setIsFetchingPrunableById] = useState({})
+  const [isFetchingPrunableSizeAll, setIsFetchingPrunableAll] = useState(false)
+
+  const fetchPrunableSizeAll = useCallback(async () => {
+    try {
+      setIsFetchingPrunableAll(true)
+      const prunable = await bus?.contractsPrunable()
+      setPrunableSizes((data) => ({
+        ...data,
+        ...prunable.data?.contracts.reduce(
+          (acc, contract) => ({
+            ...acc,
+            [contract.id]: {
+              id: contract.id,
+              size: contract.size,
+              prunable: contract.prunable,
+            },
+          }),
+          {}
+        ),
+      }))
+    } catch (err) {
+      triggerErrorToast({ title: 'Error', body: err.message })
+    } finally {
+      setIsFetchingPrunableAll(false)
+    }
+  }, [bus])
+
+  const fetchPrunableSize = useCallback(
+    async (id: string) => {
+      try {
+        setIsFetchingPrunableById((data) => ({
+          ...data,
+          [id]: true,
+        }))
+        const prunable = await bus?.contractSize({ params: { id } })
+        setPrunableSizes((data) => ({
+          ...data,
+          [id]: {
+            id,
+            ...prunable.data,
+          },
+        }))
+      } catch (err) {
+        triggerErrorToast({ title: 'Error', body: err.message })
+      } finally {
+        setIsFetchingPrunableById((data) => ({
+          ...data,
+          [id]: false,
+        }))
+      }
+    },
+    [bus]
+  )
+
+  return {
+    prunableSizes,
+    isFetchingPrunableSizeAll,
+    isFetchingPrunableSizeById,
+    fetchPrunableSize,
+    fetchPrunableSizeAll,
+  }
+}

--- a/apps/walletd-e2e/src/fixtures/table.ts
+++ b/apps/walletd-e2e/src/fixtures/table.ts
@@ -1,0 +1,10 @@
+import { Page } from '@playwright/test'
+
+export async function waitForTableToReload(page: Page, tableTestId: string) {
+  await page
+    .locator(`[data-testid=${tableTestId}][data-loading=true]`)
+    .isVisible()
+  await page
+    .locator(`[data-testid=${tableTestId}][data-loading=false]`)
+    .isVisible()
+}

--- a/apps/walletd-e2e/src/fixtures/wallet.ts
+++ b/apps/walletd-e2e/src/fixtures/wallet.ts
@@ -1,6 +1,7 @@
 import { BrowserContext, expect, Page } from '@playwright/test'
 import { fillTextInputByName } from './textInput'
 import { clickTextareaByName, fillTextareaByName } from './textarea'
+import { waitForTableToReload } from './table'
 
 export async function createNewWallet(
   page: Page,
@@ -59,8 +60,9 @@ export async function unlockWallet(page: Page, name: string, mnemonic: string) {
 }
 
 export async function deleteWalletIfExists(page: Page, name: string) {
+  await waitForTableToReload(page, 'walletsTable')
   const doesWalletExist = await page
-    .getByRole('table')
+    .getByTestId('walletsTable')
     .getByText(name)
     .first()
     .isVisible()

--- a/apps/walletd-e2e/src/specs/seedSendSiacoin.spec.ts
+++ b/apps/walletd-e2e/src/specs/seedSendSiacoin.spec.ts
@@ -54,7 +54,7 @@ test('send siacoin with a seed wallet', async ({ page }) => {
       .getByTestId('eventsTable')
       .locator('tbody tr')
       .first()
-      .locator('[data-columnid="amount"]')
+      .getByTestId('amount')
       .getByText(`-${amountWithFeeString}`)
   ).toBeVisible()
 })

--- a/apps/walletd/components/WalletsList/index.tsx
+++ b/apps/walletd/components/WalletsList/index.tsx
@@ -37,6 +37,7 @@ export function WalletsList() {
         {dataState === 'noneYet' && <StateNoneYet />}
         {dataState !== 'noneYet' && (
           <Table
+            testId="walletsTable"
             isLoading={dataState === 'loading'}
             emptyState={
               dataState === 'noneMatchingFilters' ? (

--- a/libs/design-system/src/components/Table/TableRow.tsx
+++ b/libs/design-system/src/components/Table/TableRow.tsx
@@ -111,15 +111,15 @@ export function createTableRow<
             ) => (
               <td
                 key={`${id}/${data.id}`}
-                data-columnid={id}
+                data-testid={id}
                 className={cx(
                   getCellClassNames(
                     i,
                     cx(cellClassName, rowCellClassName),
                     false
                   ),
-                  // must use shadow based borders on the individual tds because a tailwind ring
-                  // on the tr does not show up correctly in Safari
+                  // Must use shadow based borders on the individual tds because a tailwind ring
+                  // on the tr does not show up correctly in Safari.
                   focusId && focusId === data.id
                     ? [
                         'shadow-border-y',

--- a/libs/design-system/src/components/Table/index.tsx
+++ b/libs/design-system/src/components/Table/index.tsx
@@ -49,6 +49,7 @@ export type TableColumn<Columns, Data, Context> = {
   rowCellClassName?: string
   rowContentClassName?: string
   render: React.FC<Row<Data, Context>>
+  summary?: React.FC<{ context?: Context }>
 }
 
 type Props<
@@ -155,6 +156,14 @@ export function Table<
 
   const sensors = useSensors(mouseSensor, touchSensor)
 
+  const atLeastOneSummaryEl = useMemo(
+    () =>
+      columns.some(({ summary: Render }) => {
+        return Render && Render({ context })
+      }),
+    [columns, context]
+  )
+
   return (
     <DndContext
       sensors={sensors}
@@ -209,12 +218,13 @@ export function Table<
                   return (
                     <th
                       key={id}
+                      data-testid={id}
                       className={cx(
                         getCellClassNames(i, cellClassName, false),
                         'border-b border-gray-400 dark:border-graydark-400'
                       )}
                     >
-                      <div className={cx('overflow-hidden', 'py-3')}>
+                      <div className="overflow-hidden py-3">
                         <div
                           onClick={() => {
                             if (isSortable) {
@@ -252,7 +262,6 @@ export function Table<
                               <CaretUp16 className="scale-75" />
                             </Text>
                           )}
-                          {/* {tip && <InfoTip>{tip}</InfoTip>} */}
                         </div>
                       </div>
                     </th>
@@ -260,6 +269,38 @@ export function Table<
                 }
               )}
             </tr>
+            {atLeastOneSummaryEl && (
+              <tr>
+                {columns.map(
+                  (
+                    { id, cellClassName, contentClassName, summary: Summary },
+                    i
+                  ) => {
+                    return (
+                      <th
+                        key={id}
+                        data-testid={id}
+                        className={cx(
+                          getCellClassNames(i, cellClassName, false),
+                          'border-b border-gray-400 dark:border-graydark-400',
+                          'relative -top-px'
+                        )}
+                      >
+                        <div className="overflow-hidden py-3">
+                          <div
+                            className={cx(
+                              getContentClassNames(i, contentClassName)
+                            )}
+                          >
+                            {Summary && <Summary context={context} />}
+                          </div>
+                        </div>
+                      </th>
+                    )
+                  }
+                )}
+              </tr>
+            )}
           </thead>
           <tbody className="bg-gray-50 dark:bg-graydark-50">
             {show === 'currentData' &&

--- a/libs/design-system/src/core/PoolCombo.tsx
+++ b/libs/design-system/src/core/PoolCombo.tsx
@@ -17,6 +17,8 @@ export function PoolCombo({ values, options, onChange }: Props) {
       {options.map((option) => {
         return (
           <Button
+            role="checkbox"
+            aria-checked={values.includes(option.value)}
             key={option.value}
             variant={values.includes(option.value) ? 'active' : 'inactive'}
             onClick={() => {

--- a/libs/design-system/src/hooks/useClientFilteredDataset.ts
+++ b/libs/design-system/src/hooks/useClientFilteredDataset.ts
@@ -40,10 +40,22 @@ export function useClientFilteredDataset<
       const aVal = a[sortField]
       const bVal = b[sortField]
       if (sortDirection === 'desc') {
+        if (aVal === undefined) {
+          return 1
+        }
+        if (bVal === undefined) {
+          return -1
+        }
         if (aVal instanceof BigNumber && bVal instanceof BigNumber) {
           return aVal.lte(bVal) ? 1 : -1
         }
         return aVal <= bVal ? 1 : -1
+      }
+      if (aVal === undefined) {
+        return -1
+      }
+      if (bVal === undefined) {
+        return 1
       }
       if (aVal instanceof BigNumber && bVal instanceof BigNumber) {
         return aVal.gte(bVal) ? 1 : -1

--- a/libs/units/src/bytes.ts
+++ b/libs/units/src/bytes.ts
@@ -40,8 +40,8 @@ export function bytesToTB(bytes: BigNumber | string | number): BigNumber {
 }
 
 // function converts TB to bytes
-export function TBToBytes(TiB: BigNumber | string | number): BigNumber {
-  return new BigNumber(TiB).times(1000).times(1000).times(1000).times(1000)
+export function TBToBytes(TB: BigNumber | string | number): BigNumber {
+  return new BigNumber(TB).times(1000).times(1000).times(1000).times(1000)
 }
 
 // function converts bytes to GB


### PR DESCRIPTION
- The file stats no longer show reclaimable space.
- The contracts table now allows the user to check the prunable and expiring data size for a specific contract, across all contracts, or a filtered set of contracts. Prunable means data that the autopilot sector pruning feature would prune, expiring means prunable data outside of autopilot contracts that will likely eventually expire.
- The contracts contract set column tags now more clearly show whether a set is the autopilot set, default set, or both.
- All contract table financial columns now show a sum total across filtered contracts in the summary row.
<img width="1915" alt="Screenshot 2024-07-09 at 4 19 00 PM" src="https://github.com/SiaFoundation/web/assets/1412796/9669f9f4-1e36-46c7-ae85-5750b2b2bd5c">
<img width="960" alt="Screenshot 2024-07-09 at 4 20 28 PM" src="https://github.com/SiaFoundation/web/assets/1412796/be4e67be-dd00-4a6f-b4f5-fc7188f4e415">
<img width="563" alt="Screenshot 2024-07-09 at 4 11 10 PM" src="https://github.com/SiaFoundation/web/assets/1412796/46290da2-e310-4cba-bee3-210334173550">
<img width="472" alt="Screenshot 2024-07-09 at 4 08 46 PM" src="https://github.com/SiaFoundation/web/assets/1412796/bbcce602-bd40-4560-a6ac-531bb93e3f24">
<img width="458" alt="Screenshot 2024-07-09 at 4 08 32 PM" src="https://github.com/SiaFoundation/web/assets/1412796/0f34b173-f56f-41a6-b2d1-d31f3fe93b6c">
<img width="486" alt="Screenshot 2024-07-09 at 4 08 09 PM" src="https://github.com/SiaFoundation/web/assets/1412796/bf591a92-9822-4990-a546-0824c255d37a">
