### PR TITLE
fix: renterd pinned average display

### DIFF
--- a/.changeset/chilly-buttons-sell.md
+++ b/.changeset/chilly-buttons-sell.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where network averages shown on pinned field tips did not follow the currency display preference.

--- a/.changeset/shiny-phones-burn.md
+++ b/.changeset/shiny-phones-burn.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fiat fields now show averages and suggestions according to the currency display preference.

--- a/apps/hostd/contexts/config/types.ts
+++ b/apps/hostd/contexts/config/types.ts
@@ -1,5 +1,5 @@
 import { DNSProvider } from '@siafoundation/hostd-types'
-import { SiaCentralCurrency } from '@siafoundation/sia-central-types'
+import { CurrencyId } from '@siafoundation/react-core'
 import BigNumber from 'bignumber.js'
 
 export type ConfigViewMode = 'basic' | 'advanced'
@@ -29,7 +29,7 @@ export const dnsProviderOptions: { value: DNSProvider; label: string }[] = [
 ]
 
 export const defaultValuesSettingsPinned = {
-  pinnedCurrency: '' as SiaCentralCurrency | '',
+  pinnedCurrency: '' as CurrencyId | '',
   pinnedThreshold: new BigNumber(0),
   shouldPinStoragePrice: false,
   storagePricePinned: new BigNumber(0),

--- a/apps/renterd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/renterd-e2e/src/fixtures/beforeTest.ts
@@ -5,6 +5,7 @@ import { configResetAllSettings } from './configResetAllSettings'
 import { setViewMode } from './configViewMode'
 import { Page } from 'playwright'
 import { mockApiSiaScanExchangeRates } from './siascan'
+import { setCurrencyDisplay } from './preferences'
 
 export async function beforeTest(page: Page) {
   await mockApiSiaCentralExchangeRates({ page })
@@ -12,6 +13,7 @@ export async function beforeTest(page: Page) {
   await login({ page })
 
   // Reset state.
+  await setCurrencyDisplay(page, 'bothPreferSc')
   await navigateToConfig({ page })
   await configResetAllSettings({ page })
   await setViewMode({ page, state: 'basic' })

--- a/apps/renterd-e2e/src/fixtures/preferences.ts
+++ b/apps/renterd-e2e/src/fixtures/preferences.ts
@@ -1,0 +1,11 @@
+import { Page } from 'playwright'
+import { fillSelectInputByName } from './selectInput'
+
+export async function setCurrencyDisplay(
+  page: Page,
+  display: 'sc' | 'fiat' | 'bothPreferSc' | 'bothPreferFiat'
+) {
+  await page.getByLabel('App preferences').click()
+  await fillSelectInputByName(page, 'currencyDisplay', display)
+  await page.getByRole('dialog').getByLabel('close').click()
+}

--- a/apps/renterd-e2e/src/specs/config.spec.ts
+++ b/apps/renterd-e2e/src/specs/config.spec.ts
@@ -9,6 +9,7 @@ import {
 import { clearToasts } from '../fixtures/clearToasts'
 import { clickIfEnabledAndWait, clickIf } from '../fixtures/click'
 import { beforeTest } from '../fixtures/beforeTest'
+import { setCurrencyDisplay } from '../fixtures/preferences'
 
 test.beforeEach(async ({ page }) => {
   await beforeTest(page)
@@ -56,6 +57,33 @@ test('basic field change and save behaviour', async ({ page }) => {
   for (const part of estimateParts) {
     await expect(page.getByText(part)).toBeVisible()
   }
+
+  // Tips are displayed in the correct currency.
+  await expect(
+    page
+      .getByTestId('maxStoragePriceTBMonthGroup')
+      .getByLabel('Network average')
+      .getByText('357')
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('maxStoragePriceTBMonthGroup')
+      .getByLabel('Fit current allowance')
+      .getByText('300')
+  ).toBeVisible()
+  await setCurrencyDisplay(page, 'bothPreferFiat')
+  await expect(
+    page
+      .getByTestId('maxStoragePriceTBMonthGroup')
+      .getByLabel('Network average')
+      .getByText('$3.77')
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('maxStoragePriceTBMonthGroup')
+      .getByLabel('Fit current allowance')
+      .getByText('$3.17')
+  ).toBeVisible()
 })
 
 test('set max prices to fit current allowance', async ({ page }) => {

--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -4,8 +4,7 @@
   "version": "4.6.0",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^18.2.0",
-    "@siafoundation/sia-central-types": "0.1.1"
+    "react": "^18.2.0"
   },
   "dependencies": {
     "@siafoundation/react-icons": "^0.2.3",

--- a/libs/design-system/src/app/CurrencyDisplaySelector.tsx
+++ b/libs/design-system/src/app/CurrencyDisplaySelector.tsx
@@ -15,6 +15,8 @@ export function CurrencyDisplaySelector() {
 
   return (
     <Select
+      aria-label="currency display"
+      name="currencyDisplay"
       disabled={!settings.siaCentral}
       value={settings.currencyDisplay}
       onChange={(e) =>

--- a/libs/design-system/src/core/SiacoinField.tsx
+++ b/libs/design-system/src/core/SiacoinField.tsx
@@ -5,8 +5,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import BigNumber from 'bignumber.js'
 import { cx } from 'class-variance-authority'
 import { toFixedMaxString } from '../lib/numbers'
-import { useSiaCentralExchangeRates } from '@siafoundation/sia-central-react'
 import { BaseNumberField } from './BaseNumberField'
+import { useExchangeRate } from '../hooks/useExchangeRate'
 
 type Props = Omit<
   React.ComponentProps<typeof BaseNumberField>,
@@ -22,8 +22,6 @@ type Props = Omit<
   error?: boolean
   changed?: boolean
 }
-
-const zero = new BigNumber(0)
 
 export function SiacoinField({
   sc: _externalSc,
@@ -47,19 +45,7 @@ export function SiacoinField({
     [_externalSc]
   )
   const { settings } = useAppSettings()
-  const rates = useSiaCentralExchangeRates({
-    config: {
-      swr: {
-        revalidateOnFocus: false,
-      },
-    },
-  })
-  const rate = useMemo(() => {
-    if (!settings.siaCentral || !rates.data) {
-      return zero
-    }
-    return new BigNumber(rates.data?.rates.sc[settings.currency.id] || zero)
-  }, [rates.data, settings])
+  const rate = useExchangeRate({ currency: settings.currency.id })
   const [active, setActive] = useState<'sc' | 'fiat'>()
   const [localSc, setLocalSc] = useState<string>('')
   const [localFiat, setLocalFiat] = useState<string>('')

--- a/libs/design-system/src/hooks/useExchangeRate.tsx
+++ b/libs/design-system/src/hooks/useExchangeRate.tsx
@@ -1,0 +1,33 @@
+import { CurrencyId, useAppSettings } from '@siafoundation/react-core'
+import { useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+import { useSiaCentralExchangeRates } from '@siafoundation/sia-central-react'
+
+type Props = {
+  currency?: CurrencyId | ''
+}
+
+export function useExchangeRate({ currency }: Props): BigNumber {
+  const { settings } = useAppSettings()
+  const rates = useSiaCentralExchangeRates({
+    disabled: !currency || !settings.siaCentral,
+    config: {
+      swr: {
+        revalidateOnFocus: false,
+      },
+    },
+  })
+  const rate = useMemo(() => {
+    if (!settings.siaCentral || !rates.data) {
+      return new BigNumber(0)
+    }
+    return new BigNumber((currency && rates.data?.rates.sc[currency]) || 0)
+  }, [rates.data, settings, currency])
+
+  return rate
+}
+
+export function useActiveExchangeRate(): BigNumber {
+  const { settings } = useAppSettings()
+  return useExchangeRate({ currency: settings.currency.id })
+}

--- a/libs/design-system/src/hooks/useSiacoinFiat.tsx
+++ b/libs/design-system/src/hooks/useSiacoinFiat.tsx
@@ -1,32 +1,18 @@
 import { CurrencyOption, useAppSettings } from '@siafoundation/react-core'
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
-import { useSiaCentralExchangeRates } from '@siafoundation/sia-central-react'
+import { useExchangeRate } from './useExchangeRate'
 
 type Props = {
   sc: BigNumber
 }
-
-const zero = new BigNumber(0)
 
 export function useSiacoinFiat({ sc }: Props): {
   fiat?: BigNumber
   currency?: CurrencyOption
 } {
   const { settings } = useAppSettings()
-  const rates = useSiaCentralExchangeRates({
-    config: {
-      swr: {
-        revalidateOnFocus: false,
-      },
-    },
-  })
-  const rate = useMemo(() => {
-    if (!settings.siaCentral || !rates.data) {
-      return zero
-    }
-    return new BigNumber(rates.data?.rates.sc[settings.currency.id] || zero)
-  }, [rates.data, settings])
+  const rate = useExchangeRate({ currency: settings.currency.id })
   const fiat = useMemo(() => new BigNumber(sc).times(rate), [sc, rate])
 
   if (rate.isZero()) {

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -163,6 +163,7 @@ export * from './hooks/useServerFilters'
 export * from './hooks/useFormChanged'
 export * from './hooks/useDatasetEmptyState'
 export * from './hooks/useSiacoinFiat'
+export * from './hooks/useExchangeRate'
 export * from './hooks/useOS'
 
 // data


### PR DESCRIPTION
- Fixed an issue where network averages shown on pinned field tips did not follow the currency display preference.
<img width="471" alt="Screenshot 2024-08-19 at 3 41 31 PM" src="https://github.com/user-attachments/assets/2eb14a41-7ff9-4f75-91bb-cd9daa4ae77a">
<img width="377" alt="Screenshot 2024-08-19 at 3 41 33 PM" src="https://github.com/user-attachments/assets/3f54031c-9df6-44f1-b6ff-780cecc7043a">
