### PR TITLE
refactor: renterd remove deprecated hosts API

### DIFF
--- a/.changeset/short-lizards-shop.md
+++ b/.changeset/short-lizards-shop.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Remove deprecated hosts API. Relates to https://github.com/SiaFoundation/renterd/pull/1484

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -97,9 +97,6 @@ import {
   HostsBlocklistUpdateParams,
   HostsBlocklistUpdatePayload,
   HostsBlocklistUpdateResponse,
-  HostsParams,
-  HostsPayload,
-  HostsResponse,
   HostsSearchParams,
   HostsSearchPayload,
   HostsSearchResponse,
@@ -238,7 +235,6 @@ import {
   busHostsAllowlistRoute,
   busHostsBlocklistRoute,
   busHostsHostKeyRoute,
-  busHostsRoute,
   busMetricChurnRoute,
   busMetricContractRoute,
   busMetricContractsetRoute,
@@ -383,11 +379,6 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       WalletPendingPayload,
       WalletPendingResponse
     >(axios, 'get', busWalletPendingRoute),
-    hosts: buildRequestHandler<HostsParams, HostsPayload, HostsResponse>(
-      axios,
-      'get',
-      busHostsRoute
-    ),
     hostsSearch: buildRequestHandler<
       HostsSearchParams,
       HostsSearchPayload,

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -91,8 +91,6 @@ import {
   HostsBlocklistUpdateParams,
   HostsBlocklistUpdatePayload,
   HostsBlocklistUpdateResponse,
-  HostsParams,
-  HostsResponse,
   HostsSearchParams,
   HostsSearchPayload,
   HostsSearchResponse,
@@ -208,7 +206,6 @@ import {
   busHostsAllowlistRoute,
   busHostsBlocklistRoute,
   busHostsHostKeyRoute,
-  busHostsRoute,
   busObjectsRoute,
   busObjectsKeyRoute,
   busObjectsListRoute,
@@ -484,13 +481,6 @@ export function useWalletPending(
   args?: HookArgsSwr<WalletPendingParams, WalletPendingResponse>
 ) {
   return useGetSwr({ ...args, route: busWalletPendingRoute })
-}
-
-export function useHosts(args: HookArgsSwr<HostsParams, HostsResponse>) {
-  return useGetSwr({
-    ...args,
-    route: busHostsRoute,
-  })
 }
 
 export function useHostsSearch(

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -41,7 +41,6 @@ export const busWalletDiscardRoute = '/bus/wallet/discard'
 export const busWalletPrepareFormRoute = '/bus/wallet/prepare/form'
 export const busWalletPrepareRenewRoute = '/bus/wallet/prepare/renew'
 export const busWalletPendingRoute = '/bus/wallet/pending'
-export const busHostsRoute = '/bus/hosts'
 export const busSearchHostsRoute = '/bus/search/hosts'
 export const busHostHostKeyRoute = '/bus/host/:hostKey'
 export const busHostsHostKeyRoute = '/bus/hosts/:hostKey'
@@ -232,13 +231,6 @@ export type WalletPendingPayload = void
 export type WalletPendingResponse = Transaction[]
 
 // hosts
-
-export type HostsParams = {
-  offset?: number
-  limit?: number
-}
-export type HostsPayload = void
-export type HostsResponse = Host[]
 
 export type HostsSearchParams = void
 export type HostsSearchFilterMode = 'all' | 'allowed' | 'blocked'


### PR DESCRIPTION
- Remove deprecated hosts API. Relates to https://github.com/SiaFoundation/renterd/pull/1484
