### PR TITLE
refactor: renterd tests cluster

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -10,7 +10,7 @@ inputs:
   go_version:
     description: Go version
     required: false
-    default: '1.21.7'
+    default: '1.23.0'
 
 runs:
   using: composite

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,7 +6,7 @@ inputs:
   go_version:
     description: Go version
     required: false
-    default: '1.21.7'
+    default: '1.23.0'
 
 runs:
   using: composite

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       - name: Commit lint
         shell: bash
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       # The SDK is referenced via dist in the tsconfig.base.json
       # because the next executor does not actually support
       # buildLibsFromSource=false
@@ -80,7 +80,7 @@ jobs:
         run: npx playwright install-deps
       - name: Test e2e
         shell: bash
-        run: npx nx affected --target=e2e --parallel=5
+        run: npx nx affected --target=e2e --parallel=1
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RENTERD_E2E_TEST_API_URL: ${{ secrets.RENTERD_E2E_TEST_API_URL }}
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
-          go_version: 1.21.7
+          go_version: 1.23.0
       - name: Lint Go
         uses: golangci/golangci-lint-action@v4
         with:

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       - name: Release
         run: ./scripts/release-go.sh
       - name: Commit

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       # The SDK is referenced via dist in the tsconfig.base.json
       # because the next executor does not actually support
       # buildLibsFromSource=false
@@ -83,7 +83,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       - uses: docker/setup-buildx-action@v2
       - uses: docker/login-action@v2
         with:
@@ -125,7 +125,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       - name: Lint TypeScript
         shell: bash
         run: npx nx run-many --target=lint --all --parallel=5
@@ -157,7 +157,7 @@ jobs:
         uses: ./.github/actions/setup-all
         with:
           node_version: 20.10.0
-          go_version: 1.21.7
+          go_version: 1.23.0
       # The SDK is referenced via dist in the tsconfig.base.json
       # because the next executor does not actually support
       # buildLibsFromSource=false
@@ -171,7 +171,7 @@ jobs:
         run: npx playwright install-deps
       - name: Test e2e
         shell: bash
-        run: npx nx run-many --target=e2e --all --parallel=5
+        run: npx nx run-many --target=e2e --all --parallel=1
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RENTERD_E2E_TEST_API_URL: ${{ secrets.RENTERD_E2E_TEST_API_URL }}
@@ -212,7 +212,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
-          go_version: 1.21.7
+          go_version: 1.23.0
       - name: Lint Go
         uses: golangci/golangci-lint-action@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ dist
 /assets
 
 .nx/cache
+
+bin/

--- a/apps/renterd-e2e/playwright.config.ts
+++ b/apps/renterd-e2e/playwright.config.ts
@@ -24,11 +24,11 @@ export default defineConfig({
     trace: 'on-first-retry',
     video: 'on-first-retry',
   },
-  // Timeout per test.
-  timeout: 60_000,
+  // Timeout per test. The cluster takes up to 30 seconds to start and form contracts.
+  timeout: 120_000,
   expect: {
     // Raise the timeout because it is running against next dev mode
-    // which requires compilation the first to a page is visited
+    // which requires compilation the first to a page is visited.
     timeout: 15_000,
   },
   outputDir: 'output',
@@ -39,20 +39,16 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },
-  // Run the tests serially as they may mutate the state of the same application.
-  workers: 1,
+  workers: process.env.CI ? 4 : undefined,
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
-    // Disable firefox and webkit to save time since tests are running serially.
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
     // {
     //   name: 'webkit',
     //   use: { ...devices['Desktop Safari'] },

--- a/apps/renterd-e2e/project.json
+++ b/apps/renterd-e2e/project.json
@@ -5,9 +5,16 @@
   "projectType": "application",
   "implicitDependencies": ["renterd"],
   "targets": {
+    "build-cluster": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "go build -C internal/cluster -o bin/clusterd ./cmd/clusterd"
+      }
+    },
     "e2e": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/renterd-e2e"],
+      "dependsOn": ["build-cluster"],
       "options": {
         "config": "apps/renterd-e2e/playwright.config.ts"
       }

--- a/apps/renterd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/renterd-e2e/src/fixtures/beforeTest.ts
@@ -1,26 +1,26 @@
-import {
-  mockApiSiaCentralExchangeRates,
-  mockApiSiaCentralHostsNetworkAverages,
-} from '@siafoundation/sia-central-mock'
 import { login } from './login'
-import { navigateToConfig } from './navigate'
-import { configResetAllSettings } from './configResetAllSettings'
-import { setViewMode } from './configViewMode'
 import { Page } from 'playwright'
-import { mockApiSiaScanExchangeRates } from './siascan'
 import { setCurrencyDisplay } from './preferences'
+import { mockApiSiaScanExchangeRates } from './siascan'
+import { mockApiSiaCentralHostsNetworkAverages } from '@siafoundation/sia-central-mock'
+import { clickIf } from './click'
+import { clusterd, setupCluster, teardownCluster } from './clusterd'
 
-export async function beforeTest(page: Page, shouldResetConfig = true) {
-  await mockApiSiaCentralExchangeRates({ page })
-  await mockApiSiaCentralHostsNetworkAverages({ page })
+export async function beforeTest(page: Page, { hostdCount = 0 } = {}) {
   await mockApiSiaScanExchangeRates({ page })
-  await login({ page })
+  await mockApiSiaCentralHostsNetworkAverages({ page })
+  await setupCluster({ hostdCount })
+  await login({
+    page,
+    address: clusterd.renterdAddress,
+    password: clusterd.renterdPassword,
+  })
 
   // Reset state.
   await setCurrencyDisplay(page, 'bothPreferSc')
-  if (shouldResetConfig) {
-    await navigateToConfig({ page })
-    await configResetAllSettings({ page })
-    await setViewMode({ page, state: 'basic' })
-  }
+  await clickIf(page.getByLabel('minimize onboarding wizard'), 'isVisible')
+}
+
+export async function afterTest() {
+  teardownCluster()
 }

--- a/apps/renterd-e2e/src/fixtures/clusterd.ts
+++ b/apps/renterd-e2e/src/fixtures/clusterd.ts
@@ -1,0 +1,139 @@
+import child from 'child_process'
+import { random } from '@technically/lodash'
+import Axios from 'axios'
+import { Bus } from '@siafoundation/renterd-js'
+import { pluralize } from '@siafoundation/units'
+
+export const clusterd = {
+  process: null as child.ChildProcessWithoutNullStreams,
+  managementPort: undefined as number,
+  renterdAddress: undefined as string,
+  renterdPassword: undefined as string,
+}
+
+const maxTimeWaitingForAllNodesToStartup = 30_000
+const maxTimeWaitingForContractsToForm = 60_000
+
+export async function setupCluster({ hostdCount = 0 } = {}) {
+  clusterd.managementPort = random(10000, 65535)
+  console.log('Starting cluster on port', clusterd.managementPort)
+
+  clusterd.process = child.spawn('internal/cluster/bin/clusterd', [
+    '-renterd=1',
+    `-hostd=${hostdCount}`,
+    `-api=:${clusterd.managementPort}`,
+  ])
+  // Drain buffer to prevent process from hanging.
+  clusterd.process.stdout.on('data', () => null)
+  clusterd.process.stderr.on('data', () => null)
+  clusterd.process.on('error', (err) => {
+    console.error('Failed to start clusterd:', err)
+  })
+  clusterd.process.on('exit', (code) => {
+    console.log(
+      `clusterd process ${clusterd.process.pid} exited with code ${code}`
+    )
+  })
+
+  console.time('waiting for nodes to start')
+  await waitFor(
+    async () => {
+      const addr = `http://localhost:${clusterd.managementPort}/nodes`
+      try {
+        const nodes = await Axios.get(addr)
+        const renterNodes = nodes.data.filter((n) => n.type === 'renterd')
+        const hostdNodes = nodes.data.filter((n) => n.type === 'hostd')
+        if (renterNodes.length === 1 && hostdNodes.length === hostdCount) {
+          clusterd.renterdAddress = renterNodes[0].apiAddress.replace(
+            '[::]',
+            '127.0.0.1'
+          )
+          clusterd.renterdPassword = renterNodes[0].password
+          return true
+        }
+        console.log('waiting for nodes...')
+        return false
+      } catch (e) {
+        console.log(`Error fetching nodes: ${addr}`)
+        return false
+      }
+    },
+    {
+      timeout: maxTimeWaitingForAllNodesToStartup,
+      interval: 1_000,
+    }
+  )
+  console.timeEnd('waiting for nodes to start')
+
+  console.log(`renterd node started, ${hostdCount} hostd nodes started`)
+
+  const renterdApi = `${clusterd.renterdAddress}/api`
+  const bus = Bus({
+    api: renterdApi,
+    password: clusterd.renterdPassword,
+  })
+
+  if (hostdCount === 0) {
+    return
+  }
+
+  console.time('waiting for contracts to form')
+  await waitFor(
+    async () => {
+      await mine(1)
+      const hosts = await bus.hostsSearch({
+        data: {
+          filterMode: 'allowed',
+          usabilityMode: 'usable',
+          limit: 50,
+          offset: 0,
+        },
+      })
+      const contracts = await bus.contracts()
+      console.log(
+        `usable hosts: ${hosts.data.length}/${hostdCount} - active contracts: ${contracts.data.length}/${hostdCount}`
+      )
+      return (
+        hosts.data.length >= hostdCount && contracts.data.length >= hostdCount
+      )
+    },
+    {
+      timeout: maxTimeWaitingForContractsToForm,
+      interval: 2_000,
+    }
+  )
+  console.timeEnd('waiting for contracts to form')
+}
+
+export async function mine(blocks: number) {
+  console.log(`Mining ${pluralize(blocks, 'block')}...`)
+  await Axios.post(`http://localhost:${clusterd.managementPort}/mine`, {
+    blocks,
+  })
+}
+
+export async function teardownCluster() {
+  console.log('stopping cluster')
+  clusterd.process?.kill()
+}
+
+function waitFor(
+  condition: () => Promise<boolean>,
+  {
+    timeout = 1000,
+    interval = 500,
+  }: { timeout?: number; interval?: number } = {}
+) {
+  return new Promise<void>((resolve, reject) => {
+    const intervalRef = setInterval(async () => {
+      if (await condition()) {
+        clearInterval(intervalRef)
+        resolve()
+      }
+    }, interval)
+    setTimeout(() => {
+      clearInterval(intervalRef)
+      reject(new Error('Timeout'))
+    }, timeout)
+  })
+}

--- a/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
+++ b/apps/renterd-e2e/src/fixtures/configResetAllSettings.ts
@@ -5,8 +5,10 @@ import { fillTextInputByName } from './textInput'
 import { clearToasts } from './clearToasts'
 import { clickIfEnabledAndWait } from './click'
 import { fillSelectInputByName } from './selectInput'
+import { navigateToConfig } from './navigate'
 
 export async function configResetAllSettings({ page }: { page: Page }) {
+  await navigateToConfig({ page })
   await setViewMode({ page, state: 'advanced' })
 
   // pinning
@@ -29,14 +31,14 @@ export async function configResetAllSettings({ page }: { page: Page }) {
   await fillTextInputByName(page, 'allowanceMonth', '21000')
   await fillTextInputByName(page, 'periodWeeks', '6')
   await fillTextInputByName(page, 'renewWindowWeeks', '2')
-  await fillTextInputByName(page, 'amountHosts', '12')
+  await fillTextInputByName(page, 'amountHosts', '3')
   await fillTextInputByName(page, 'autopilotContractSet', 'autopilot')
   await setSwitchByLabel(page, 'prune', false)
 
   // hosts
   await setSwitchByLabel(page, 'allowRedundantIPs', false)
-  await fillTextInputByName(page, 'maxDowntimeHours', '7')
-  await fillTextInputByName(page, 'maxConsecutiveScanFailures', '1')
+  await fillTextInputByName(page, 'maxDowntimeHours', '330')
+  await fillTextInputByName(page, 'maxConsecutiveScanFailures', '10')
   await fillTextInputByName(page, 'minProtocolVersion', '1.6.0')
 
   // contracts
@@ -69,8 +71,8 @@ export async function configResetAllSettings({ page }: { page: Page }) {
   await fillTextInputByName(page, 'migrationSurchargeMultiplier', '1')
 
   // redundancy
-  await fillTextInputByName(page, 'minShards', '2')
-  await fillTextInputByName(page, 'totalShards', '6')
+  await fillTextInputByName(page, 'minShards', '1')
+  await fillTextInputByName(page, 'totalShards', '3')
 
   // save
   await clickIfEnabledAndWait(
@@ -78,4 +80,5 @@ export async function configResetAllSettings({ page }: { page: Page }) {
     page.getByText('Configuration has been saved')
   )
   await clearToasts({ page })
+  await setViewMode({ page, state: 'basic' })
 }

--- a/apps/renterd-e2e/src/fixtures/hosts.ts
+++ b/apps/renterd-e2e/src/fixtures/hosts.ts
@@ -1,0 +1,60 @@
+import { Locator, Page, expect } from '@playwright/test'
+
+export async function getHostRowById(page: Page, id: string) {
+  return page.getByTestId('hostsTable').getByTestId(id)
+}
+
+export async function getHostsSummaryRow(page: Page) {
+  return page.getByTestId('hostsTable').locator('thead').getByRole('row').nth(1)
+}
+
+export async function getHostRowByIndex(page: Page, index: number) {
+  return page
+    .getByTestId('hostsTable')
+    .locator('tbody')
+    .getByRole('row')
+    .nth(index)
+}
+
+export async function getHostRows(page: Page) {
+  return page.getByTestId('hostsTable').locator('tbody').getByRole('row').all()
+}
+
+export async function openHostContextMenu(page: Page, name: string) {
+  await page
+    .getByTestId('hostsTable')
+    .locator('tbody')
+    .getByRole('row', { name })
+    .getByRole('button')
+    .first()
+    .click()
+}
+
+export async function openRowHostContextMenu(row: Locator) {
+  await row.getByTestId('actions').getByRole('button').first().click()
+}
+
+export async function toggleColumnVisibility(
+  page: Page,
+  name: string,
+  visible: boolean
+) {
+  await page.getByLabel('configure view').click()
+  const configureView = page.getByRole('dialog')
+  const columnToggle = configureView.getByRole('checkbox', {
+    name,
+  })
+
+  if (visible) {
+    await expect(columnToggle).toBeVisible()
+    if (!(await columnToggle.isChecked())) {
+      await columnToggle.click()
+    }
+  } else {
+    await expect(columnToggle).toBeHidden()
+    if (await columnToggle.isChecked()) {
+      await columnToggle.click()
+    }
+  }
+  await page.getByLabel('configure view').click()
+}

--- a/apps/renterd-e2e/src/fixtures/login.ts
+++ b/apps/renterd-e2e/src/fixtures/login.ts
@@ -1,17 +1,21 @@
 import { Page, expect } from '@playwright/test'
 import { fillTextInputByName } from './textInput'
 
-export async function login({ page }: { page: Page }) {
+export async function login({
+  page,
+  address,
+  password,
+}: {
+  page: Page
+  address: string
+  password: string
+}) {
   await page.goto('/login')
   await expect(page).toHaveTitle('renterd')
   await page.getByLabel('login settings').click()
   await page.getByRole('menuitem', { name: 'Show custom API' }).click()
-  await fillTextInputByName(page, 'api', process.env.RENTERD_E2E_TEST_API_URL)
-  await fillTextInputByName(
-    page,
-    'password',
-    process.env.RENTERD_E2E_TEST_API_PASSWORD
-  )
+  await fillTextInputByName(page, 'api', address)
+  await fillTextInputByName(page, 'password', password)
   await page.locator('input[name=password]').press('Enter')
   await expect(page.getByTestId('navbar').getByText('Buckets')).toBeVisible()
 }

--- a/apps/renterd-e2e/src/fixtures/navigate.ts
+++ b/apps/renterd-e2e/src/fixtures/navigate.ts
@@ -23,3 +23,8 @@ export async function navigateToWallet(page: Page) {
   await page.getByTestId('sidenav').getByLabel('Wallet').click()
   await expect(page.getByTestId('navbar').getByText('Wallet')).toBeVisible()
 }
+
+export async function navigateToHosts({ page }: { page: Page }) {
+  await page.getByTestId('sidenav').getByLabel('Hosts').click()
+  await expect(page.getByTestId('navbar').getByText('Hosts')).toBeVisible()
+}

--- a/apps/renterd-e2e/src/specs/buckets.spec.ts
+++ b/apps/renterd-e2e/src/specs/buckets.spec.ts
@@ -7,10 +7,14 @@ import {
   deleteBucketIfExists,
   openBucketContextMenu,
 } from '../fixtures/buckets'
-import { beforeTest } from '../fixtures/beforeTest'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
 
 test.beforeEach(async ({ page }) => {
   await beforeTest(page)
+})
+
+test.afterEach(async () => {
+  await afterTest()
 })
 
 test('can change a buckets policy', async ({ page }) => {

--- a/apps/renterd-e2e/src/specs/config.spec.ts
+++ b/apps/renterd-e2e/src/specs/config.spec.ts
@@ -6,13 +6,17 @@ import {
   expectTextInputByName,
   fillTextInputByName,
 } from '../fixtures/textInput'
-import { clearToasts } from '../fixtures/clearToasts'
-import { clickIfEnabledAndWait, clickIf } from '../fixtures/click'
-import { beforeTest } from '../fixtures/beforeTest'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
 import { setCurrencyDisplay } from '../fixtures/preferences'
+import { configResetAllSettings } from '../fixtures/configResetAllSettings'
 
 test.beforeEach(async ({ page }) => {
   await beforeTest(page)
+  await configResetAllSettings({ page })
+})
+
+test.afterEach(async () => {
+  await afterTest()
 })
 
 test('basic field change and save behaviour', async ({ page }) => {
@@ -254,117 +258,4 @@ test('set max prices via individual field tips', async ({ page }) => {
   await expectTextInputByName(page, 'maxStoragePriceTBMonthPinned', '$3.53')
   await expectTextInputByName(page, 'maxUploadPriceTBPinned', '$0.88')
   await expectTextInputByName(page, 'maxDownloadPriceTB', '1,118.588756')
-})
-
-test('system offers recommendations', async ({ page }) => {
-  // Reset state.
-  await navigateToConfig({ page })
-  await setViewMode({ page, state: 'basic' })
-
-  // Reset to very high values that will not need any recommendations.
-  await fillTextInputByName(page, 'storageTB', '1')
-  await fillTextInputByName(page, 'uploadTBMonth', '1')
-  await fillTextInputByName(page, 'downloadTBMonth', '1')
-  await fillTextInputByName(page, 'maxStoragePriceTBMonth', '100000000')
-  await fillTextInputByName(page, 'maxUploadPriceTB', '100000000')
-  await fillTextInputByName(page, 'maxDownloadPriceTB', '100000000')
-  await clickIfEnabledAndWait(
-    page.getByText('Save changes'),
-    page.getByText('Configuration has been saved')
-  )
-  await clearToasts({ page })
-
-  await expect(
-    page.getByText(
-      /(No recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
-    )
-  ).toBeVisible()
-
-  await fillTextInputByName(page, 'storageTB', '10')
-  await fillTextInputByName(page, 'uploadTBMonth', '10')
-  await fillTextInputByName(page, 'downloadTBMonth', '4')
-  await fillTextInputByName(page, 'allowanceMonth', '21000')
-  await fillTextInputByName(page, 'maxStoragePriceTBMonth', '100')
-  await fillTextInputByName(page, 'maxUploadPriceTB', '100')
-  await fillTextInputByName(page, 'maxDownloadPriceTB', '100')
-  await clickIfEnabledAndWait(
-    page.getByText('Save changes'),
-    page.getByText('Configuration has been saved')
-  )
-  await clearToasts({ page })
-  // There are now recommendations.
-  await expect(
-    page.getByText('No recommendations to match with more hosts')
-  ).toBeHidden()
-
-  // Apply all recommendations.
-  const count = await page
-    .getByTestId('recommendationsList')
-    .locator('*')
-    .evaluateAll((elements) => elements.length)
-  expect(count).toBeGreaterThan(0)
-
-  const storagePriceBtn = page
-    .getByTestId('recommendationsList')
-    .getByTestId('maxStoragePriceTBMonth')
-    .locator('button')
-  const uploadPriceBtn = page
-    .getByTestId('recommendationsList')
-    .getByTestId('maxUploadPriceTB')
-    .locator('button')
-  const downloadPriceBtn = page
-    .getByTestId('recommendationsList')
-    .getByTestId('maxDownloadPriceTB')
-    .locator('button')
-
-  await clickIf(storagePriceBtn, 'isVisible')
-  await expect(storagePriceBtn).toBeHidden()
-  await clickIf(uploadPriceBtn, 'isVisible')
-  await expect(uploadPriceBtn).toBeHidden()
-  await clickIf(downloadPriceBtn, 'isVisible')
-  await expect(downloadPriceBtn).toBeHidden()
-
-  // Check that all recommendations were applied and there are changes to the config.
-  // TODO: disabled because sometimes the "increase value" recommendation is
-  // replaced with a "decrease value" recommendation with the same value.
-  // await expect(page.getByTestId('recommendationsList')).toBeHidden()
-
-  await expect(page.getByText(`Save changes`)).toBeEnabled()
-})
-
-test('recommendations work with pinned fields', async ({ page }) => {
-  // Reset state.
-  await navigateToConfig({ page })
-  await setViewMode({ page, state: 'basic' })
-
-  // Set to low values that will trigger recommendations.
-  await fillTextInputByName(page, 'storageTB', '10')
-  await fillTextInputByName(page, 'uploadTBMonth', '10')
-  await fillTextInputByName(page, 'downloadTBMonth', '4')
-  await fillTextInputByName(page, 'allowanceMonth', '21000')
-  await fillTextInputByName(page, 'maxStoragePriceTBMonth', '100')
-  await fillTextInputByName(page, 'maxUploadPriceTB', '100')
-  await fillTextInputByName(page, 'maxDownloadPriceTB', '100')
-  // There are now recommendations.
-  await expect(
-    page.getByText('No recommendations to match with more hosts')
-  ).toBeHidden()
-
-  // Set to high mixed values that will not need any recommendations.
-  await setSwitchByLabel(page, 'shouldPinMaxStoragePrice', true)
-  await fillTextInputByName(page, 'maxStoragePriceTBMonthPinned', '100000000')
-  await fillTextInputByName(page, 'maxUploadPriceTB', '100000000')
-  await fillTextInputByName(page, 'maxDownloadPriceTB', '100000000')
-  await expect(
-    page.getByText(
-      /(No recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
-    )
-  ).toBeVisible()
-
-  // Set the pinned max storage price to a low USD value equivalent to 100 SC.
-  await fillTextInputByName(page, 'maxStoragePriceTBMonthPinned', '0.39')
-  // There are now recommendations again.
-  await expect(
-    page.getByText('No recommendations to match with more hosts')
-  ).toBeHidden()
 })

--- a/apps/renterd-e2e/src/specs/contracts.spec.ts
+++ b/apps/renterd-e2e/src/specs/contracts.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { navigateToContracts } from '../fixtures/navigate'
-import { beforeTest } from '../fixtures/beforeTest'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
 import {
   getContractRowByIndex,
   getContractRows,
@@ -9,7 +9,13 @@ import {
 } from '../fixtures/contracts'
 
 test.beforeEach(async ({ page }) => {
-  await beforeTest(page)
+  await beforeTest(page, {
+    hostdCount: 3,
+  })
+})
+
+test.afterEach(async () => {
+  await afterTest()
 })
 
 test('contracts prunable size', async ({ page }) => {
@@ -23,7 +29,9 @@ test('contracts prunable size', async ({ page }) => {
   const summaryRowCell = summaryRow.getByTestId('prunableSize')
   await expect(summaryRowCell).toBeVisible()
   await expect(summaryRowCell.getByRole('button')).toBeVisible()
-  await expect(summaryRowCell.getByLabel('prunable sizes')).toBeHidden()
+  await expect(summaryRowCell.getByLabel('prunable sizes')).toBeHidden({
+    timeout: 30_000,
+  })
 
   // Check that the prunable size is not visible on the first row.
   const row1 = await getContractRowByIndex(page, 0)

--- a/apps/renterd-e2e/src/specs/files.spec.ts
+++ b/apps/renterd-e2e/src/specs/files.spec.ts
@@ -20,10 +20,16 @@ import {
 } from '../fixtures/files'
 import { fillTextInputByName } from '../fixtures/textInput'
 import { clearToasts } from '../fixtures/clearToasts'
-import { beforeTest } from '../fixtures/beforeTest'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
 
 test.beforeEach(async ({ page }) => {
-  await beforeTest(page)
+  await beforeTest(page, {
+    hostdCount: 3,
+  })
+})
+
+test.afterEach(async () => {
+  await afterTest()
 })
 
 test('can create directory, upload file, rename file, navigate, delete a file, delete a directory', async ({

--- a/apps/renterd-e2e/src/specs/login.spec.ts
+++ b/apps/renterd-e2e/src/specs/login.spec.ts
@@ -1,7 +1,20 @@
 import { test, expect } from '@playwright/test'
 import { login } from '../fixtures/login'
+import { clusterd, setupCluster, teardownCluster } from '../fixtures/clusterd'
+
+test.beforeEach(async () => {
+  await setupCluster()
+})
+
+test.afterEach(async () => {
+  await teardownCluster()
+})
 
 test('login', async ({ page }) => {
-  await login({ page })
+  await login({
+    page,
+    address: clusterd.renterdAddress,
+    password: clusterd.renterdPassword,
+  })
   await expect(page.getByTestId('navbar').getByText('Buckets')).toBeVisible()
 })

--- a/apps/renterd-e2e/src/specs/recommendations.spec.ts
+++ b/apps/renterd-e2e/src/specs/recommendations.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test'
+import { setSwitchByLabel } from '../fixtures/switchValue'
+import { setViewMode } from '../fixtures/configViewMode'
+import { navigateToConfig } from '../fixtures/navigate'
+import { fillTextInputByName } from '../fixtures/textInput'
+import { clearToasts } from '../fixtures/clearToasts'
+import { clickIfEnabledAndWait, clickIf } from '../fixtures/click'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
+import { configResetAllSettings } from '../fixtures/configResetAllSettings'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page, {
+    hostdCount: 6,
+  })
+  await configResetAllSettings({ page })
+})
+
+test.afterEach(async () => {
+  await afterTest()
+})
+
+test('system offers recommendations', async ({ page }) => {
+  // Reset state.
+  await navigateToConfig({ page })
+  await setViewMode({ page, state: 'basic' })
+
+  // Reset to very high values that will not need any recommendations.
+  await fillTextInputByName(page, 'storageTB', '1')
+  await fillTextInputByName(page, 'uploadTBMonth', '1')
+  await fillTextInputByName(page, 'downloadTBMonth', '1')
+  await fillTextInputByName(page, 'maxStoragePriceTBMonth', '100000000')
+  await fillTextInputByName(page, 'maxUploadPriceTB', '100000000')
+  await fillTextInputByName(page, 'maxDownloadPriceTB', '100000000')
+  await clickIfEnabledAndWait(
+    page.getByText('Save changes'),
+    page.getByText('Configuration has been saved')
+  )
+  await clearToasts({ page })
+
+  // Configuration matches with hosts.
+  await expect(
+    page.getByText(
+      /(No recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
+    )
+  ).toBeVisible()
+
+  // Reset to low values that will need recommendations.
+  await fillTextInputByName(page, 'storageTB', '1')
+  await fillTextInputByName(page, 'uploadTBMonth', '1')
+  await fillTextInputByName(page, 'downloadTBMonth', '1')
+  await fillTextInputByName(page, 'allowanceMonth', '1000')
+  await fillTextInputByName(page, 'maxStoragePriceTBMonth', '300')
+  await fillTextInputByName(page, 'maxUploadPriceTB', '75')
+  await fillTextInputByName(page, 'maxDownloadPriceTB', '375')
+  await clickIfEnabledAndWait(
+    page.getByText('Save changes'),
+    page.getByText('Configuration has been saved')
+  )
+  await clearToasts({ page })
+  // There are now recommendations.
+  await expect(
+    page.getByText('No recommendations to match with more hosts')
+  ).toBeHidden()
+
+  // Apply all recommendations.
+  const count = await page
+    .getByTestId('recommendationsList')
+    .locator('*')
+    .evaluateAll((elements) => elements.length)
+  expect(count).toBeGreaterThan(0)
+
+  const storagePriceBtn = page
+    .getByTestId('recommendationsList')
+    .getByTestId('maxStoragePriceTBMonth')
+    .locator('button')
+  const uploadPriceBtn = page
+    .getByTestId('recommendationsList')
+    .getByTestId('maxUploadPriceTB')
+    .locator('button')
+  const downloadPriceBtn = page
+    .getByTestId('recommendationsList')
+    .getByTestId('maxDownloadPriceTB')
+    .locator('button')
+
+  await clickIf(storagePriceBtn, 'isVisible')
+  await expect(storagePriceBtn).toBeHidden()
+  await clickIf(uploadPriceBtn, 'isVisible')
+  await expect(uploadPriceBtn).toBeHidden()
+  await clickIf(downloadPriceBtn, 'isVisible')
+  await expect(downloadPriceBtn).toBeHidden()
+
+  // Check that all recommendations were applied and there are changes to the config.
+  await expect(page.getByTestId('recommendationsList')).toBeHidden()
+
+  await expect(page.getByText(`Save changes`)).toBeEnabled()
+})
+
+test('recommendations work with pinned fields', async ({ page }) => {
+  // Reset state.
+  await navigateToConfig({ page })
+  await setViewMode({ page, state: 'basic' })
+
+  // Set to low values that will trigger recommendations.
+  await fillTextInputByName(page, 'storageTB', '1')
+  await fillTextInputByName(page, 'uploadTBMonth', '1')
+  await fillTextInputByName(page, 'downloadTBMonth', '1')
+  await fillTextInputByName(page, 'allowanceMonth', '1000')
+  await fillTextInputByName(page, 'maxStoragePriceTBMonth', '300')
+  await fillTextInputByName(page, 'maxUploadPriceTB', '75')
+  await fillTextInputByName(page, 'maxDownloadPriceTB', '375')
+  // There are now recommendations.
+  await expect(
+    page.getByText('No recommendations to match with more hosts')
+  ).toBeHidden()
+
+  // Set to high mixed values that will not need any recommendations.
+  await setSwitchByLabel(page, 'shouldPinMaxStoragePrice', true)
+  await fillTextInputByName(page, 'maxStoragePriceTBMonthPinned', '100000000')
+  await fillTextInputByName(page, 'maxUploadPriceTB', '100000000')
+  await fillTextInputByName(page, 'maxDownloadPriceTB', '100000000')
+  await expect(
+    page.getByText(
+      /(No recommendations to match with more hosts|Configuration matches with a sufficient number of hosts)/
+    )
+  ).toBeVisible()
+
+  // Set the pinned max storage price to a low USD value equivalent to 100 SC.
+  await fillTextInputByName(page, 'maxStoragePriceTBMonthPinned', '0.39')
+  // There are now recommendations again.
+  await expect(
+    page.getByText('No recommendations to match with more hosts')
+  ).toBeHidden()
+})

--- a/apps/renterd/components/Hosts/index.tsx
+++ b/apps/renterd/components/Hosts/index.tsx
@@ -68,6 +68,7 @@ export function Hosts() {
               )}
             >
               <Table
+                testId="hostsTable"
                 focusId={activeHost?.publicKey}
                 focusColor={
                   activeHost ? getHostStatus(activeHost).colorName : undefined

--- a/apps/renterd/components/OnboardingBar.tsx
+++ b/apps/renterd/components/OnboardingBar.tsx
@@ -80,7 +80,11 @@ export function OnboardingBar() {
                   Welcome to Sia
                 </Text>
               </div>
-              <Button variant="ghost" onClick={() => setMaximized(false)}>
+              <Button
+                aria-label="minimize onboarding wizard"
+                variant="ghost"
+                onClick={() => setMaximized(false)}
+              >
                 <Subtract24 />
               </Button>
             </div>

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -139,7 +139,10 @@ export const columns: HostsTableColumn[] = (
           >
             <div className="flex gap-2 items-center">
               <div className="mt-[5px]">
-                <Text color={data.usable ? 'green' : 'red'}>
+                <Text
+                  aria-label={data.usable ? 'usable' : 'not usable'}
+                  color={data.usable ? 'green' : 'red'}
+                >
                   {data.usable ? (
                     <CheckboxCheckedFilled16 />
                   ) : (

--- a/hostd/go.mod
+++ b/hostd/go.mod
@@ -1,7 +1,5 @@
 module go.sia.tech/web/hostd
 
-go 1.21.7
-
-toolchain go1.22.1
+go 1.23.0
 
 require go.sia.tech/web v0.0.0-20240422221546-c1709d16b6ef

--- a/renterd/go.mod
+++ b/renterd/go.mod
@@ -1,7 +1,5 @@
 module go.sia.tech/web/renterd
 
-go 1.21.7
-
-toolchain go1.22.1
+go 1.23.0
 
 require go.sia.tech/web v0.0.0-20240422221546-c1709d16b6ef

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module go.sia.tech/web/sdk
 
-go 1.21.7
+go 1.23.0
 
 require (
 	go.sia.tech/core v0.2.2-0.20240229154321-d97c1d5b2172

--- a/walletd/go.mod
+++ b/walletd/go.mod
@@ -1,7 +1,5 @@
 module go.sia.tech/web/walletd
 
-go 1.21.7
-
-toolchain go1.22.1
+go 1.23.0
 
 require go.sia.tech/web v0.0.0-20240422221546-c1709d16b6ef


### PR DESCRIPTION
- Add support for clusterd testing.
- Migrate all renterd tests to clusterd.
- Testing is now parallel, worker count: half logical cpus locally, 2 workers on CI
- Re-enabled testing against all browsers.
- Updated all go versions to 1.23.0, to align with cluster deps.