### PR TITLE
add explored api sdk to config, for use in future siacentral phase out

### DIFF
--- a/.changeset/lovely-clocks-juggle.md
+++ b/.changeset/lovely-clocks-juggle.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added base explored API for future Siacentral phase out.

--- a/apps/explorer/config/explored.ts
+++ b/apps/explorer/config/explored.ts
@@ -1,0 +1,4 @@
+import { Explored } from '@siafoundation/explored-js'
+import { exploredApi as api } from '.'
+
+export const explored = Explored({ api })

--- a/apps/explorer/config/index.ts
+++ b/apps/explorer/config/index.ts
@@ -10,3 +10,4 @@ export const isMainnet = true
 // APIs
 export const faucetApi = 'https://api.siascan.com/zen/faucet'
 export const siaCentralApi = 'https://api.siacentral.com/v2'
+export const exploredApi = 'https://explored.siascan.sia.dev/api'

--- a/apps/explorer/config/testnet-zen.ts
+++ b/apps/explorer/config/testnet-zen.ts
@@ -10,3 +10,4 @@ export const isMainnet = false
 // APIs
 export const faucetApi = 'https://api.siascan.com/zen/faucet'
 export const siaCentralApi = 'https://api.siacentral.com/v2/zen'
+export const exploredApi = 'https://explored.zen.siascan.sia.dev/api'


### PR DESCRIPTION
I figured this one conceptually made sense as its own little PR as opposed to tacking it onto the first phase out route PR and having it get lost in the history a bit.

The zen address is probably wrong here or there just isn't support for this yet. Should I remove that line or is there a current working address? Am I correct that we're using testnet-zen in a docker config to stand in for that local `index.ts` to switch between the different modes?