### PR TITLE
fix: scrollbar flush edge

### DIFF
--- a/.changeset/cool-spies-laugh.md
+++ b/.changeset/cool-spies-laugh.md
@@ -1,0 +1,9 @@
+---
+'explorer': patch
+'hostd': patch
+'renterd': patch
+'walletd': patch
+'website': patch
+---
+
+Fixed an issue where scrollbars could not be grabbed by moving mouse to the edge of the screen. Closes https://github.com/SiaFoundation/hostd/issues/423 Fixed by https://github.com/kocoten1992


### PR DESCRIPTION
- Fixed an issue where scrollbars could not be grabbed by moving mouse to the edge of the screen. https://github.com/SiaFoundation/hostd/issues/423 Fixed by https://github.com/kocoten1992

