### PR TITLE
fix: renterd pinned field units

### DIFF
--- a/.changeset/cyan-deers-wash.md
+++ b/.changeset/cyan-deers-wash.md
@@ -1,0 +1,8 @@
+---
+'renterd': minor
+'@siafoundation/renterd-types': minor
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+---
+
+Max RPC price is no longer pinnable.

--- a/.changeset/smart-crabs-play.md
+++ b/.changeset/smart-crabs-play.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Fixed an issue where the UI would set extremely small pinned max price values because it set values in per byte instead of TB.

--- a/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
+++ b/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
@@ -47,17 +47,14 @@ export async function configResetAllSettings({ page }: { page: Page }) {
   await setSwitchByLabel(page, 'shouldPinMaxStoragePrice', true)
   await setSwitchByLabel(page, 'shouldPinMaxDownloadPrice', true)
   await setSwitchByLabel(page, 'shouldPinMaxUploadPrice', true)
-  await setSwitchByLabel(page, 'shouldPinMaxRPCPrice', true)
 
   await fillTextInputByName(page, 'maxStoragePriceTBMonthPinned', '5')
   await fillTextInputByName(page, 'maxUploadPriceTBPinned', '5')
   await fillTextInputByName(page, 'maxDownloadPriceTBPinned', '5')
-  await fillTextInputByName(page, 'maxRPCPriceMillionPinned', '1')
 
   await setSwitchByLabel(page, 'shouldPinMaxStoragePrice', false)
   await setSwitchByLabel(page, 'shouldPinMaxDownloadPrice', false)
   await setSwitchByLabel(page, 'shouldPinMaxUploadPrice', false)
-  await setSwitchByLabel(page, 'shouldPinMaxRPCPrice', false)
 
   await fillTextInputByName(page, 'maxStoragePriceTBMonth', '3000')
   await fillTextInputByName(page, 'maxUploadPriceTB', '3000')

--- a/apps/renterd/components/Config/index.tsx
+++ b/apps/renterd/components/Config/index.tsx
@@ -30,7 +30,6 @@ export function Config() {
   const shouldPinMaxStoragePrice = form.watch('shouldPinMaxStoragePrice')
   const shouldPinMaxUploadPrice = form.watch('shouldPinMaxUploadPrice')
   const shouldPinMaxDownloadPrice = form.watch('shouldPinMaxDownloadPrice')
-  const shouldPinMaxRpcPrice = form.watch('shouldPinMaxRPCPrice')
 
   const canShowPinned = pinningEnabled && pinnedCurrency && forexEndpointURL
 
@@ -251,41 +250,11 @@ export function Config() {
               form={form}
               fields={fields}
             />
-            <PanelMenuSetting
-              id="maxRPCPriceMillionGroup"
-              title="Max RPC price"
-              description={fields.maxRPCPriceMillion.description}
-              control={
-                <div className="flex flex-col gap-1 w-[260px]">
-                  <ShouldPinSwitch
-                    name="shouldPinMaxRPCPrice"
-                    form={form}
-                    fields={fields}
-                  />
-                  {shouldPinMaxRpcPrice ? (
-                    canShowPinned ? (
-                      <ConfigurationFiat
-                        name="maxRPCPriceMillionPinned"
-                        form={form}
-                        fields={fields}
-                        currency={pinnedCurrency || undefined}
-                      />
-                    ) : (
-                      <PinnedCurrencyWarning
-                        pinningEnabled={pinningEnabled}
-                        pinnedCurrency={pinnedCurrency}
-                        forexEndpointURL={forexEndpointURL}
-                      />
-                    )
-                  ) : (
-                    <ConfigurationSiacoin
-                      name="maxRPCPriceMillion"
-                      form={form}
-                      fields={fields}
-                    />
-                  )}
-                </div>
-              }
+            <ConfigurationPanelSetting
+              autoVisibility
+              name="maxRPCPriceMillion"
+              form={form}
+              fields={fields}
             />
             <ConfigurationPanelSetting
               autoVisibility

--- a/apps/renterd/contexts/config/fieldTips/MaxRPCPrice.tsx
+++ b/apps/renterd/contexts/config/fieldTips/MaxRPCPrice.tsx
@@ -5,9 +5,8 @@ import {
 } from '@siafoundation/design-system'
 import React from 'react'
 import { Categories, RecommendationItem, SettingsData } from '../types'
-import { fiatToSiacoin, toHastings } from '@siafoundation/units'
+import { toHastings } from '@siafoundation/units'
 import { UseFormReturn } from 'react-hook-form'
-import { useForexExchangeRate } from '../useAllowanceDerivedPricing'
 import { recommendationTipContent } from './Tip'
 
 export function MaxRPCPriceTips({
@@ -35,46 +34,6 @@ export function MaxRPCPriceTips({
             fields,
             name: 'maxRPCPriceMillion',
             value: recommendationPrice,
-            options: true,
-          })
-        }
-      />
-    )
-  )
-}
-
-export function MaxRPCPricePinnedTips({
-  form,
-  fields,
-  recommendations,
-}: {
-  form: UseFormReturn<SettingsData>
-  fields: ConfigFields<SettingsData, Categories>
-  recommendations: Partial<Record<keyof SettingsData, RecommendationItem>>
-}) {
-  const exchangeRate = useForexExchangeRate({
-    form,
-  })
-  const recommendationInFiat =
-    recommendations?.maxRPCPriceMillionPinned?.targetValue
-  const recommendationInSiacoin =
-    recommendationInFiat && exchangeRate
-      ? fiatToSiacoin(recommendationInFiat, exchangeRate)
-      : null
-  return (
-    recommendationInSiacoin && (
-      <TipNumber
-        type="siacoin"
-        label="Match with more hosts"
-        tip={recommendationTipContent}
-        decimalsLimit={0}
-        value={toHastings(recommendationInSiacoin)}
-        onClick={() =>
-          formSetField({
-            form,
-            fields,
-            name: 'maxRPCPriceMillionPinned',
-            value: recommendationInFiat,
             options: true,
           })
         }

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -30,7 +30,7 @@ import {
   MaxDownloadPriceTips,
   MaxDownloadPricePinnedTips,
 } from './fieldTips/MaxDownloadPrice'
-import { MaxRPCPricePinnedTips, MaxRPCPriceTips } from './fieldTips/MaxRPCPrice'
+import { MaxRPCPriceTips } from './fieldTips/MaxRPCPrice'
 
 export const scDecimalPlaces = 6
 
@@ -670,13 +670,6 @@ export function getFields({
         },
       },
     },
-    shouldPinMaxRPCPrice: {
-      title: '',
-      description: '',
-      type: 'boolean',
-      category: 'gouging',
-      validation: {},
-    },
     maxRPCPriceMillion: {
       category: 'gouging',
       type: 'siacoin',
@@ -701,47 +694,6 @@ export function getFields({
       },
       after: ({ form, fields }) => (
         <MaxRPCPriceTips
-          form={form}
-          fields={fields}
-          recommendations={recommendations}
-        />
-      ),
-    },
-    maxRPCPriceMillionPinned: {
-      title: '',
-      description: '',
-      units: '/million',
-      type: 'fiat',
-      category: 'gouging',
-      average: averagesFiat?.rpcAverage,
-      averageTip: 'Averages provided by Sia Central.',
-      validation: {
-        validate: {
-          required: requiredIfPinningEnabled(
-            validationContext,
-            (value: BigNumber, values) => {
-              if (!values.shouldPinMaxRPCPrice) {
-                return true
-              }
-              return !!value || 'required'
-            }
-          ),
-          currency: requiredIfPinningEnabled(
-            validationContext,
-            (_, values) =>
-              !!values.pinnedCurrency || 'must select a pinned currency'
-          ),
-          range: requiredIfPinningEnabled(
-            validationContext,
-            (value: BigNumber, values) =>
-              !values.shouldPinMaxRPCPrice ||
-              value?.gt(0) ||
-              'must be greater than 0'
-          ),
-        },
-      },
-      after: ({ form, fields }) => (
-        <MaxRPCPricePinnedTips
           form={form}
           fields={fields}
           recommendations={recommendations}

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -11,7 +11,6 @@ import {
 import { SettingsData } from './types'
 import {
   blocksToWeeks,
-  monthsToBlocks,
   weeksToBlocks,
   toHastings,
   valuePerPeriodToPerMonth,
@@ -48,12 +47,12 @@ describe('tansforms', () => {
         })
       ).toEqual({
         autopilotContractSet: 'autopilot',
-        allowanceMonth: new BigNumber('500'),
+        allowanceMonth: new BigNumber('357.142857'),
         amountHosts: new BigNumber('51'),
-        periodWeeks: new BigNumber('4.285714285714286'),
+        periodWeeks: new BigNumber('6'),
         renewWindowWeeks: new BigNumber('2.2301587301587302'),
-        downloadTBMonth: new BigNumber('1.1'),
-        uploadTBMonth: new BigNumber('1.1'),
+        downloadTBMonth: new BigNumber('0.79'),
+        uploadTBMonth: new BigNumber('0.79'),
         storageTB: new BigNumber('1'),
         prune: true,
         allowRedundantIPs: false,
@@ -74,7 +73,7 @@ describe('tansforms', () => {
         migrationSurchargeMultiplier: new BigNumber(10),
         minShards: new BigNumber(10),
         totalShards: new BigNumber(30),
-        allowanceMonthPinned: new BigNumber('100'),
+        allowanceMonthPinned: new BigNumber('71.43'),
         maxStoragePriceTBMonthPinned: new BigNumber('5'),
         maxDownloadPriceTBPinned: new BigNumber('4'),
         maxUploadPriceTBPinned: new BigNumber('2'),
@@ -418,7 +417,7 @@ describe('tansforms', () => {
           autopilot: {
             allowance: {
               pinned: true,
-              value: 1000,
+              value: 1400,
             },
           },
         },
@@ -561,7 +560,7 @@ function buildAllResponses() {
         set: 'autopilot',
         amount: 51,
         allowance: toHastings(500).toString(),
-        period: monthsToBlocks(1),
+        period: weeksToBlocks(6),
         renewWindow: 2248,
         download: 1099511627776,
         upload: 1100000000000,
@@ -607,7 +606,7 @@ function buildAllResponses() {
         },
       },
       autopilots: {
-        // Update the default autopilot named 'autopilot'.
+        // The default autopilot named 'autopilot'.
         autopilot: {
           allowance: {
             pinned: false,

--- a/apps/renterd/contexts/config/transformDown.ts
+++ b/apps/renterd/contexts/config/transformDown.ts
@@ -19,8 +19,6 @@ import {
   valuePerBytePerBlockToPerTBPerMonth,
   valuePerPeriodToPerMonth,
   valuePerOneToPerMillion,
-  valuePerByteToPerTB,
-  weeksToBlocks,
 } from '@siafoundation/units'
 import BigNumber from 'bignumber.js'
 import {
@@ -173,10 +171,7 @@ export function transformDownGouging({
   }
 }
 
-export function transformDownPricePinning(
-  p: PricePinSettings,
-  periodBlocks?: number
-): PricePinData {
+export function transformDownPricePinning(p: PricePinSettings): PricePinData {
   const fixedFiat = currencyOptions.find((c) => c.id === p.currency)?.fixed || 6
   return {
     pinningEnabled: p.enabled,
@@ -186,38 +181,20 @@ export function transformDownPricePinning(
     // Assume the default autopilot named 'autopilot'.
     shouldPinAllowance: p.autopilots['autopilot']?.allowance.pinned || false,
     allowanceMonthPinned: toFixedMaxBigNumber(
-      valuePerPeriodToPerMonth(
-        new BigNumber(p.autopilots['autopilot']?.allowance.value || 0),
-        // If pinned allowance is non zero, the period value will be defined.
-        periodBlocks || weeksToBlocks(6)
-      ),
-      fixedFiat
-    ),
-    shouldPinMaxRPCPrice: p.gougingSettingsPins?.maxRPCPrice.pinned,
-    maxRPCPriceMillionPinned: toFixedMaxBigNumber(
-      valuePerOneToPerMillion(
-        new BigNumber(p.gougingSettingsPins.maxRPCPrice.value)
-      ),
+      new BigNumber(p.autopilots['autopilot']?.allowance.value || 0),
       fixedFiat
     ),
     shouldPinMaxStoragePrice: p.gougingSettingsPins?.maxStorage.pinned,
-    maxStoragePriceTBMonthPinned: toFixedMaxBigNumber(
-      valuePerBytePerBlockToPerTBPerMonth(
-        new BigNumber(p.gougingSettingsPins.maxStorage.value)
-      ),
-      fixedFiat
+    maxStoragePriceTBMonthPinned: new BigNumber(
+      p.gougingSettingsPins.maxStorage.value
     ),
     shouldPinMaxUploadPrice: p.gougingSettingsPins?.maxUpload.pinned,
-    maxUploadPriceTBPinned: toFixedMaxBigNumber(
-      valuePerByteToPerTB(new BigNumber(p.gougingSettingsPins.maxUpload.value)),
-      fixedFiat
+    maxUploadPriceTBPinned: new BigNumber(
+      p.gougingSettingsPins.maxUpload.value
     ),
     shouldPinMaxDownloadPrice: p.gougingSettingsPins?.maxDownload.pinned,
-    maxDownloadPriceTBPinned: toFixedMaxBigNumber(
-      valuePerByteToPerTB(
-        new BigNumber(p.gougingSettingsPins.maxDownload.value)
-      ),
-      fixedFiat
+    maxDownloadPriceTBPinned: new BigNumber(
+      p.gougingSettingsPins.maxDownload.value
     ),
   }
 }
@@ -270,7 +247,7 @@ export function transformDown({
       hasBeenConfigured,
     }),
     // price pinning
-    ...transformDownPricePinning(pricePinning, autopilot?.contracts.period),
+    ...transformDownPricePinning(pricePinning),
     // redundancy
     ...transformDownRedundancy(redundancy),
   }

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -16,7 +16,6 @@ import {
   TBToBytes,
   valuePerTBPerMonthToPerBytePerBlock,
   valuePerMonthToPerPeriod,
-  valuePerTBToPerByte,
   valuePerMillionToPerOne,
 } from '@siafoundation/units'
 import {
@@ -167,35 +166,22 @@ export function transformUpPricePinning(
       autopilot: {
         allowance: {
           pinned: values.shouldPinAllowance,
-          value: valuePerMonthToPerPeriod(
-            values.allowanceMonthPinned,
-            // If autopilot is disabled the period value may be undefined,
-            // but in that case the pinned allowance is also unused.
-            values.periodWeeks || new BigNumber(6)
-          ).toNumber(),
+          value: values.allowanceMonthPinned.toNumber(),
         },
       },
     },
     gougingSettingsPins: {
       maxStorage: {
         pinned: values.shouldPinMaxStoragePrice,
-        value: valuePerTBPerMonthToPerBytePerBlock(
-          values.maxStoragePriceTBMonthPinned
-        ).toNumber(),
+        value: values.maxStoragePriceTBMonthPinned.toNumber(),
       },
       maxDownload: {
         pinned: values.shouldPinMaxDownloadPrice,
-        value: valuePerTBToPerByte(values.maxDownloadPriceTBPinned).toNumber(),
+        value: values.maxDownloadPriceTBPinned.toNumber(),
       },
       maxUpload: {
         pinned: values.shouldPinMaxUploadPrice,
-        value: valuePerTBToPerByte(values.maxUploadPriceTBPinned).toNumber(),
-      },
-      maxRPCPrice: {
-        pinned: values.shouldPinMaxRPCPrice,
-        value: valuePerMillionToPerOne(
-          values.maxRPCPriceMillionPinned
-        ).toNumber(),
+        value: values.maxUploadPriceTBPinned.toNumber(),
       },
     },
   }

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -166,7 +166,12 @@ export function transformUpPricePinning(
       autopilot: {
         allowance: {
           pinned: values.shouldPinAllowance,
-          value: values.allowanceMonthPinned.toNumber(),
+          value: valuePerMonthToPerPeriod(
+            values.allowanceMonthPinned,
+            // If autopilot is disabled the period value may be undefined,
+            // but in that case the pinned allowance is also unused.
+            values.periodWeeks || new BigNumber(6)
+          ).toNumber(),
         },
       },
     },

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -64,8 +64,6 @@ export const defaultPricePinning = {
   maxStoragePriceTBMonthPinned: undefined as BigNumber | undefined,
   shouldPinMaxDownloadPrice: false,
   maxDownloadPriceTBPinned: undefined as BigNumber | undefined,
-  shouldPinMaxRPCPrice: false,
-  maxRPCPriceMillionPinned: undefined as BigNumber | undefined,
   shouldPinMaxUploadPrice: false,
   maxUploadPriceTBPinned: undefined as BigNumber | undefined,
   shouldPinAllowance: false,

--- a/apps/renterd/contexts/config/useAllowanceDerivedPricing.tsx
+++ b/apps/renterd/contexts/config/useAllowanceDerivedPricing.tsx
@@ -290,13 +290,11 @@ export function pricesToPinnedPrices({
   maxStoragePriceTBMonth,
   maxDownloadPriceTB,
   maxUploadPriceTB,
-  maxRPCPriceMillion,
 }: {
   exchangeRate?: BigNumber
   maxStoragePriceTBMonth: BigNumber
   maxDownloadPriceTB: BigNumber
   maxUploadPriceTB: BigNumber
-  maxRPCPriceMillion: BigNumber
 }) {
   if (!exchangeRate) {
     return null
@@ -308,6 +306,5 @@ export function pricesToPinnedPrices({
     ),
     maxDownloadPriceTBPinned: siacoinToFiat(maxDownloadPriceTB, exchangeRate),
     maxUploadPriceTBPinned: siacoinToFiat(maxUploadPriceTB, exchangeRate),
-    maxRPCPriceMillionPinned: siacoinToFiat(maxRPCPriceMillion, exchangeRate),
   }
 }

--- a/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
+++ b/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
@@ -269,7 +269,6 @@ export function useAutopilotEvaluations({
       maxStoragePriceTBMonth: recommended.maxStoragePriceTBMonth,
       maxDownloadPriceTB: recommended.maxDownloadPriceTB,
       maxUploadPriceTB: recommended.maxUploadPriceTB,
-      maxRPCPriceMillion: recommended.maxRPCPriceMillion,
     })
 
     const recommendedValues = {
@@ -404,7 +403,6 @@ type PinnablePrices = {
   maxStoragePriceTBMonthPinned: BigNumber
   maxUploadPriceTBPinned: BigNumber
   maxDownloadPriceTBPinned: BigNumber
-  maxRPCPriceMillionPinned: BigNumber
 }
 
 type RecommendableFields = GougingData & PinnablePrices
@@ -417,7 +415,6 @@ const fieldToHrefId: Record<keyof RecommendableFields, string> = {
   maxStoragePriceTBMonthPinned: 'maxStoragePriceTBMonthGroup',
   maxUploadPriceTBPinned: 'maxUploadPriceTBGroup',
   maxDownloadPriceTBPinned: 'maxDownloadPriceTBGroup',
-  maxRPCPriceMillionPinned: 'maxRPCPriceMillionGroup',
   maxContractPrice: 'maxContractPrice',
   hostBlockHeightLeeway: 'hostBlockHeightLeeway',
   minPriceTableValidityMinutes: 'minPriceTableValidityMinutes',
@@ -434,7 +431,6 @@ const fieldToLabel: Record<keyof RecommendableFields, string> = {
   maxStoragePriceTBMonthPinned: 'max storage price',
   maxUploadPriceTBPinned: 'max upload price',
   maxDownloadPriceTBPinned: 'max download price',
-  maxRPCPriceMillionPinned: 'max RPC price',
   maxContractPrice: 'max contract price',
   hostBlockHeightLeeway: 'host block height leeway',
   minPriceTableValidityMinutes: 'min price table validity',
@@ -461,9 +457,7 @@ export const valuesZeroDefaults: SettingsData = {
   minProtocolVersion: '',
   defaultContractSet: '',
   uploadPackingEnabled: true,
-  shouldPinMaxRPCPrice: false,
   maxRPCPriceMillion: new BigNumber(0),
-  maxRPCPriceMillionPinned: new BigNumber(0),
   shouldPinMaxStoragePrice: false,
   maxStoragePriceTBMonth: new BigNumber(0),
   maxStoragePriceTBMonthPinned: new BigNumber(0),

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -166,7 +166,6 @@ export type GougingSettingsPins = {
   maxStorage: Pin
   maxDownload: Pin
   maxUpload: Pin
-  maxRPCPrice: Pin
 }
 
 export type AutopilotPins = {


### PR DESCRIPTION
- Fixed an issue where the UI would set extremely small pinned max price values because it set values in per byte instead of TB.
- Max RPC price is no longer pinnable.