### PR TITLE
fix: explored-types: add 'type' to core types import, silencing webpack empty export warning

### DIFF
--- a/.changeset/spicy-clouds-deliver.md
+++ b/.changeset/spicy-clouds-deliver.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/explored-types': minor
+---
+
+Fixed webpack-related empty export warning.

--- a/libs/explored-types/src/types.ts
+++ b/libs/explored-types/src/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Address,
   BlockID,
   Block,


### PR DESCRIPTION
In creating this PR: https://github.com/SiaFoundation/web/pull/698

I discovered a webpack-related warning for our import of core types in the `explored-types`. By doing:

```ts
import { Address, ... } from '@siafoundation/types'
```

this led to an avalanche of warnings like so:

```bash
export 'Address' (reexported as 'Address') was not found in '@siafoundation/types' (module has no exports)
```

By adding the 'type' at the top of `types.ts`:

```ts
import type { Address, ... } from '@siafoundation/types'
```

this warning no longer sounds. I believe this has to do with some bare metal typescript -> javascript transpilation + importing rules at the webpack level. There was no obvious bug/misbehavior as a result of the former implementation. The library worked, from what I tested, and types were valid/enforced, even with this warning. 

In terms of where to put the `type` keyword, I believe from testing one could also do it here:

```ts
export type {
  Address,
  Block,
  BlockID,
  ...
}
```

but I like it at the import better. Everything 'up the tree' or neighboring (but also importing from) either explicitly defines a type to export, uses these core imported types, and/or uses primitives. In some sense, putting it at the import strikes at "a single source of truth"--our core types. This import is the parent of everything in this library beyond primitives, so it seems right at this spot.

For more information about the warning/solution, see [this comment](https://github.com/storybookjs/storybook/issues/13504#issuecomment-752212029) and the rest of the thread.