### PR TITLE
refactor: renterd account reset drift moved to worker

### DIFF
--- a/.changeset/cold-trees-relate.md
+++ b/.changeset/cold-trees-relate.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+The account reset drift API was moved from bus to worker. Closes https://github.com/SiaFoundation/web/issues/704

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -1,7 +1,4 @@
 import {
-  AccountResetDriftParams,
-  AccountResetDriftPayload,
-  AccountResetDriftResponse,
   AlertsDismissParams,
   AlertsDismissPayload,
   AlertsDismissResponse,
@@ -212,7 +209,6 @@ import {
   WalletUtxoParams,
   WalletUtxoPayload,
   WalletUtxoResponse,
-  busAccountIdResetdriftRoute,
   busAlertsDismissRoute,
   busAlertsRoute,
   busBucketNamePolicyRoute,
@@ -419,11 +415,6 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       HostResetLostSectorCountPayload,
       HostResetLostSectorCountResponse
     >(axios, 'post', busHostPublicKeyResetlostsectorsRoute),
-    accountResetDrift: buildRequestHandler<
-      AccountResetDriftParams,
-      AccountResetDriftPayload,
-      AccountResetDriftResponse
-    >(axios, 'post', busAccountIdResetdriftRoute),
     contracts: buildRequestHandler<
       ContractsParams,
       ContractsPayload,

--- a/libs/renterd-js/src/worker.ts
+++ b/libs/renterd-js/src/worker.ts
@@ -1,4 +1,7 @@
 import {
+  AccountResetDriftParams,
+  AccountResetDriftPayload,
+  AccountResetDriftResponse,
   MultipartUploadPartParams,
   MultipartUploadPartPayload,
   MultipartUploadPartResponse,
@@ -14,6 +17,7 @@ import {
   WorkerStateParams,
   WorkerStatePayload,
   WorkerStateResponse,
+  workerAccountIdResetdriftRoute,
   workerMultipartKeyRoute,
   workerObjectsKeyRoute,
   workerRhpScanRoute,
@@ -66,5 +70,10 @@ export function Worker({ api, password }: { api: string; password?: string }) {
       RhpScanPayload,
       RhpScanResponse
     >(axios, 'post', workerRhpScanRoute),
+    accountResetDrift: buildRequestHandler<
+      AccountResetDriftParams,
+      AccountResetDriftPayload,
+      AccountResetDriftResponse
+    >(axios, 'post', workerAccountIdResetdriftRoute),
   }
 }

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -15,9 +15,6 @@ import {
   getTestnetZenBlockHeight,
 } from '@siafoundation/units'
 import {
-  AccountResetDriftParams,
-  AccountResetDriftPayload,
-  AccountResetDriftResponse,
   AlertsDismissParams,
   AlertsDismissPayload,
   AlertsDismissResponse,
@@ -185,7 +182,6 @@ import {
   WalletTransactionsResponse,
   WalletUtxoParams,
   WalletUtxoResponse,
-  busAccountIdResetdriftRoute,
   busBucketRoute,
   busBucketNamePolicyRoute,
   busBucketNameRoute,
@@ -579,21 +575,6 @@ export function useHostResetLostSectorCount(
   return usePostFunc({
     ...args,
     route: busHostPublicKeyResetlostsectorsRoute,
-  })
-}
-
-// accounts
-
-export function useAccountResetDrift(
-  args?: HookArgsCallback<
-    AccountResetDriftParams,
-    AccountResetDriftPayload,
-    AccountResetDriftResponse
-  >
-) {
-  return usePostFunc({
-    ...args,
-    route: busAccountIdResetdriftRoute,
   })
 }
 

--- a/libs/renterd-react/src/worker.ts
+++ b/libs/renterd-react/src/worker.ts
@@ -8,6 +8,9 @@ import {
   useGetSwr,
 } from '@siafoundation/react-core'
 import {
+  AccountResetDriftParams,
+  AccountResetDriftPayload,
+  AccountResetDriftResponse,
   AutopilotHost,
   Host,
   MultipartUploadPartParams,
@@ -27,6 +30,7 @@ import {
   autopilotHostsRoute,
   busObjectsRoute,
   busSearchHostsRoute,
+  workerAccountIdResetdriftRoute,
   workerMultipartKeyRoute,
   workerObjectsKeyRoute,
   workerRhpScanRoute,
@@ -169,4 +173,19 @@ export function useRhpScan(
       })
     }
   )
+}
+
+// accounts
+
+export function useAccountResetDrift(
+  args?: HookArgsCallback<
+    AccountResetDriftParams,
+    AccountResetDriftPayload,
+    AccountResetDriftResponse
+  >
+) {
+  return usePostFunc({
+    ...args,
+    route: workerAccountIdResetdriftRoute,
+  })
 }

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -48,7 +48,6 @@ export const busHostsBlocklistRoute = '/bus/hosts/blocklist'
 export const busHostsAllowlistRoute = '/bus/hosts/allowlist'
 export const busHostPublicKeyResetlostsectorsRoute =
   '/bus/host/:publicKey/resetlostsectors'
-export const busAccountIdResetdriftRoute = '/bus/account/:id/resetdrift'
 export const busContractsRoute = '/bus/contracts'
 export const busContractIdAcquireRoute = '/bus/contract/:id/acquire'
 export const busContractIdReleaseRoute = '/bus/contract/:id/release'
@@ -284,12 +283,6 @@ export type HostResetLostSectorCountParams = {
 }
 export type HostResetLostSectorCountPayload = void
 export type HostResetLostSectorCountResponse = void
-
-// accounts
-
-export type AccountResetDriftParams = { id: string }
-export type AccountResetDriftPayload = void
-export type AccountResetDriftResponse = void
 
 // contracts
 

--- a/libs/renterd-types/src/worker.ts
+++ b/libs/renterd-types/src/worker.ts
@@ -5,6 +5,7 @@ export const workerStateRoute = '/worker/state'
 export const workerObjectsKeyRoute = '/worker/objects/:key'
 export const workerMultipartKeyRoute = '/worker/multipart/:key'
 export const workerRhpScanRoute = '/worker/rhp/scan'
+export const workerAccountIdResetdriftRoute = '/worker/account/:id/resetdrift'
 
 // state
 
@@ -13,6 +14,8 @@ export type WorkerStatePayload = void
 export type WorkerStateResponse = BusStateResponse & {
   id: string
 }
+
+// objects
 
 export type ObjectDownloadParams = { key: string; bucket: string }
 export type ObjectDownloadPayload = void
@@ -28,6 +31,8 @@ export type ObjectUploadPayload =
   | Record<string, unknown>
 export type ObjectUploadResponse = void
 
+// multipart
+
 export type MultipartUploadPartParams = {
   key: string
   uploadid: string
@@ -41,6 +46,8 @@ export type MultipartUploadPartParams = {
 export type MultipartUploadPartPayload = Blob | Buffer | ArrayBuffer | string
 export type MultipartUploadPartResponse = void
 
+// rhp
+
 export type RhpScanParams = void
 export type RhpScanPayload = {
   hostKey: string
@@ -52,3 +59,9 @@ export type RhpScanResponse = {
   scanError?: string
   settings?: HostSettings
 }
+
+// accounts
+
+export type AccountResetDriftParams = { id: string }
+export type AccountResetDriftPayload = void
+export type AccountResetDriftResponse = void


### PR DESCRIPTION
- The account reset drift API was moved from bus to worker. https://github.com/SiaFoundation/web/issues/704

