### PR TITLE
fix: remove 1 px margin between in scroll bar holder and scroll bar

### DIFF
--- a/libs/design-system/src/core/ScrollArea.tsx
+++ b/libs/design-system/src/core/ScrollArea.tsx
@@ -31,7 +31,7 @@ export const ScrollArea = React.forwardRef<
     <ScrollAreaPrimitive.Scrollbar
       key={keyToResetScrollbars ? `v-${keyToResetScrollbars}` : undefined}
       orientation="vertical"
-      className="z-10 flex select-none touch-none transition-colors hover:bg-black/20 w-1.5 m-px"
+      className="z-10 flex select-none touch-none transition-colors hover:bg-black/20 w-1.5"
     >
       <ScrollAreaPrimitive.Thumb
         className={cx(
@@ -43,7 +43,7 @@ export const ScrollArea = React.forwardRef<
     <ScrollAreaPrimitive.Scrollbar
       key={keyToResetScrollbars ? `h-${keyToResetScrollbars}` : undefined}
       orientation="horizontal"
-      className="z-10 flex flex-col select-none touch-none transition-colors duration-1000 hover:bg-black/20 h-1 m-px"
+      className="z-10 flex flex-col select-none touch-none transition-colors duration-1000 hover:bg-black/20 h-1"
     >
       <ScrollAreaPrimitive.Thumb
         className={cx(


### PR DESCRIPTION
This would fix [issue](https://github.com/SiaFoundation/hostd/issues/423)

The more elegant fix would be:
- create a invisible bar on top the actual scroll bar without the margin.
- and make current scroll bar unclickable, that should keep the visual the same - but would complicated code.

If you like this simple approach then please merge this. Thank you!