### PR TITLE
fix: renterd pricepinning autopilot config structure

### DIFF
--- a/.changeset/hip-trees-appear.md
+++ b/.changeset/hip-trees-appear.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-types': minor
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+---
+
+Updated the pricepinning configuration structure to support multiple autopilots. Closes https://github.com/SiaFoundation/renterd/issues/1448

--- a/.changeset/stupid-peaches-brake.md
+++ b/.changeset/stupid-peaches-brake.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed an issue where the pricepinning response was crashing the app. Closes https://github.com/SiaFoundation/renterd/issues/1448

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -421,9 +421,11 @@ describe('tansforms', () => {
         forexEndpointURL: '',
         threshold: 0.01,
         autopilots: {
-          allowance: {
-            pinned: true,
-            value: 1400,
+          autopilot: {
+            allowance: {
+              pinned: true,
+              value: 1400,
+            },
           },
         },
         gougingSettingsPins: {
@@ -626,9 +628,12 @@ function buildAllResponses() {
         },
       },
       autopilots: {
-        allowance: {
-          pinned: false,
-          value: 0,
+        // Update the default autopilot named 'autopilot'.
+        autopilot: {
+          allowance: {
+            pinned: false,
+            value: 0,
+          },
         },
       },
     },

--- a/apps/renterd/contexts/config/transformDown.ts
+++ b/apps/renterd/contexts/config/transformDown.ts
@@ -183,10 +183,11 @@ export function transformDownPricePinning(
     pinnedCurrency: p.currency,
     forexEndpointURL: p.forexEndpointURL,
     pinnedThreshold: new BigNumber(p.threshold).times(100),
-    shouldPinAllowance: p.autopilots?.allowance.pinned || false,
+    // Assume the default autopilot named 'autopilot'.
+    shouldPinAllowance: p.autopilots['autopilot']?.allowance.pinned || false,
     allowanceMonthPinned: toFixedMaxBigNumber(
       valuePerPeriodToPerMonth(
-        new BigNumber(p.autopilots?.allowance.value || 0),
+        new BigNumber(p.autopilots['autopilot']?.allowance.value || 0),
         // If pinned allowance is non zero, the period value will be defined.
         periodBlocks || weeksToBlocks(6)
       ),

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -163,14 +163,17 @@ export function transformUpPricePinning(
     forexEndpointURL: values.forexEndpointURL,
     threshold: values.pinnedThreshold.div(100).toNumber(),
     autopilots: {
-      allowance: {
-        pinned: values.shouldPinAllowance,
-        value: valuePerMonthToPerPeriod(
-          values.allowanceMonthPinned,
-          // If autopilot is disabled the period value may be undefined,
-          // but in that case the pinned allowance is also unused.
-          values.periodWeeks || new BigNumber(6)
-        ).toNumber(),
+      // Update the default autopilot named 'autopilot'.
+      autopilot: {
+        allowance: {
+          pinned: values.shouldPinAllowance,
+          value: valuePerMonthToPerPeriod(
+            values.allowanceMonthPinned,
+            // If autopilot is disabled the period value may be undefined,
+            // but in that case the pinned allowance is also unused.
+            values.periodWeeks || new BigNumber(6)
+          ).toNumber(),
+        },
       },
     },
     gougingSettingsPins: {

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -194,7 +194,7 @@ export type PricePinSettings = {
   threshold: number
 
   // Autopilots contains the pinned settings for every autopilot.
-  autopilots: AutopilotPins
+  autopilots: Record<string, AutopilotPins>
 
   // GougingSettingsPins contains the pinned settings for the gouging
   // settings.


### PR DESCRIPTION
- Updated the pricepinning configuration structure to support multiple autopilots. https://github.com/SiaFoundation/renterd/issues/1448
- Fixed an issue where the pricepinning response was crashing the app. https://github.com/SiaFoundation/renterd/issues/1448