### PR TITLE
feat: renterd hostd wallet send

### DIFF
--- a/.changeset/moody-zebras-fly.md
+++ b/.changeset/moody-zebras-fly.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+The send siacoin feature now calculates the fee using the daemon's recommended fee per byte and a standard transaction size.

--- a/.changeset/shy-dots-complain.md
+++ b/.changeset/shy-dots-complain.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/hostd-types': minor
+'@siafoundation/hostd-js': minor
+'@siafoundation/hostd-react': minor
+---
+
+The wallet send API now supports the subtractMinerFee option.

--- a/.changeset/thick-rats-smell.md
+++ b/.changeset/thick-rats-smell.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': patch
+'@siafoundation/renterd-react': patch
+'@siafoundation/renterd-types': patch
+---
+
+Fixed the route for the recommended fee API.

--- a/.changeset/young-gifts-return.md
+++ b/.changeset/young-gifts-return.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Added the wallet send API.

--- a/apps/hostd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/hostd-e2e/src/fixtures/beforeTest.ts
@@ -22,5 +22,6 @@ export async function beforeTest(page: Page, shouldResetConfig = true) {
     await navigateToConfig({ page })
     await configResetAllSettings({ page })
     await setViewMode({ page, state: 'basic' })
+    await navigateToConfig({ page })
   }
 }

--- a/apps/hostd-e2e/src/fixtures/navigate.ts
+++ b/apps/hostd-e2e/src/fixtures/navigate.ts
@@ -1,18 +1,23 @@
 import { Page, expect } from '@playwright/test'
 
 export async function navigateToDashboard({ page }: { page: Page }) {
-  await page.getByLabel('Overview').click()
+  await page.getByTestId('sidenav').getByLabel('Overview').click()
   await expect(page.getByTestId('navbar').getByText('Overview')).toBeVisible()
 }
 
 export async function navigateToConfig({ page }: { page: Page }) {
-  await page.getByLabel('Configuration').click()
+  await page.getByTestId('sidenav').getByLabel('Configuration').click()
   await expect(
     page.getByTestId('navbar').getByText('Configuration')
   ).toBeVisible()
 }
 
 export async function navigateToVolumes({ page }: { page: Page }) {
-  await page.getByLabel('Volumes').click()
+  await page.getByTestId('sidenav').getByLabel('Volumes').click()
   await expect(page.getByTestId('navbar').getByText('Volumes')).toBeVisible()
+}
+
+export async function navigateToWallet(page: Page) {
+  await page.getByTestId('sidenav').getByLabel('Wallet').click()
+  await expect(page.getByTestId('navbar').getByText('Wallet')).toBeVisible()
 }

--- a/apps/hostd-e2e/src/fixtures/preferences.ts
+++ b/apps/hostd-e2e/src/fixtures/preferences.ts
@@ -1,0 +1,11 @@
+import { Page } from 'playwright'
+import { fillSelectInputByName } from './selectInput'
+
+export async function setCurrencyDisplay(
+  page: Page,
+  display: 'sc' | 'fiat' | 'bothPreferSc' | 'bothPreferFiat'
+) {
+  await page.getByLabel('App preferences').click()
+  await fillSelectInputByName(page, 'currencyDisplay', display)
+  await page.getByRole('dialog').getByLabel('close').click()
+}

--- a/apps/hostd-e2e/src/fixtures/siascan.ts
+++ b/apps/hostd-e2e/src/fixtures/siascan.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright'
+
+export async function mockApiSiaScanExchangeRates({ page }: { page: Page }) {
+  await page.route(
+    'https://api.siascan.com/exchange-rate/siacoin/*',
+    async (route) => {
+      await route.fulfill({ json: 0.003944045283 })
+    }
+  )
+}

--- a/apps/hostd-e2e/src/specs/config.spec.ts
+++ b/apps/hostd-e2e/src/specs/config.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test'
-import { login } from '../fixtures/login'
 import {
   expectSwitchByLabel,
   expectSwitchVisible,
@@ -7,23 +6,20 @@ import {
 } from '../fixtures/switchValue'
 import { setViewMode } from '../fixtures/configViewMode'
 import { navigateToConfig } from '../fixtures/navigate'
-import { mockApiSiaCentralExchangeRates } from '@siafoundation/sia-central-mock'
-import { configResetAllSettings } from '../fixtures/configResetAllSettings'
 import {
   expectTextInputByName,
   expectTextInputNotVisible,
   fillTextInputByName,
 } from '../fixtures/textInput'
 import { fillSelectInputByName } from '../fixtures/selectInput'
+import { beforeTest } from '../fixtures/beforeTest'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page)
+})
 
 test('basic field change and save behaviour', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   // Reset state.
-  await navigateToConfig({ page })
-  await configResetAllSettings({ page })
   await setViewMode({ page, state: 'advanced' })
 
   // Test that values can be updated.
@@ -63,10 +59,6 @@ test('basic field change and save behaviour', async ({ page }) => {
 })
 
 test('pin switches should show in both view modes', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
   await navigateToConfig({ page })
   await setViewMode({ page, state: 'basic' })
   await expectSwitchVisible(page, 'shouldPinStoragePrice')
@@ -83,14 +75,7 @@ test('pin switches should show in both view modes', async ({ page }) => {
 })
 
 test('dynamic max collateral suggestion', async ({ page }) => {
-  // Set up.
-  await mockApiSiaCentralExchangeRates({ page })
-  await login({ page })
-
-  // Reset state.
   await navigateToConfig({ page })
-  await configResetAllSettings({ page })
-  await setViewMode({ page, state: 'basic' })
   await fillTextInputByName(page, 'maxCollateral', '777')
   await expect(
     page

--- a/apps/hostd-e2e/src/specs/volumes.spec.ts
+++ b/apps/hostd-e2e/src/specs/volumes.spec.ts
@@ -1,16 +1,19 @@
 import { test } from '@playwright/test'
 import { navigateToVolumes } from '../fixtures/navigate'
-import { login } from '../fixtures/login'
 import {
   createVolume,
   deleteVolume,
   deleteVolumeIfExists,
 } from '../fixtures/volumes'
+import { beforeTest } from '../fixtures/beforeTest'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page, false)
+})
 
 test('can create and delete a volume', async ({ page }) => {
   const name = 'my-new-volume'
   const path = '/data'
-  await login({ page })
   await navigateToVolumes({ page })
   await deleteVolumeIfExists(page, name, path)
   await createVolume(page, name, path)

--- a/apps/hostd-e2e/src/specs/wallet.spec.ts
+++ b/apps/hostd-e2e/src/specs/wallet.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test'
+import { navigateToWallet } from '../fixtures/navigate'
+import { random } from '@technically/lodash'
+import { beforeTest } from '../fixtures/beforeTest'
+import { fillTextInputByName } from '../fixtures/textInput'
+import { setSwitchByLabel } from '../fixtures/switchValue'
+import BigNumber from 'bignumber.js'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page, false)
+})
+
+test('send siacoin with include fee off', async ({ page }) => {
+  const receiveAddress =
+    '5739945c21e60afd70eaf97ccd33ea27836e0219212449f39e4b38acaa8b3119aa4150a9ef0f'
+  const amount = String(random(1, 5))
+  const amountString = `${amount}.000 SC`
+  const amountWithFeeString = `${amount}.012 SC`
+
+  await navigateToWallet(page)
+
+  // Setup.
+  await page.getByLabel('send').click()
+  const sendDialog = page.getByRole('dialog', { name: 'Send siacoin' })
+  await fillTextInputByName(page, 'address', receiveAddress)
+  await fillTextInputByName(page, 'siacoin', amount)
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountWithFeeString)
+  ).toBeVisible()
+
+  // Confirm.
+  await page.getByRole('button', { name: 'Generate transaction' }).click()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountWithFeeString)
+  ).toBeVisible()
+
+  // Complete.
+  await page.getByRole('button', { name: 'Broadcast transaction' }).click()
+  await expect(
+    page.getByText('Transaction successfully broadcasted.')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountWithFeeString)
+  ).toBeVisible()
+  await expect(sendDialog.getByTestId('transactionId')).toBeVisible()
+
+  // List.
+  // TODO: Add this after we migrate to the new events API.
+  // await sendDialog.getByRole('button', { name: 'Close' }).click()
+  // await expect(page.getByTestId('eventsTable')).toBeVisible()
+  // await expect(
+  //   page.getByTestId('eventsTable').locator('tbody tr').first()
+  // ).toBeVisible()
+  // await expect(
+  //   page
+  //     .getByTestId('eventsTable')
+  //     .locator('tbody tr')
+  //     .first()
+  //     .getByTestId('amount')
+  //     .getByText(`-${amountWithFeeString}`)
+  // ).toBeVisible()
+})
+
+test('send siacoin with include fee on', async ({ page }) => {
+  const receiveAddress =
+    '5739945c21e60afd70eaf97ccd33ea27836e0219212449f39e4b38acaa8b3119aa4150a9ef0f'
+  const amount = new BigNumber(random(1, 5))
+  const amountString = `${amount.toFixed(3)} SC`
+  const amountWithoutFeeString = `${amount.minus(0.012).toFixed(3)} SC`
+
+  await navigateToWallet(page)
+
+  // Setup.
+  await page.getByLabel('send').click()
+  const sendDialog = page.getByRole('dialog', { name: 'Send siacoin' })
+  await fillTextInputByName(page, 'address', receiveAddress)
+  await fillTextInputByName(page, 'siacoin', amount.toString())
+  await setSwitchByLabel(page, 'include fee', true)
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountString)
+  ).toBeVisible()
+
+  // Confirm.
+  await page.getByRole('button', { name: 'Generate transaction' }).click()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountWithoutFeeString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountString)
+  ).toBeVisible()
+
+  // Complete.
+  await page.getByRole('button', { name: 'Broadcast transaction' }).click()
+  await expect(
+    page.getByText('Transaction successfully broadcasted.')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountWithoutFeeString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountString)
+  ).toBeVisible()
+  await expect(sendDialog.getByTestId('transactionId')).toBeVisible()
+
+  // List.
+  // TODO: Add this after we migrate to the new events API.
+  // await sendDialog.getByRole('button', { name: 'Close' }).click()
+  // await expect(page.getByTestId('eventsTable')).toBeVisible()
+  // await expect(
+  //   page.getByTestId('eventsTable').locator('tbody tr').first()
+  // ).toBeVisible()
+  // await expect(
+  //   page
+  //     .getByTestId('eventsTable')
+  //     .locator('tbody tr')
+  //     .first()
+  //     .getByTestId('amount')
+  //     .getByText(`-${amountWithFeeString}`)
+  // ).toBeVisible()
+})

--- a/apps/renterd-e2e/src/fixtures/navigate.ts
+++ b/apps/renterd-e2e/src/fixtures/navigate.ts
@@ -18,3 +18,8 @@ export async function navigateToConfig({ page }: { page: Page }) {
     page.getByTestId('navbar').getByText('Configuration')
   ).toBeVisible()
 }
+
+export async function navigateToWallet(page: Page) {
+  await page.getByTestId('sidenav').getByLabel('Wallet').click()
+  await expect(page.getByTestId('navbar').getByText('Wallet')).toBeVisible()
+}

--- a/apps/renterd-e2e/src/specs/wallet.spec.ts
+++ b/apps/renterd-e2e/src/specs/wallet.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test'
+import { navigateToWallet } from '../fixtures/navigate'
+import { random } from '@technically/lodash'
+import { beforeTest } from '../fixtures/beforeTest'
+import { fillTextInputByName } from '../fixtures/textInput'
+import BigNumber from 'bignumber.js'
+import { setSwitchByLabel } from '../fixtures/switchValue'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page, false)
+})
+
+test('send siacoin with include fee off', async ({ page }) => {
+  const receiveAddress =
+    '5739945c21e60afd70eaf97ccd33ea27836e0219212449f39e4b38acaa8b3119aa4150a9ef0f'
+  const amount = String(random(1, 5))
+  const amountString = `${amount}.000 SC`
+  const amountWithFeeString = `${amount}.012 SC`
+
+  await navigateToWallet(page)
+
+  // Setup.
+  await page.getByLabel('send').click()
+  const sendDialog = page.getByRole('dialog', { name: 'Send siacoin' })
+  await fillTextInputByName(page, 'address', receiveAddress)
+  await fillTextInputByName(page, 'siacoin', amount)
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountWithFeeString)
+  ).toBeVisible()
+
+  // Confirm.
+  await page.getByRole('button', { name: 'Generate transaction' }).click()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountWithFeeString)
+  ).toBeVisible()
+
+  // Complete.
+  await page.getByRole('button', { name: 'Broadcast transaction' }).click()
+  await expect(
+    page.getByText('Transaction successfully broadcasted.')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountWithFeeString)
+  ).toBeVisible()
+  await expect(sendDialog.getByTestId('transactionId')).toBeVisible()
+
+  // List.
+  // TODO: Add this after we migrate to the new events API.
+  // await sendDialog.getByRole('button', { name: 'Close' }).click()
+  // await expect(page.getByTestId('eventsTable')).toBeVisible()
+  // await expect(
+  //   page.getByTestId('eventsTable').locator('tbody tr').first()
+  // ).toBeVisible()
+  // await expect(
+  //   page
+  //     .getByTestId('eventsTable')
+  //     .locator('tbody tr')
+  //     .first()
+  //     .getByTestId('amount')
+  //     .getByText(`-${amountWithFeeString}`)
+  // ).toBeVisible()
+})
+
+test('send siacoin with include fee on', async ({ page }) => {
+  const receiveAddress =
+    '5739945c21e60afd70eaf97ccd33ea27836e0219212449f39e4b38acaa8b3119aa4150a9ef0f'
+  const amount = new BigNumber(random(1, 5))
+  const amountString = `${amount.toFixed(3)} SC`
+  const amountWithoutFeeString = `${amount.minus(0.012).toFixed(3)} SC`
+
+  await navigateToWallet(page)
+
+  // Setup.
+  await page.getByLabel('send').click()
+  const sendDialog = page.getByRole('dialog', { name: 'Send siacoin' })
+  await fillTextInputByName(page, 'address', receiveAddress)
+  await fillTextInputByName(page, 'siacoin', amount.toString())
+  await setSwitchByLabel(page, 'include fee', true)
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountString)
+  ).toBeVisible()
+
+  // Confirm.
+  await page.getByRole('button', { name: 'Generate transaction' }).click()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountWithoutFeeString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountString)
+  ).toBeVisible()
+
+  // Complete.
+  await page.getByRole('button', { name: 'Broadcast transaction' }).click()
+  await expect(
+    page.getByText('Transaction successfully broadcasted.')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('address').getByText(receiveAddress.slice(0, 5))
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('amount').getByText(amountWithoutFeeString)
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('networkFee').getByText('0.012 SC')
+  ).toBeVisible()
+  await expect(
+    sendDialog.getByTestId('total').getByText(amountString)
+  ).toBeVisible()
+  await expect(sendDialog.getByTestId('transactionId')).toBeVisible()
+
+  // List.
+  // TODO: Add this after we migrate to the new events API.
+  // await sendDialog.getByRole('button', { name: 'Close' }).click()
+  // await expect(page.getByTestId('eventsTable')).toBeVisible()
+  // await expect(
+  //   page.getByTestId('eventsTable').locator('tbody tr').first()
+  // ).toBeVisible()
+  // await expect(
+  //   page
+  //     .getByTestId('eventsTable')
+  //     .locator('tbody tr')
+  //     .first()
+  //     .getByTestId('amount')
+  //     .getByText(`-${amountWithFeeString}`)
+  // ).toBeVisible()
+})

--- a/libs/design-system/src/app/WalletLayoutActions.tsx
+++ b/libs/design-system/src/app/WalletLayoutActions.tsx
@@ -41,12 +41,17 @@ export function WalletLayoutActions({
         />
       )}
       {receiveSiacoin && (
-        <Button size="small" onClick={receiveSiacoin}>
+        <Button aria-label="receive" size="small" onClick={receiveSiacoin}>
           <ArrowDownLeft16 />
           Receive
         </Button>
       )}
-      <Button size="small" variant="accent" onClick={sendSiacoin}>
+      <Button
+        aria-label="send"
+        size="small"
+        variant="accent"
+        onClick={sendSiacoin}
+      >
         <ArrowUpRight16 />
         Send
       </Button>

--- a/libs/design-system/src/app/WalletSendSiacoinDialog/Complete.tsx
+++ b/libs/design-system/src/app/WalletSendSiacoinDialog/Complete.tsx
@@ -2,18 +2,16 @@ import BigNumber from 'bignumber.js'
 import { Text } from '../../core/Text'
 import { CheckmarkFilled32 } from '@siafoundation/react-icons'
 import { WalletSendSiacoinReceipt } from './Receipt'
+import { SendSiacoinFormData } from './types'
 
 type Props = {
-  data: {
-    address: string
-    siacoin: BigNumber
-  }
+  data: SendSiacoinFormData
   fee: BigNumber
   transactionId?: string
 }
 
 export function WalletSendSiacoinComplete({
-  data: { address, siacoin },
+  data: { address, hastings, includeFee },
   fee,
   transactionId,
 }: Props) {
@@ -21,7 +19,8 @@ export function WalletSendSiacoinComplete({
     <div className="flex flex-col gap-4">
       <WalletSendSiacoinReceipt
         address={address}
-        siacoin={siacoin}
+        hastings={hastings}
+        includeFee={includeFee}
         fee={fee}
         transactionId={transactionId}
       />

--- a/libs/design-system/src/app/WalletSendSiacoinDialog/Confirm.tsx
+++ b/libs/design-system/src/app/WalletSendSiacoinDialog/Confirm.tsx
@@ -1,16 +1,13 @@
 import { useFormik } from 'formik'
 import BigNumber from 'bignumber.js'
 import { WalletSendSiacoinReceipt } from './Receipt'
+import { SendSiacoinFormData } from './types'
 
 type Props = {
-  send: (params: {
-    address: string
-    sc: BigNumber
-  }) => Promise<{ transactionId?: string; error?: string }>
-  formData: {
-    address: string
-    siacoin: BigNumber
-  }
+  send: (
+    params: SendSiacoinFormData
+  ) => Promise<{ transactionId?: string; error?: string }>
+  formData: SendSiacoinFormData
   fee: BigNumber
   onConfirm: (params: { transactionId?: string }) => void
 }
@@ -21,13 +18,14 @@ export function useSendSiacoinConfirmForm({
   fee,
   onConfirm,
 }: Props) {
-  const { address, siacoin } = formData || {}
+  const { address, hastings, includeFee } = formData || {}
   const formik = useFormik({
     initialValues: {},
     onSubmit: async () => {
       const { transactionId, error } = await send({
         address,
-        sc: siacoin,
+        hastings,
+        includeFee,
       })
 
       if (error) {
@@ -45,7 +43,12 @@ export function useSendSiacoinConfirmForm({
 
   const form = (
     <div className="flex flex-col gap-4">
-      <WalletSendSiacoinReceipt address={address} siacoin={siacoin} fee={fee} />
+      <WalletSendSiacoinReceipt
+        address={address}
+        hastings={hastings}
+        fee={fee}
+        includeFee={includeFee}
+      />
     </div>
   )
 

--- a/libs/design-system/src/app/WalletSendSiacoinDialog/Receipt.tsx
+++ b/libs/design-system/src/app/WalletSendSiacoinDialog/Receipt.tsx
@@ -2,28 +2,38 @@ import { Text } from '../../core/Text'
 import { ValueSc } from '../../components/ValueSc'
 import BigNumber from 'bignumber.js'
 import { ValueCopyable } from '../../components/ValueCopyable'
+import { SendSiacoinFormData } from './types'
+import { getAmountUserWillReceive, getTotalTransactionCost } from './utils'
 
-type Props = {
-  address: string
-  siacoin: BigNumber
+type Props = SendSiacoinFormData & {
   fee: BigNumber
   transactionId?: string
 }
 
 export function WalletSendSiacoinReceipt({
   address,
-  siacoin,
+  hastings,
   fee,
+  includeFee,
   transactionId,
 }: Props) {
-  const totalSiacoin = siacoin.plus(fee)
+  const amount = getAmountUserWillReceive({
+    hastings,
+    includeFee,
+    fee,
+  })
+  const total = getTotalTransactionCost({
+    hastings,
+    includeFee,
+    fee,
+  })
   return (
     <div className="flex flex-col gap-2">
       <div className="flex gap-6 justify-between items-center">
         <Text color="verySubtle" noWrap>
           Address
         </Text>
-        <ValueCopyable value={address} type="address" />
+        <ValueCopyable testId="address" value={address} type="address" />
       </div>
       <div className="flex gap-2 justify-between items-center">
         <Text color="verySubtle" noWrap>
@@ -31,8 +41,9 @@ export function WalletSendSiacoinReceipt({
         </Text>
         <div className="flex relative top-[-0.5px]">
           <ValueSc
+            testId="amount"
             size="14"
-            value={siacoin}
+            value={amount}
             variant="value"
             dynamicUnits={false}
           />
@@ -43,7 +54,13 @@ export function WalletSendSiacoinReceipt({
           Network fee
         </Text>
         <div className="flex relative top-[-0.5px]">
-          <ValueSc size="14" value={fee} variant="value" dynamicUnits={false} />
+          <ValueSc
+            testId="networkFee"
+            size="14"
+            value={fee}
+            variant="value"
+            dynamicUnits={false}
+          />
         </div>
       </div>
       <div className="flex items-center gap-2 justify-between">
@@ -52,8 +69,9 @@ export function WalletSendSiacoinReceipt({
         </Text>
         <div className="flex relative top-[-0.5px]">
           <ValueSc
+            testId="total"
             size="14"
-            value={totalSiacoin}
+            value={total}
             variant="value"
             dynamicUnits={false}
           />
@@ -64,7 +82,11 @@ export function WalletSendSiacoinReceipt({
           <Text color="verySubtle" noWrap>
             Transaction ID
           </Text>
-          <ValueCopyable value={transactionId} type="transaction" />
+          <ValueCopyable
+            testId="transactionId"
+            value={transactionId}
+            type="transaction"
+          />
         </div>
       )}
     </div>

--- a/libs/design-system/src/app/WalletSendSiacoinDialog/index.tsx
+++ b/libs/design-system/src/app/WalletSendSiacoinDialog/index.tsx
@@ -2,7 +2,6 @@
 
 import BigNumber from 'bignumber.js'
 import { useMemo, useState } from 'react'
-import { toHastings } from '@siafoundation/units'
 import { Separator } from '../../core/Separator'
 import { Dialog } from '../../core/Dialog'
 import { useSendSiacoinGenerateForm } from './Generate'
@@ -10,20 +9,13 @@ import { useSendSiacoinConfirmForm } from './Confirm'
 import { ProgressSteps } from '../ProgressSteps'
 import { WalletSendSiacoinComplete } from './Complete'
 import { FormSubmitButtonFormik } from '../../components/FormFormik'
-
-export type SendSiacoinFormData = {
-  address: string
-  siacoin: BigNumber
-  includeFee: boolean
-}
+import { SendSiacoinFormData } from './types'
 
 type Step = 'setup' | 'confirm' | 'done'
 
-const fee = toHastings(0.00393)
-
-const emptyFormData = {
+const emptyFormData: SendSiacoinFormData = {
   address: '',
-  siacoin: new BigNumber(0),
+  hastings: new BigNumber(0),
   includeFee: false,
 }
 
@@ -32,10 +24,10 @@ type Props = {
   open: boolean
   onOpenChange: (val: boolean) => void
   balance?: BigNumber
-  send: (params: {
-    address: string
-    sc: BigNumber
-  }) => Promise<{ transactionId?: string; error?: string }>
+  fee: BigNumber
+  send: (
+    params: SendSiacoinFormData
+  ) => Promise<{ transactionId?: string; error?: string }>
 }
 
 export function WalletSendSiacoinDialog({
@@ -43,6 +35,7 @@ export function WalletSendSiacoinDialog({
   open,
   onOpenChange,
   balance,
+  fee,
   send,
 }: Props) {
   const [step, setStep] = useState<Step>('setup')

--- a/libs/design-system/src/app/WalletSendSiacoinDialog/types.ts
+++ b/libs/design-system/src/app/WalletSendSiacoinDialog/types.ts
@@ -1,0 +1,9 @@
+'use client'
+
+import BigNumber from 'bignumber.js'
+
+export type SendSiacoinFormData = {
+  address: string
+  hastings: BigNumber
+  includeFee: boolean
+}

--- a/libs/design-system/src/app/WalletSendSiacoinDialog/utils.ts
+++ b/libs/design-system/src/app/WalletSendSiacoinDialog/utils.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import BigNumber from 'bignumber.js'
+
+export function getTotalTransactionCost({
+  hastings,
+  includeFee,
+  fee,
+}: {
+  hastings: BigNumber
+  includeFee: boolean
+  fee: BigNumber
+}) {
+  return includeFee ? hastings : hastings.plus(fee)
+}
+
+export function getAmountUserWillReceive({
+  hastings,
+  includeFee,
+  fee,
+}: {
+  hastings: BigNumber
+  includeFee: boolean
+  fee: BigNumber
+}) {
+  return includeFee ? hastings.minus(fee) : hastings
+}

--- a/libs/design-system/src/components/ValueCopyable.tsx
+++ b/libs/design-system/src/components/ValueCopyable.tsx
@@ -23,6 +23,7 @@ import {
 } from '../core/DropdownMenu'
 
 type Props = {
+  testId?: string
   value: string
   displayValue?: string
   type?: EntityType
@@ -40,6 +41,7 @@ type Props = {
 }
 
 export function ValueCopyable({
+  testId,
   value,
   displayValue,
   type,
@@ -65,7 +67,7 @@ export function ValueCopyable({
   const text = renderValue || defaultFormatValue(cleanValue, maxLength)
 
   return (
-    <div className={cx('flex items-center', className)}>
+    <div data-testid={testId} className={cx('flex items-center', className)}>
       {href ? (
         <Link
           href={href}

--- a/libs/design-system/src/components/ValueSc.tsx
+++ b/libs/design-system/src/components/ValueSc.tsx
@@ -6,6 +6,7 @@ import { humanSiacoin } from '@siafoundation/units'
 import BigNumber from 'bignumber.js'
 
 type Props = {
+  testId?: string
   size?: React.ComponentProps<typeof Text>['size']
   scaleSize?: React.ComponentProps<typeof Text>['scaleSize']
   value: BigNumber // hastings
@@ -22,6 +23,7 @@ type Props = {
 }
 
 export function ValueSc({
+  testId,
   value,
   size,
   scaleSize,
@@ -49,6 +51,7 @@ export function ValueSc({
 
   const el = (
     <Text
+      data-testid={testId}
       size={size}
       scaleSize={scaleSize}
       weight="medium"

--- a/libs/hostd-types/src/api.ts
+++ b/libs/hostd-types/src/api.ts
@@ -170,6 +170,7 @@ export type WalletSendParams = void
 export type WalletSendPayload = {
   amount: string
   address: string
+  subtractMinerFee?: boolean
 }
 export type WalletSendResponse = TransactionID
 

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -169,9 +169,9 @@ import {
   TxPoolBroadcastParams,
   TxPoolBroadcastPayload,
   TxPoolBroadcastResponse,
-  TxPoolFeeParams,
-  TxPoolFeePayload,
-  TxPoolFeeResponse,
+  TxPoolRecommendedFeeParams,
+  TxPoolRecommendedFeePayload,
+  TxPoolRecommendedFeeResponse,
   TxPoolTransactionsParams,
   TxPoolTransactionsPayload,
   TxPoolTransactionsResponse,
@@ -203,6 +203,9 @@ import {
   WalletRedistributePayload,
   WalletRedistributeResponse,
   WalletResponse,
+  WalletSendParams,
+  WalletSendPayload,
+  WalletSendResponse,
   WalletSignParams,
   WalletSignPayload,
   WalletSignResponse,
@@ -259,7 +262,7 @@ import {
   busSyncerConnectRoute,
   busSyncerPeersRoute,
   busTxpoolBroadcastRoute,
-  busTxpoolFeeRoute,
+  busTxpoolRecommendedFeeRoute,
   busTxpoolTransactionsRoute,
   busWalletAddressesRoute,
   busWalletDiscardRoute,
@@ -269,6 +272,7 @@ import {
   busWalletPrepareFormRoute,
   busWalletRedistributeRoute,
   busWalletRoute,
+  busWalletSendRoute,
   busWalletSignRoute,
   busWalletTransactionsRoute,
 } from '@siafoundation/renterd-types'
@@ -310,10 +314,10 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       SyncerAddressResponse
     >(axios, 'get', busSyncerAddrRoute),
     txPoolFee: buildRequestHandler<
-      TxPoolFeeParams,
-      TxPoolFeePayload,
-      TxPoolFeeResponse
-    >(axios, 'get', busTxpoolFeeRoute),
+      TxPoolRecommendedFeeParams,
+      TxPoolRecommendedFeePayload,
+      TxPoolRecommendedFeeResponse
+    >(axios, 'get', busTxpoolRecommendedFeeRoute),
     txPoolTransactions: buildRequestHandler<
       TxPoolTransactionsParams,
       TxPoolTransactionsPayload,
@@ -349,6 +353,11 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       WalletFundPayload,
       WalletFundResponse
     >(axios, 'post', busWalletFundRoute),
+    walletSend: buildRequestHandler<
+      WalletSendParams,
+      WalletSendPayload,
+      WalletSendResponse
+    >(axios, 'post', busWalletSendRoute),
     walletSign: buildRequestHandler<
       WalletSignParams,
       WalletSignPayload,

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -151,8 +151,8 @@ import {
   TxPoolBroadcastParams,
   TxPoolBroadcastPayload,
   TxPoolBroadcastResponse,
-  TxPoolFeeParams,
-  TxPoolFeeResponse,
+  TxPoolRecommendedFeeParams,
+  TxPoolRecommendedFeeResponse,
   TxPoolTransactionsParams,
   TxPoolTransactionsResponse,
   WalletAddressesParams,
@@ -220,7 +220,7 @@ import {
   busSyncerConnectRoute,
   busSyncerPeersRoute,
   busTxpoolBroadcastRoute,
-  busTxpoolFeeRoute,
+  busTxpoolRecommendedFeeRoute,
   busTxpoolTransactionsRoute,
   busWalletAddressesRoute,
   busWalletDiscardRoute,
@@ -259,6 +259,10 @@ import {
   ContractSizeResponse,
   busContractIdSize,
   PricePinSettings,
+  WalletSendParams,
+  WalletSendPayload,
+  WalletSendResponse,
+  busWalletSendRoute,
 } from '@siafoundation/renterd-types'
 
 // state
@@ -354,10 +358,10 @@ export function useSyncerAddress(
 
 // txpool
 
-export function useTxPoolFee(
-  args?: HookArgsSwr<TxPoolFeeParams, TxPoolFeeResponse>
+export function useTxPoolRecommendedFee(
+  args?: HookArgsSwr<TxPoolRecommendedFeeParams, TxPoolRecommendedFeeResponse>
 ) {
-  return useGetSwr({ ...args, route: busTxpoolFeeRoute })
+  return useGetSwr({ ...args, route: busTxpoolRecommendedFeeRoute })
 }
 
 export function useTxPoolTransactions(
@@ -435,6 +439,24 @@ export function useWalletSign(
   >
 ) {
   return usePostFunc({ ...args, route: busWalletSignRoute })
+}
+
+export function useWalletSend(
+  args?: HookArgsCallback<
+    WalletSendParams,
+    WalletSendPayload,
+    WalletSendResponse
+  >
+) {
+  return usePostFunc({ ...args, route: busWalletSendRoute }, async (mutate) => {
+    await delay(2_000)
+    mutate((key) => {
+      return (
+        key.startsWith(busTxpoolTransactionsRoute) ||
+        key.startsWith(busWalletPendingRoute)
+      )
+    })
+  })
 }
 
 export function useWalletRedistribute(

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -7,6 +7,7 @@ import {
   CoveredFields,
   FileContractID,
   Block,
+  TransactionID,
 } from '@siafoundation/types'
 import {
   ConsensusState,
@@ -29,13 +30,14 @@ export const busSyncerConnectRoute = '/bus/syncer/connect'
 export const busSyncerAddrRoute = '/bus/syncer/addr'
 export const busTxpoolTransactionsRoute = '/bus/txpool/transactions'
 export const busTxpoolBroadcastRoute = '/bus/txpool/broadcast'
-export const busTxpoolFeeRoute = '/bus/txpool/fee'
+export const busTxpoolRecommendedFeeRoute = '/bus/txpool/recommendedfee'
 export const busWalletRoute = '/bus/wallet'
 export const busWalletAddressesRoute = '/bus/wallet/addresses'
 export const busWalletTransactionsRoute = '/bus/wallet/transactions'
 export const busWalletOutputsRoute = '/bus/wallet/outputs'
 export const busWalletFundRoute = '/bus/wallet/fund'
 export const busWalletSignRoute = '/bus/wallet/sign'
+export const busWalletSendRoute = '/bus/wallet/send'
 export const busWalletRedistributeRoute = '/bus/wallet/redistribute'
 export const busWalletDiscardRoute = '/bus/wallet/discard'
 export const busWalletPrepareFormRoute = '/bus/wallet/prepare/form'
@@ -130,9 +132,9 @@ export type SyncerAddressResponse = string
 
 // txpool
 
-export type TxPoolFeeParams = void
-export type TxPoolFeePayload = void
-export type TxPoolFeeResponse = Currency
+export type TxPoolRecommendedFeeParams = void
+export type TxPoolRecommendedFeePayload = void
+export type TxPoolRecommendedFeeResponse = Currency
 
 export type TxPoolTransactionsParams = void
 export type TxPoolTransactionsPayload = void
@@ -187,6 +189,15 @@ export type WalletSignPayload = {
   coveredFields: CoveredFields
 }
 export type WalletSignResponse = Transaction
+
+export type WalletSendParams = void
+export type WalletSendPayload = {
+  address: string
+  amount: Currency
+  subtractMinerFee?: boolean
+  useUnconfirmed?: boolean
+}
+export type WalletSendResponse = TransactionID
 
 export type WalletRedistributeParams = void
 export type WalletRedistributePayload = {


### PR DESCRIPTION
Blocked by https://github.com/SiaFoundation/hostd/issues/454
Relates to https://github.com/SiaFoundation/renterd/pull/1436

### renterd
- The send siacoin feature now calculates the fee using the daemon's recommended fee and a standard transaction size.
- Add e2e tests for sending siacoin.

### renterd sdks
- Fixed the recommended fee API route.
- Added the wallet send API.

### hostd
- The send siacoin feature now calculates the fee using the daemon's recommended fee and a standard transaction size.
- Add e2e tests for sending siacoin.
- Refactor test setup with `beforeTest` helper.

### hostd sdks
- The wallet send API now supports the subtractMinerFee option.
