### PR TITLE
fix: renterd no recommendations

### DIFF
--- a/.changeset/small-cameras-lay.md
+++ b/.changeset/small-cameras-lay.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The recommendations now say "no recommendations" instead of 0. Closes https://github.com/SiaFoundation/desktop/issues/90

--- a/apps/renterd-e2e/src/specs/config.spec.ts
+++ b/apps/renterd-e2e/src/specs/config.spec.ts
@@ -276,7 +276,7 @@ test('system offers recommendations', async ({ page }) => {
 
   await expect(
     page.getByText(
-      /(0 recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
+      /(No recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
     )
   ).toBeVisible()
 
@@ -294,7 +294,7 @@ test('system offers recommendations', async ({ page }) => {
   await clearToasts({ page })
   // There are now recommendations.
   await expect(
-    page.getByText('0 recommendations to match with more hosts')
+    page.getByText('No recommendations to match with more hosts')
   ).toBeHidden()
 
   // Apply all recommendations.
@@ -347,7 +347,7 @@ test('recommendations work with pinned fields', async ({ page }) => {
   await fillTextInputByName(page, 'maxDownloadPriceTB', '100')
   // There are now recommendations.
   await expect(
-    page.getByText('0 recommendations to match with more hosts')
+    page.getByText('No recommendations to match with more hosts')
   ).toBeHidden()
 
   // Set to high mixed values that will not need any recommendations.
@@ -357,7 +357,7 @@ test('recommendations work with pinned fields', async ({ page }) => {
   await fillTextInputByName(page, 'maxDownloadPriceTB', '100000000')
   await expect(
     page.getByText(
-      /(0 recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
+      /(No recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
     )
   ).toBeVisible()
 
@@ -365,6 +365,6 @@ test('recommendations work with pinned fields', async ({ page }) => {
   await fillTextInputByName(page, 'maxStoragePriceTBMonthPinned', '0.39')
   // There are now recommendations again.
   await expect(
-    page.getByText('0 recommendations to match with more hosts')
+    page.getByText('No recommendations to match with more hosts')
   ).toBeHidden()
 })

--- a/apps/renterd/components/Config/Recommendations.tsx
+++ b/apps/renterd/components/Config/Recommendations.tsx
@@ -177,7 +177,9 @@ export function Recommendations() {
             {usableHostsCurrent}/{hostTarget50}
           </Text>
           <Text size="16" weight="medium">
-            {recommendations.length === 1
+            {recommendations.length === 0
+              ? 'No recommendations'
+              : recommendations.length === 1
               ? '1 recommendation'
               : `${recommendations.length} recommendations`}{' '}
             to match with more hosts


### PR DESCRIPTION
- The recommendations now say "no recommendations" instead of 0. https://github.com/SiaFoundation/desktop/issues/90
