### PR TITLE
refactor: react-core hooks key format

### DIFF
--- a/.changeset/four-carpets-run.md
+++ b/.changeset/four-carpets-run.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Migrated all settings interaction to the more specific requestSettings.

--- a/.changeset/quick-bears-watch.md
+++ b/.changeset/quick-bears-watch.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Hooks keys are now a two element array that includes the request method. This fixes an issue where hooks using the same route on different methods could conflict. The mutation matcher still uses the route string without any method information.

--- a/.changeset/twenty-ants-behave.md
+++ b/.changeset/twenty-ants-behave.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Removed the unused standalone option.

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -219,9 +219,9 @@ export const columns: HostsTableColumn[] = (
       render: function LastScan({ data }) {
         const { workflows } = useWorkflows()
         const isPending = workflows.find((w) => {
-          const rhpw = w as { path?: string; payload?: RhpScanPayload }
+          const rhpw = w as { route?: string; payload?: RhpScanPayload }
           return (
-            rhpw.path?.startsWith(workerRhpScanRoute) &&
+            rhpw.route?.startsWith(workerRhpScanRoute) &&
             rhpw.payload?.hostKey === data.publicKey
           )
         })

--- a/libs/react-core/.eslintrc.json
+++ b/libs/react-core/.eslintrc.json
@@ -5,7 +5,8 @@
     "@nx/dependency-checks": [
       "error",
       {
-        "ignoredFiles": ["libs/react-core/rollup.config.js"]
+        "ignoredFiles": ["libs/react-core/rollup.config.js"],
+        "ignoredDependencies": ["undici"]
       }
     ]
   },

--- a/libs/react-core/README.md
+++ b/libs/react-core/README.md
@@ -1,17 +1,12 @@
 # react-core
 
-Core library for building React hooks for interacting with a Sia daemon.
+Core library for building [SWR](https://swr.vercel.app) React hooks for RPC with a Sia daemon.
 
 ## usage
 
-react-core APIs are for building [swr](https://swr.vercel.app) interacting with
-a Sia daemon.
-
 ### Declarative data fetching
 
-To build a hook for making a GET request to renterd for a contract we would
-create types for the params and response and use them with `HookArgsSwr` to
-ensure the resulting hook is correctly typed.
+To build a hook for making a GET request to renterd for a contract we would create types for the params and response and use them with `HookArgsSwr` to ensure the resulting hook is correctly typed.
 
 ```ts
 type ContractParams = { id: string; extra?: string }
@@ -22,9 +17,7 @@ export function useContract(
 }
 ```
 
-The resulting hook is then used like any other swr hook, the return value is an
-`SWRResponse` where data is of type `ConsensusStateResponse` and error is of
-type `SWRError`.
+The resulting hook is then used like any other SWR hook, the return value is an `SWRResponse` where data is of type `ConsensusStateResponse` and error is of type `SWRError`.
 
 ```ts
 const { data, isValidating, error } = useContract({
@@ -32,16 +25,15 @@ const { data, isValidating, error } = useContract({
 })
 ```
 
-The hook must be called with any required params. Params that are specified in
-the route string are automatically replaced with the provided values, any others
-are added to the query string. The above hook would make a request to
-`/contracts/123?extra=abc`.
+The hook must be called with any required params. Params that are specified in the route string are automatically replaced with the provided values, any others are added to the query string. The above hook would make a request to `/contracts/123?extra=abc`.
 
-#### Configure swr and axios
+### Revalidation
 
-`useGetSwr` and its siblings all accept a config object which can be used to
-configure swr and axios. For example, to refresh the data every 10 seconds and
-dedupe the request:
+The hook will automatically revalidate whenever the underlying SWR key changes. The components of the unique key are the route, request method, parameters, and payload.
+
+### Configuring SWR and Axios
+
+`useGetSwr` and its siblings all accept a config object which can be used to configure SWR and Axios. For example, to refresh the data every 10 seconds and dedupe the request:
 
 ```ts
 useGetSwr({
@@ -68,18 +60,11 @@ useGetSwr({
 })
 ```
 
-### Imperative mutations
+### Imperative methods
 
-Declarative hooks are great for fetching data, but sometimes you need a method
-that can be used more imperatively, for example when submitting a form.
+Declarative hooks are great for fetching data, but sometimes you need a method that can be used more imperatively, for example when submitting a form.
 
-`usePostFunc` and its siblings are used for imperative mutations. Instead of
-declaratively fetching, the following hook returns a method that can be called.
-Besides the `HookArgsCallback` and route string, the method takes another
-callback argument which provides access to a `mutate` function. The callback is
-triggered any time the contract add method is called successfully. The `mutate`
-function can be used to trigger revalidation on dependent keys to refresh data
-that is affected by `useContractAdd`, such as the contracts list.
+`usePostFunc` and its siblings are used for imperative methods. Instead of declaratively fetching, the hook returns a method that can be called later imperatively. Besides the `HookArgsCallback` and route string, the method takes another callback argument which provides access to a `mutate` function. The callback is triggered any time the returned method is called successfully. The `mutate` function can be used to trigger revalidation and/or optimistically mutate data on dependent routes to refresh data that is affected by the method. For example, adding a contract with `useContractAdd` may affect the contracts list therefore in the example below we revalidate data under that route.
 
 ```ts
 export function useContractAdd(
@@ -90,8 +75,8 @@ export function useContractAdd(
   >
 ) {
   return usePostFunc({ ...args, route: busContractIdNewRoute }, async (mutate) => {
-    mutate((key) => {
-      return key.startsWith(busContractRoute)
+    mutate((route) => {
+      return route.startsWith(busContractRoute)
     })
   })
 }
@@ -109,6 +94,44 @@ function handleSubmit(values: Values) {
   })
 }
 ```
+
+#### Workflows
+
+The lifecycle of imperative methods are tracked by a workflow ID. Workflows allow the consumer to check whether a call is still pending or complete from a code that may not be near the actual hook call. The following code shows a method's workflow status being looked up by matching on the route and payload.
+
+```ts
+// Hook
+export function useRhpScan(
+  args?: HookArgsCallback<RhpScanParams, RhpScanPayload, RhpScanResponse>
+) {
+  return usePostFunc({ ...args, route: workerRhpScanRoute })
+}
+
+// Usage
+const rescan = useRhpScan()
+await rescan.post({
+  payload: {
+    hostKey: publicKey,
+    hostIP: address,
+    timeout: secondsInMilliseconds(30),
+  },
+})
+```
+
+```ts
+// Check the workflow status.
+const { workflows } = useWorkflows()
+const isPending = workflows.find((w) => {
+  return (
+    w.route?.startsWith(workerRhpScanRoute) &&
+    w.payload?.hostKey === data.publicKey
+  )
+})
+```
+
+### Global mutate
+
+The `mutate` method returned by `useMutate` or the one available via callback on the imperative mutation hooks. Both match against routes. Note that this is not the same as the underlying keys which are array tuples of method and API prefixed route plus serialized params and payload. The mutate method allows matching against the plain route string.
 
 ### Typing hooks
 

--- a/libs/react-core/jest.config.ts
+++ b/libs/react-core/jest.config.ts
@@ -1,7 +1,6 @@
 /* eslint-disable */
 export default {
   displayName: 'react-core',
-  preset: '../../jest.preset.js',
   transform: {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
     '^.+\\.[tj]sx?$': [
@@ -14,4 +13,14 @@ export default {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/react-core',
+  preset: '../../jest.preset.js',
+  transformIgnorePatterns: [
+    '/node_modules/(?!d3|d3-array|d3-axis|d3-brush|d3-chord|d3-color|d3-contour|d3-delaunay|d3-dispatch|d3-drag|d3-dsv|d3-ease|d3-fetch|d3-force|d3-format|d3-geo|d3-hierarchy|d3-interpolate|d3-path|d3-polygon|d3-quadtree|d3-random|d3-scale|d3-scale-chromatic|d3-selection|d3-shape|d3-time|d3-time-format|d3-timer|d3-transition|d3-zoom}|internmap|d3-delaunay|delaunator|robust-predicates|clipboard-polyfill)',
+  ],
+  moduleNameMapper: {
+    'next/font/(.*)': require.resolve(
+      'next/dist/build/jest/__mocks__/nextFontMock.js'
+    ),
+  },
+  setupFiles: ['./jest.polyfills.js'],
 }

--- a/libs/react-core/jest.polyfills.js
+++ b/libs/react-core/jest.polyfills.js
@@ -1,0 +1,31 @@
+// jest.polyfills.js
+/**
+ * @note The block below contains polyfills for Node.js globals
+ * required for Jest to function when running JSDOM tests.
+ * These HAVE to be require's and HAVE to be in this exact
+ * order, since "undici" depends on the "TextEncoder" global API.
+ *
+ * Consider migrating to a more modern test runner if
+ * you don't want to deal with this.
+ */
+
+const { TextDecoder, TextEncoder, ReadableStream } = require('node:util')
+
+Object.defineProperties(globalThis, {
+  TextDecoder: { value: TextDecoder },
+  TextEncoder: { value: TextEncoder },
+  ReadableStream: { value: ReadableStream },
+})
+
+const { Blob, File } = require('node:buffer')
+const { fetch, Headers, FormData, Request, Response } = require('undici')
+
+Object.defineProperties(globalThis, {
+  fetch: { value: fetch, writable: true },
+  Blob: { value: Blob },
+  File: { value: File },
+  Headers: { value: Headers },
+  FormData: { value: FormData },
+  Request: { value: Request, configurable: true },
+  Response: { value: Response, configurable: true },
+})

--- a/libs/react-core/package.json
+++ b/libs/react-core/package.json
@@ -16,5 +16,8 @@
     "detect-gpu": "^5.0.34",
     "bignumber.js": "^9.0.2"
   },
+  "devDependencies": {
+    "undici": "5.28.3"
+  },
   "types": "./src/index.d.ts"
 }

--- a/libs/react-core/src/index.spec.tsx
+++ b/libs/react-core/src/index.spec.tsx
@@ -1,0 +1,253 @@
+import { AppSettingsProvider } from './appSettings'
+import { render, waitFor } from '@testing-library/react'
+import { CoreProvider } from './coreProvider'
+import { useGetSwr } from './useGet'
+import { UseMutateReturn, useMutate } from './mutate'
+import { setupServer } from 'msw/node'
+import { HttpResponse, http } from 'msw'
+import { usePostFunc, usePostSwr } from './usePost'
+import { RequestConfig, Response } from './request'
+import { delay } from './utils'
+import { WorkflowPayload, useWorkflows } from './workflows'
+import { act } from 'react-dom/test-utils'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    query: {},
+    push: jest.fn(),
+  }),
+  usePathname: jest.fn().mockReturnValue('/some-route'),
+}))
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    query: {},
+    push: jest.fn(),
+  }),
+}))
+
+const server = setupServer()
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('react-core', () => {
+  test('swr hook data fetching and mutate matcher', async () => {
+    mockEndpoint('post', '/api/a/b', 'ab')
+    mockEndpoint('get', '/api/a', 'a')
+
+    let mutate: UseMutateReturn = () => Promise.resolve([])
+    function Component() {
+      const a = useGetSwr<void, string>({
+        route: '/a',
+      })
+      const ab = usePostSwr<void, void, string>({
+        route: '/a/b',
+      })
+      mutate = useMutate()
+      const str = a.data && ab.data ? a.data + ab.data : ''
+      if (!str) return 'loading'
+      return str
+    }
+
+    const el = render(
+      <CoreProvider>
+        <AppSettingsProvider>
+          <Component />
+        </AppSettingsProvider>
+      </CoreProvider>
+    )
+
+    // Check that the initial render is correct.
+    await waitFor(() => {
+      expect(el.getByText('aab')).toBeTruthy()
+    })
+
+    // Update endpoint responses.
+    mockEndpoint('post', '/api/a/b', 'xy')
+    mockEndpoint('get', '/api/a', 'x')
+
+    // Data should be the same.
+    await waitFor(() => {
+      expect(el.getByText('aab')).toBeTruthy()
+    })
+
+    // Revalidate by route, matching does not include the api prefix.
+    mutate((route) => route.startsWith('/a'))
+
+    // Data should be updated.
+    await waitFor(() => {
+      expect(el.getByText('xxy')).toBeTruthy()
+    })
+  })
+
+  test('swr hook with same route but different payloads act as distinct keys', async () => {
+    mockEndpointByPayload('post', '/api/a')
+
+    let mutate: UseMutateReturn = () => Promise.resolve([])
+    function Component({ foo1, foo2 }: { foo1: string; foo2: string }) {
+      const a1 = usePostSwr<void, { foo: string }, { foo: string }>({
+        route: '/a',
+        payload: { foo: foo1 },
+      })
+      const a2 = usePostSwr<void, { foo: string }, { foo: string }>({
+        route: '/a',
+        payload: { foo: foo2 },
+      })
+      mutate = useMutate()
+      const str =
+        a1.data && a2.data
+          ? JSON.stringify(a1.data) + JSON.stringify(a2.data)
+          : ''
+      if (!str) return 'loading'
+      return str
+    }
+
+    const el = render(
+      <CoreProvider>
+        <AppSettingsProvider>
+          <Component foo1="bar" foo2="jazz" />
+        </AppSettingsProvider>
+      </CoreProvider>
+    )
+
+    // Check that the initial render is correct.
+    await waitFor(() => {
+      expect(el.getByText('{"foo":"bar"}{"foo":"jazz"}')).toBeTruthy()
+    })
+
+    const startingCallCount = networkCallCount
+
+    el.rerender(
+      <CoreProvider>
+        <AppSettingsProvider>
+          <Component foo1="baz" foo2="jazz" />
+        </AppSettingsProvider>
+      </CoreProvider>
+    )
+
+    await waitFor(() => {
+      // Check that the rerender is correct.
+      expect(el.getByText('{"foo":"baz"}{"foo":"jazz"}')).toBeTruthy()
+      // Check that only 1 hook was revalidated.
+      expect(networkCallCount - startingCallCount).toBe(1)
+    })
+
+    // Revalidate both by route.
+    mutate((route) => route.startsWith('/a'))
+
+    // Check that both hooks were revalidated.
+    await waitFor(() => {
+      expect(el.getByText('{"foo":"baz"}{"foo":"jazz"}')).toBeTruthy()
+      expect(networkCallCount - startingCallCount).toBe(3)
+    })
+  })
+
+  test('func is tracked by workflow and revalidates its dependencies', async () => {
+    mockEndpoint('get', '/api/dependency', 'response1')
+    mockEndpoint('post', '/api/postroute', '', 200)
+
+    let post: (args: {
+      api?: string | undefined
+      config?: RequestConfig<void, string> | undefined
+    }) => Promise<Response<string>> = () => {
+      throw new Error('not implemented')
+    }
+    let workflows: { workflows: WorkflowPayload[] } = { workflows: [] }
+
+    function Component() {
+      workflows = useWorkflows()
+      const dependency = useGetSwr<void, string>({
+        route: '/dependency',
+      })
+      const func = usePostFunc<void, void, string>(
+        {
+          route: '/postroute',
+        },
+        async (mutate) => {
+          mutate((route) => route.startsWith('/dependency'))
+        }
+      )
+      post = func.post
+      return dependency.data
+    }
+
+    const el = render(
+      <CoreProvider>
+        <AppSettingsProvider>
+          <Component />
+        </AppSettingsProvider>
+      </CoreProvider>
+    )
+
+    // Check that the initial render is correct.
+    await waitFor(() => {
+      expect(el.getByText('response1')).toBeTruthy()
+    })
+
+    // Change the dependency endpoint response.
+    mockEndpoint('get', '/api/dependency', 'response2')
+
+    let promise: Promise<Response<string>> | undefined
+    act(() => {
+      // Call the post function.
+      promise = post({})
+    })
+
+    // Check that the workflow is registered.
+    expect(
+      workflows.workflows.find(
+        (w?: { route?: string }) => w?.route === '/postroute'
+      )
+    ).toBeTruthy()
+
+    await act(async () => {
+      // Wait for the promise to resolve.
+      await promise
+    })
+
+    // Check that the workflow has been removed.
+    expect(
+      workflows.workflows.find(
+        (w?: { route?: string }) => w?.route === '/postroute'
+      )
+    ).toBeFalsy()
+
+    // Dependency should have been revalidated.
+    await waitFor(() => {
+      expect(el.getByText('response2')).toBeTruthy()
+    })
+  })
+})
+
+let networkCallCount = 0
+
+function mockEndpoint(
+  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
+  route: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  response: any,
+  delayMs = 0
+) {
+  server.use(
+    http[method](route, async () => {
+      await delay(delayMs)
+      networkCallCount += 1
+      return HttpResponse.json(response)
+    })
+  )
+}
+
+function mockEndpointByPayload(
+  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
+  route: string,
+  delayMs = 0
+) {
+  server.use(
+    http[method](route, async ({ request }) => {
+      await delay(delayMs)
+      networkCallCount += 1
+      return HttpResponse.json(await request.json())
+    })
+  )
+}

--- a/libs/react-core/src/request.ts
+++ b/libs/react-core/src/request.ts
@@ -15,14 +15,12 @@ export type HookArgsSwr<
 > = Params extends void
   ? {
       api?: string
-      standalone?: string
       config?: RequestConfig<void, Result>
       disabled?: boolean
     }
   : {
       params: Params
       api?: string
-      standalone?: string
       config?: RequestConfig<void, Result>
       disabled?: boolean
     }
@@ -43,13 +41,11 @@ export type HookArgsWithPayloadSwr<
   ? Payload extends void
     ? {
         api?: string
-        standalone?: string
         config?: RequestConfig<void, Result>
         disabled?: boolean
       }
     : {
         api?: string
-        standalone?: string
         payload: Payload
         config?: RequestConfig<void, Result>
         disabled?: boolean
@@ -58,7 +54,6 @@ export type HookArgsWithPayloadSwr<
   ? {
       params: Params
       api?: string
-      standalone?: string
       config?: RequestConfig<void, Result>
       disabled?: boolean
     }
@@ -66,7 +61,6 @@ export type HookArgsWithPayloadSwr<
       params: Params
       payload: Payload
       api?: string
-      standalone?: string
       config?: RequestConfig<void, Result>
       disabled?: boolean
     }
@@ -190,16 +184,16 @@ export type Response<T> = {
   error?: string
 }
 
-function getApi<Params extends RequestParams, Payload, Result>(
-  settings: RequestSettings,
+function getApi(
+  requestSettings: RequestSettings,
   hookArgs:
     | {
         api?: string
       }
     | undefined,
-  callArgs: InternalCallbackArgs<Params, Payload, Result> | undefined
+  callArgs: { api?: string } | undefined
 ): string {
-  return callArgs?.api || hookArgs?.api || settings.api
+  return callArgs?.api || hookArgs?.api || requestSettings.api
 }
 
 function buildHeaders<Params extends RequestParams, Payload, Result>(
@@ -240,7 +234,7 @@ export function buildRouteWithParams<
   Result
 >(
   settings: RequestSettings,
-  route: string | null,
+  route: string,
   hookArgs:
     | {
         api?: string
@@ -248,10 +242,7 @@ export function buildRouteWithParams<
       }
     | undefined,
   callArgs: InternalCallbackArgs<Params, Payload, Result> | undefined
-): string | null {
-  if (!route) {
-    return null
-  }
+): string {
   let params = hookArgs?.params || {}
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (callArgs && (callArgs as any).params) {
@@ -262,9 +253,6 @@ export function buildRouteWithParams<
     }
   }
   route = parameterizeRoute(route, params)
-  if (!route) {
-    return null
-  }
   const api = getApi(settings, hookArgs, callArgs)
   if (api === settings.api) {
     return `${api}/api${route}`
@@ -272,22 +260,21 @@ export function buildRouteWithParams<
   return `${api}${route}`
 }
 
-export function getPathFromKey<Params extends RequestParams, Payload, Result>(
+export function getRouteFromKey(
   settings: RequestSettings,
-  route: string,
+  key: [string, string],
   hookArgs:
     | {
         api?: string
-        params?: Params
       }
     | undefined,
-  callArgs: InternalCallbackArgs<Params, Payload, Result> | undefined
+  callArgs: { api?: string } | undefined
 ): string {
   const api = getApi(settings, hookArgs, callArgs)
   if (api === settings.api) {
-    return route.replace(`${api}/api`, '')
+    return key[1].replace(`${api}/api`, '')
   }
-  return route.replace(api, '')
+  return key[1].replace(api, '')
 }
 
 export type After<Params extends RequestParams, Payload, Result> = (

--- a/libs/react-core/src/useGet.ts
+++ b/libs/react-core/src/useGet.ts
@@ -16,7 +16,7 @@ import {
 } from './request'
 import { SWRError } from './types'
 import { useAppSettings } from './appSettings'
-import { keyOrNull } from './utils'
+import { getKey, keyOrNull } from './utils'
 import { RequestParams } from '@siafoundation/request'
 import { useRequestSettings } from './appSettings/useRequestSettings'
 
@@ -33,7 +33,7 @@ export function useGetSwr<Params extends RequestParams, Result>(
   )
   return useSWR<Result, SWRError>(
     keyOrNull(
-      args.standalone ? `${args.standalone}/${reqRoute}` : reqRoute,
+      getKey('get', reqRoute),
       hookArgs.disabled ||
         (passwordProtectRequestHooks && !requestSettings.password)
     ),

--- a/libs/react-core/src/usePatch.ts
+++ b/libs/react-core/src/usePatch.ts
@@ -11,18 +11,18 @@ import {
   mergeInternalCallbackArgs,
   Response,
   mergeInternalHookArgsCallback,
-  getPathFromKey,
+  getRouteFromKey,
   After,
   InternalHookArgsWithPayloadSwr,
   mergeInternalHookArgsSwr,
   InternalHookArgsSwr,
 } from './request'
-import { useAppSettings } from './appSettings'
 import { useMemo } from 'react'
-import { keyOrNull } from './utils'
+import { getKey, keyOrNull } from './utils'
 import { SWRError } from './types'
 import { RequestParams } from '@siafoundation/request'
 import { useRequestSettings } from './appSettings/useRequestSettings'
+import { buildMutateMatcherFn } from './mutate'
 
 export function usePatchSwr<Params extends RequestParams, Payload, Result>(
   args: InternalHookArgsWithPayloadSwr<Params, Payload, Result>
@@ -42,12 +42,7 @@ export function usePatchSwr<Params extends RequestParams, Payload, Result>(
   const key = useMemo(
     () =>
       keyOrNull(
-        reqRoute
-          ? `${reqRoute}${JSON.stringify(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (args as any).payload !== undefined ? (args as any).payload : ''
-            )}`
-          : null,
+        getKey('patch', reqRoute, args as { payload: Payload }),
         hookArgs.disabled ||
           (passwordProtectRequestHooks && !requestSettings.password)
       ),
@@ -94,16 +89,16 @@ export function usePatchFunc<Params extends RequestParams, Payload, Result>(
   after?: After<Params, Payload, Result>
 ): PatchFunc<Params, Payload, Result> {
   const { mutate } = useSWRConfig()
-  const { settings } = useAppSettings()
+  const { requestSettings } = useRequestSettings()
   const { setWorkflow, removeWorkflow } = useWorkflows()
   const hookArgs = mergeInternalHookArgsCallback(args)
   return {
     patch: async (args: InternalCallbackArgs<Params, Payload, Result>) => {
       const callArgs = mergeInternalCallbackArgs(args)
       try {
-        const reqConfig = buildAxiosConfig(settings, hookArgs, callArgs)
+        const reqConfig = buildAxiosConfig(requestSettings, hookArgs, callArgs)
         const reqRoute = buildRouteWithParams(
-          settings,
+          requestSettings,
           hookArgs.route,
           hookArgs,
           callArgs
@@ -116,40 +111,30 @@ export function usePatchFunc<Params extends RequestParams, Payload, Result>(
           payload = callArgs.payload
         }
 
-        const key = `${reqRoute}${JSON.stringify(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (args as any).payload !== undefined ? (args as any).payload : ''
-        )}`
+        const key = getKey('patch', reqRoute, args as { payload: Payload })
 
-        const path = getPathFromKey(
-          settings,
-          reqRoute,
+        const route = getRouteFromKey(
+          requestSettings,
+          key,
           args,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           callArgs as any
         )
-        setWorkflow(key, {
-          path,
+        const workflowKey = key.join('')
+        setWorkflow(workflowKey, {
+          route,
           payload,
         })
         const response = await axios.patch<Result>(reqRoute, payload, reqConfig)
         if (after) {
           await after(
             (matcher, data = (d) => d, opts) =>
-              mutate(
-                (key) => {
-                  if (typeof key !== 'string') {
-                    return false
-                  }
-                  const route = getPathFromKey(
-                    settings,
-                    key,
-                    args,
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    callArgs as any
-                  )
-                  return matcher(route)
-                },
+              buildMutateMatcherFn(
+                mutate,
+                requestSettings,
+                args,
+                callArgs,
+                matcher,
                 data,
                 opts
               ),
@@ -157,7 +142,7 @@ export function usePatchFunc<Params extends RequestParams, Payload, Result>(
             response
           )
         }
-        removeWorkflow(key)
+        removeWorkflow(workflowKey)
         return {
           status: response.status,
           data: response.data,

--- a/libs/react-core/src/usePost.ts
+++ b/libs/react-core/src/usePost.ts
@@ -13,16 +13,16 @@ import {
   mergeInternalHookArgsCallback,
   mergeInternalHookArgsSwr,
   InternalHookArgsWithPayloadSwr,
-  getPathFromKey,
+  getRouteFromKey,
   After,
   InternalHookArgsSwr,
 } from './request'
 import { SWRError } from './types'
-import { useAppSettings } from './appSettings'
-import { keyOrNull } from './utils'
+import { getKey, keyOrNull } from './utils'
 import { useWorkflows } from './workflows'
 import { RequestParams } from '@siafoundation/request'
 import { useRequestSettings } from './appSettings/useRequestSettings'
+import { buildMutateMatcherFn } from './mutate'
 
 export function usePostSwr<Params extends RequestParams, Payload, Result>(
   args: InternalHookArgsWithPayloadSwr<Params, Payload, Result>
@@ -42,12 +42,7 @@ export function usePostSwr<Params extends RequestParams, Payload, Result>(
   const key = useMemo(
     () =>
       keyOrNull(
-        reqRoute
-          ? `${reqRoute}${JSON.stringify(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (args as any).payload !== undefined ? (args as any).payload : ''
-            )}`
-          : null,
+        getKey('post', reqRoute, args as { payload: Payload }),
         hookArgs.disabled ||
           (passwordProtectRequestHooks && !requestSettings.password)
       ),
@@ -95,15 +90,15 @@ export function usePostFunc<Params extends RequestParams, Payload, Result>(
 ): PostFunc<Params, Payload, Result> {
   const { setWorkflow, removeWorkflow } = useWorkflows()
   const { mutate } = useSWRConfig()
-  const { settings } = useAppSettings()
+  const { requestSettings } = useRequestSettings()
   const hookArgs = mergeInternalHookArgsCallback(args)
   return {
     post: async (args: InternalCallbackArgs<Params, Payload, Result>) => {
       const callArgs = mergeInternalCallbackArgs(args)
       try {
-        const reqConfig = buildAxiosConfig(settings, hookArgs, callArgs)
+        const reqConfig = buildAxiosConfig(requestSettings, hookArgs, callArgs)
         const reqRoute = buildRouteWithParams(
-          settings,
+          requestSettings,
           hookArgs.route,
           hookArgs,
           callArgs
@@ -116,41 +111,31 @@ export function usePostFunc<Params extends RequestParams, Payload, Result>(
           payload = callArgs.payload
         }
 
-        const key = `${reqRoute}${JSON.stringify(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (args as any).payload !== undefined ? (args as any).payload : ''
-        )}`
+        const key = getKey('post', reqRoute, args as { payload: Payload })
 
-        const path = getPathFromKey(
-          settings,
-          reqRoute,
+        const route = getRouteFromKey(
+          requestSettings,
+          key,
           args,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           callArgs as any
         )
 
-        setWorkflow(key, {
-          path,
+        const workflowKey = key.join('')
+        setWorkflow(workflowKey, {
+          route,
           payload,
         })
         const response = await axios.post<Result>(reqRoute, payload, reqConfig)
         if (after) {
           await after(
             (matcher, data = (d) => d, opts) =>
-              mutate(
-                (key) => {
-                  if (typeof key !== 'string') {
-                    return false
-                  }
-                  const route = getPathFromKey(
-                    settings,
-                    key,
-                    args,
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    callArgs as any
-                  )
-                  return matcher(route)
-                },
+              buildMutateMatcherFn(
+                mutate,
+                requestSettings,
+                args,
+                callArgs,
+                matcher,
                 data,
                 opts
               ),
@@ -158,7 +143,7 @@ export function usePostFunc<Params extends RequestParams, Payload, Result>(
             response
           )
         }
-        removeWorkflow(key)
+        removeWorkflow(workflowKey)
         return {
           status: response.status,
           data: response.data,

--- a/libs/react-core/src/utils.ts
+++ b/libs/react-core/src/utils.ts
@@ -2,7 +2,21 @@
 
 import { mutate } from 'swr'
 
-export function keyOrNull(name: string | null, disabled?: boolean) {
+type Method = 'get' | 'post' | 'put' | 'patch' | 'delete'
+export function getKey<Payload>(
+  method: Method,
+  route: string,
+  args?: {
+    payload?: Payload
+  }
+): [Method, string] {
+  return [
+    method,
+    `${route}${args?.payload ? JSON.stringify(args.payload) : ''}`,
+  ]
+}
+
+export function keyOrNull(name: string[] | null, disabled?: boolean) {
   if (!name || disabled) {
     return null
   }

--- a/libs/react-core/src/workflows.tsx
+++ b/libs/react-core/src/workflows.tsx
@@ -9,13 +9,14 @@ import {
 } from 'react'
 
 export type WorkflowPayload = Record<string, unknown> | undefined
+type Key = string
 type PendingMap = Record<string, WorkflowPayload>
 
 function useWorkflowsMain() {
   const [workflowsMap, setWorkflowsMap] = useState<PendingMap>({})
 
   const setWorkflow = useCallback(
-    (key: string, item?: WorkflowPayload) => {
+    (key: Key, item?: WorkflowPayload) => {
       setWorkflowsMap((workflows) => {
         return {
           ...workflows,
@@ -30,7 +31,7 @@ function useWorkflowsMain() {
   )
 
   const removeWorkflow = useCallback(
-    (key: string) => {
+    (key: Key) => {
       setWorkflowsMap((workflows) => {
         delete workflows[key]
         return {

--- a/libs/request/src/index.ts
+++ b/libs/request/src/index.ts
@@ -13,9 +13,9 @@ export type RequestParams = Record<
 > | void
 
 export function parameterizeRoute(
-  route: string | null,
+  route: string,
   params: RequestParams
-): string | null {
+): string {
   if (route && params) {
     const paramKeys = Object.keys(params)
     for (const key of paramKeys) {


### PR DESCRIPTION
- Hooks keys are now a two element array that includes the request method. This fixes an issue where hooks using the same route on different methods could conflict. The mutation matcher still uses the route string without any method information.
- Migrated all settings interaction to the more specific requestSettings.
- Removed the unused standalone option.