### PR TITLE
fix: renterd network names

### DIFF
--- a/.changeset/stupid-jars-obey.md
+++ b/.changeset/stupid-jars-obey.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Added support for the new network naming scheme and the anagami testnet.

--- a/apps/renterd/components/RenterdTestnetWarningBanner.tsx
+++ b/apps/renterd/components/RenterdTestnetWarningBanner.tsx
@@ -10,7 +10,7 @@ export function RenterdTestnetWarningBanner() {
     },
   })
 
-  if (!state.data || state.data.network === 'Mainnet') {
+  if (!state.data || state.data.network === 'mainnet') {
     return null
   }
 

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -165,7 +165,7 @@ describe('tansforms', () => {
     it('up autopilot', () => {
       expect(
         transformUpAutopilot(
-          'Mainnet',
+          'mainnet',
           {
             autopilotContractSet: 'autopilot',
             allowanceMonth: new BigNumber('6006'),
@@ -207,7 +207,7 @@ describe('tansforms', () => {
     it('up autopilot accepts unknown values', () => {
       expect(
         transformUpAutopilot(
-          'Mainnet',
+          'mainnet',
           {
             autopilotContractSet: 'autopilot',
             allowanceMonth: new BigNumber('6006'),
@@ -262,7 +262,7 @@ describe('tansforms', () => {
     it('uses testnet defaults', () => {
       expect(
         transformUpAutopilot(
-          'Zen Testnet',
+          'zen',
           {
             autopilotContractSet: 'autopilot',
             allowanceMonth: new BigNumber('6006'),
@@ -425,7 +425,7 @@ describe('tansforms', () => {
       expect(settings.downloadTBMonth).toEqual(new BigNumber('92.72'))
       // a little different due to rounding
       expect(
-        transformUpAutopilot('Mainnet', settings, autopilot).contracts.download
+        transformUpAutopilot('mainnet', settings, autopilot).contracts.download
       ).toEqual(91088814814815)
       expect(settings.maxRpcPriceMillion).toEqual(new BigNumber('0.1'))
 
@@ -447,7 +447,7 @@ describe('tansforms', () => {
       expect(settings.downloadTBMonth).toEqual(new BigNumber('92.72'))
       // Using the rounded value results in same value.
       expect(
-        transformUpAutopilot('Mainnet', settings, autopilot).contracts.download
+        transformUpAutopilot('mainnet', settings, autopilot).contracts.download
       ).toEqual(91088814814815)
     })
   })

--- a/apps/renterd/contexts/config/transformUp.spec.ts
+++ b/apps/renterd/contexts/config/transformUp.spec.ts
@@ -12,7 +12,7 @@ describe('up', () => {
   it('up autopilot', () => {
     expect(
       transformUpAutopilot(
-        'Mainnet',
+        'mainnet',
         {
           autopilotContractSet: 'autopilot',
           allowanceMonth: new BigNumber('6006'),
@@ -54,7 +54,7 @@ describe('up', () => {
   it('up autopilot accepts unknown values', () => {
     expect(
       transformUpAutopilot(
-        'Mainnet',
+        'mainnet',
         {
           autopilotContractSet: 'autopilot',
           allowanceMonth: new BigNumber('6006'),
@@ -109,7 +109,7 @@ describe('up', () => {
   it('uses testnet defaults', () => {
     expect(
       transformUpAutopilot(
-        'Zen Testnet',
+        'zen',
         {
           autopilotContractSet: 'autopilot',
           allowanceMonth: new BigNumber('6006'),
@@ -272,7 +272,7 @@ describe('up down', () => {
     expect(settings.downloadTBMonth).toEqual(new BigNumber('92.72'))
     // A little different due to rounding.
     expect(
-      transformUpAutopilot('Mainnet', settings, autopilot).contracts.download
+      transformUpAutopilot('mainnet', settings, autopilot).contracts.download
     ).toEqual(91088814814815)
     expect(settings.maxRpcPriceMillion).toEqual(new BigNumber('0.1'))
 
@@ -294,7 +294,7 @@ describe('up down', () => {
     expect(settings.downloadTBMonth).toEqual(new BigNumber('92.72'))
     // Using the rounded value results in same value.
     expect(
-      transformUpAutopilot('Mainnet', settings, autopilot).contracts.download
+      transformUpAutopilot('mainnet', settings, autopilot).contracts.download
     ).toEqual(91088814814815)
   })
 })

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -32,7 +32,7 @@ import { derivePricingFromAllowance } from './derivePricesFromAllowance'
 
 // up
 export function transformUpAutopilot(
-  network: 'Mainnet' | 'Zen Testnet',
+  network: 'mainnet' | 'zen' | 'anagami',
   values: AutopilotData,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   existingValues: AutopilotConfig | undefined

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -71,7 +71,7 @@ export type SettingsData = typeof defaultValues
 
 // advanced defaults
 export function getAdvancedDefaultAutopilot(
-  network: 'Mainnet' | 'Zen Testnet'
+  network: 'mainnet' | 'zen' | 'anagami'
 ): AutopilotData {
   return {
     // must be set
@@ -81,7 +81,7 @@ export function getAdvancedDefaultAutopilot(
     // calcuated and set
     allowanceMonth: undefined,
     // defaults
-    ...(network === 'Mainnet'
+    ...(network === 'mainnet'
       ? {
           periodWeeks: new BigNumber(6),
           renewWindowWeeks: new BigNumber(2),
@@ -121,9 +121,9 @@ export const advancedDefaultGouging: GougingData = {
 }
 
 export function getAdvancedDefaultRedundancy(
-  network: 'Mainnet' | 'Zen Testnet'
+  network: 'mainnet' | 'zen' | 'anagami'
 ): RedundancyData {
-  return network === 'Mainnet'
+  return network === 'mainnet'
     ? {
         minShards: new BigNumber(10),
         totalShards: new BigNumber(30),
@@ -135,7 +135,7 @@ export function getAdvancedDefaultRedundancy(
 }
 
 export function getAdvancedDefaults(
-  network: 'Mainnet' | 'Zen Testnet'
+  network: 'mainnet' | 'zen' | 'anagami'
 ): SettingsData {
   return {
     ...getAdvancedDefaultAutopilot(network),

--- a/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
+++ b/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
@@ -349,7 +349,7 @@ export const valuesZeroDefaults: SettingsData = {
 // current value, otherwise advanced default if there is one, otherwise zero value.
 export function mergeValuesWithDefaultsOrZeroValues(
   values: SettingsData,
-  network: 'Mainnet' | 'Zen Testnet'
+  network: 'mainnet' | 'zen' | 'anagami'
 ) {
   const merged: SettingsData = getAdvancedDefaults(network)
   // advanced defaults include undefined values, for keys without defaults.

--- a/apps/renterd/hooks/useSiascanUrl.tsx
+++ b/apps/renterd/hooks/useSiascanUrl.tsx
@@ -3,7 +3,7 @@ import { useBusState } from '@siafoundation/renterd-react'
 
 export function useSiascanUrl() {
   const network = useBusState()
-  return network.data?.network === 'Zen Testnet'
+  return network.data?.network === 'zen'
     ? webLinks.explore.testnetZen
     : webLinks.explore.mainnet
 }

--- a/libs/design-system/src/app/TestnetWarningBanner.tsx
+++ b/libs/design-system/src/app/TestnetWarningBanner.tsx
@@ -8,7 +8,7 @@ export function TestnetWarningBanner({ testnetName }: { testnetName: string }) {
         <Information16 />
       </Text>
       <Text size="14" color="lo">
-        You are on the {testnetName}.
+        You are on the {testnetName} testnet.
       </Text>
     </div>
   )

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -295,7 +295,7 @@ export function useEstimatedNetworkBlockHeight(): number {
   const res = useSWR(
     state,
     () => {
-      if (state.data?.network === 'Zen Testnet') {
+      if (state.data?.network === 'zen') {
         return getTestnetZenBlockHeight()
       }
       return getMainnetBlockHeight()

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -92,7 +92,7 @@ export const busMultipartPartRoute = '/bus/multipart/part'
 // state
 
 type BuildState = {
-  network: 'Mainnet' | 'Zen Testnet'
+  network: 'mainnet' | 'zen' | 'anagami'
   version: string
   commit: string
   OS: string


### PR DESCRIPTION
- Added support for the new network naming scheme and the anagami testnet.

