### PR TITLE
fix: website walletd testnet label

### DIFF
--- a/.changeset/fifty-hornets-begin.md
+++ b/.changeset/fifty-hornets-begin.md
@@ -1,0 +1,5 @@
+---
+'website': patch
+---
+
+The testnet prefix label was removed from the walletd downloads. Closes https://github.com/SiaFoundation/web/issues/667

--- a/apps/website/components/CalloutCoreSoftware.tsx
+++ b/apps/website/components/CalloutCoreSoftware.tsx
@@ -17,7 +17,6 @@ type Props = {
   image?: string
   background: string
   children?: React.ReactNode
-  testnetOnly?: boolean
 }
 
 export function CalloutCoreSoftware({

--- a/apps/website/components/CalloutWalletd.tsx
+++ b/apps/website/components/CalloutWalletd.tsx
@@ -11,7 +11,6 @@ export function CalloutWalletd() {
       }
       status="beta"
       daemon="walletd"
-      testnetOnly
       href={routes.software.walletd}
       image={getAssetUrl('assets/walletd/send.png')}
       background={patterns.nateTrickle}

--- a/apps/website/components/DownloadSection.tsx
+++ b/apps/website/components/DownloadSection.tsx
@@ -18,14 +18,16 @@ type Props = {
   daemon: Daemon
   releaseDaemon: GitHubRelease
   releaseDesktop: GitHubRelease
-  testnetOnly?: boolean
+  statusDaemon?: string
+  statusDesktop?: string
 }
 
 export function DownloadSection({
   daemon,
   releaseDaemon,
   releaseDesktop,
-  testnetOnly,
+  statusDaemon,
+  statusDesktop,
 }: Props) {
   const guideUrl = webLinks.docs[daemon]
   const docsUrl = webLinks.apiDocs[daemon]
@@ -42,27 +44,20 @@ export function DownloadSection({
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 justify-center items-center">
         <DownloadCard
           background={backgrounds.bamboo}
-          status="beta"
+          status={statusDesktop}
           title="Desktop application"
           description="Download the full-featured desktop app for Windows, macOS, or Linux."
           downloadSelect={
-            <DownloadDesktopSelect
-              daemon={daemon}
-              release={releaseDesktop}
-              testnetOnly={testnetOnly}
-            />
+            <DownloadDesktopSelect daemon={daemon} release={releaseDesktop} />
           }
         />
         <DownloadCard
           background={backgrounds.ocean}
+          status={statusDaemon}
           title="Terminal application"
           description="Download the powerful CLI-based daemon for Windows, macOS, or Linux."
           downloadSelect={
-            <DownloadDaemonSelect
-              daemon={daemon}
-              release={releaseDaemon}
-              testnetOnly={testnetOnly}
-            />
+            <DownloadDaemonSelect daemon={daemon} release={releaseDaemon} />
           }
         />
       </div>

--- a/apps/website/pages/host/index.tsx
+++ b/apps/website/pages/host/index.tsx
@@ -61,6 +61,7 @@ export default function Host({
           daemon="hostd"
           releaseDaemon={releaseDaemon}
           releaseDesktop={releaseDesktop}
+          statusDesktop="beta"
         />
         <div className="flex flex-col">
           <SiteHeading

--- a/apps/website/pages/rent/index.tsx
+++ b/apps/website/pages/rent/index.tsx
@@ -61,6 +61,7 @@ export default function Rent({
           daemon="renterd"
           releaseDaemon={releaseDaemon}
           releaseDesktop={releaseDesktop}
+          statusDesktop="beta"
         />
         <div className="flex flex-col">
           <SiteHeading

--- a/apps/website/pages/software/hostd.tsx
+++ b/apps/website/pages/software/hostd.tsx
@@ -76,6 +76,7 @@ export default function Hostd({
             daemon={daemon}
             releaseDaemon={releaseDaemon}
             releaseDesktop={releaseDesktop}
+            statusDesktop="beta"
           />
           <div ref={appRef} className="absolute top-[70%]" />
           <div

--- a/apps/website/pages/software/renterd.tsx
+++ b/apps/website/pages/software/renterd.tsx
@@ -75,6 +75,7 @@ export default function Renterd({
             daemon={daemon}
             releaseDaemon={releaseDaemon}
             releaseDesktop={releaseDesktop}
+            statusDesktop="beta"
           />
           <div ref={appRef} className="absolute top-[70%]" />
           <div

--- a/apps/website/pages/software/walletd.tsx
+++ b/apps/website/pages/software/walletd.tsx
@@ -77,7 +77,8 @@ export default function Walletd({
           daemon={daemon}
           releaseDaemon={releaseDaemon}
           releaseDesktop={releaseDesktop}
-          testnetOnly
+          statusDaemon="beta"
+          statusDesktop="beta"
         />
         <div className="relative">
           <div ref={appRef} className="absolute top-[70%]" />

--- a/apps/website/pages/wallet/index.tsx
+++ b/apps/website/pages/wallet/index.tsx
@@ -24,6 +24,7 @@ import {
   getWalletdLatestDaemonRelease,
   getWalletdLatestDesktopRelease,
 } from '../../content/releases'
+import { DownloadSection } from '../../components/DownloadSection'
 
 const title = 'Wallet'
 const description = 'Manage your wallet on the Sia network.'
@@ -56,7 +57,13 @@ export default function Wallet({
       previewImage={previews.jungle}
     >
       <SectionGradient className="pb-20">
-        {/* <DownloadBar daemon="walletd" release={release} testnetOnly /> */}
+        <DownloadSection
+          daemon="walletd"
+          releaseDaemon={releaseDaemon}
+          releaseDesktop={releaseDesktop}
+          statusDaemon="beta"
+          statusDesktop="beta"
+        />
         <div className="flex flex-col">
           <SiteHeading
             size="32"


### PR DESCRIPTION
- The testnet prefix label was removed from the walletd downloads. https://github.com/SiaFoundation/web/issues/667
