### PR TITLE
refactor: extract clusterd library

### DIFF
--- a/.vscode/spellright.dict
+++ b/.vscode/spellright.dict
@@ -4,3 +4,4 @@ renterd
 hostd
 walletd
 js
+clusterd

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The Sia web libraries provide developers with convenient TypeScript SDKs for usi
 - [walletd-e2e](walletd-e2e) - App for testing walletd.
 - [renterd-e2e](renterd-e2e) - App for testing renterd.
 - [hostd-e2e](hostd-e2e) - App for testing hostd.
+- [@siafoundation/clusterd](libs/clusterd) - Methods for controlling `clusterd` in e2e testing.
 - [@siafoundation/walletd-mock](walletd-mock) - `walletd` data and API mock library for testing.
 - [@siafoundation/sia-central-mock](sia-central-mock) - Sia Central data and API mock library for testing.
 

--- a/apps/renterd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/renterd-e2e/src/fixtures/beforeTest.ts
@@ -4,16 +4,23 @@ import { setCurrencyDisplay } from './preferences'
 import { mockApiSiaScanExchangeRates } from './siascan'
 import { mockApiSiaCentralHostsNetworkAverages } from '@siafoundation/sia-central-mock'
 import { clickIf } from './click'
-import { clusterd, setupCluster, teardownCluster } from './clusterd'
+import {
+  clusterd,
+  setupCluster,
+  teardownCluster,
+  waitForContracts,
+} from '@siafoundation/clusterd'
 
 export async function beforeTest(page: Page, { hostdCount = 0 } = {}) {
   await mockApiSiaScanExchangeRates({ page })
   await mockApiSiaCentralHostsNetworkAverages({ page })
-  await setupCluster({ hostdCount })
+  await setupCluster({ renterdCount: 1, hostdCount })
+  const renterdNode = clusterd.nodes.find((n) => n.type === 'renterd')
+  await waitForContracts({ renterdNode, hostdCount })
   await login({
     page,
-    address: clusterd.renterdAddress,
-    password: clusterd.renterdPassword,
+    address: renterdNode.apiAddress,
+    password: renterdNode.password,
   })
 
   // Reset state.

--- a/apps/renterd-e2e/src/specs/login.spec.ts
+++ b/apps/renterd-e2e/src/specs/login.spec.ts
@@ -1,9 +1,13 @@
 import { test, expect } from '@playwright/test'
 import { login } from '../fixtures/login'
-import { clusterd, setupCluster, teardownCluster } from '../fixtures/clusterd'
+import {
+  clusterd,
+  setupCluster,
+  teardownCluster,
+} from '@siafoundation/clusterd'
 
 test.beforeEach(async () => {
-  await setupCluster()
+  await setupCluster({ renterdCount: 1 })
 })
 
 test.afterEach(async () => {
@@ -11,10 +15,11 @@ test.afterEach(async () => {
 })
 
 test('login', async ({ page }) => {
+  const renterdNode = clusterd.nodes.find((n) => n.type === 'renterd')
   await login({
     page,
-    address: clusterd.renterdAddress,
-    password: clusterd.renterdPassword,
+    address: renterdNode.apiAddress,
+    password: renterdNode.password,
   })
   await expect(page.getByTestId('navbar').getByText('Buckets')).toBeVisible()
 })

--- a/libs/clusterd/.babelrc
+++ b/libs/clusterd/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@nx/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ],
+  "plugins": []
+}

--- a/libs/clusterd/.eslintrc.json
+++ b/libs/clusterd/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "rules": {
+    "@nx/dependency-checks": [
+      "error",
+      {
+        "ignoredFiles": ["libs/clusterd/rollup.config.js"]
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": "error"
+      }
+    }
+  ]
+}

--- a/libs/clusterd/README.md
+++ b/libs/clusterd/README.md
@@ -1,0 +1,3 @@
+# clusterd
+
+Methods for controlling `clusterd` in e2e testing.

--- a/libs/clusterd/jest.config.ts
+++ b/libs/clusterd/jest.config.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+export default {
+  displayName: 'clusterd',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': [
+      'babel-jest',
+      {
+        presets: ['@nx/next/babel'],
+        plugins: ['@babel/plugin-transform-private-methods'],
+      },
+    ],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/libs/clusterd',
+}

--- a/libs/clusterd/package.json
+++ b/libs/clusterd/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@siafoundation/clusterd",
+  "description": "Methods controlling clusterd in e2e testing.",
+  "version": "0.0.0",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "@technically/lodash": "^4.17.0",
+    "axios": "^0.27.2",
+    "@siafoundation/renterd-js": "0.7.0",
+    "@siafoundation/units": "3.2.0"
+  },
+  "types": "./src/index.d.ts"
+}

--- a/libs/clusterd/project.json
+++ b/libs/clusterd/project.json
@@ -1,0 +1,42 @@
+{
+  "name": "clusterd",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/clusterd/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/rollup:rollup",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/clusterd",
+        "tsConfig": "libs/clusterd/tsconfig.lib.json",
+        "project": "libs/clusterd/package.json",
+        "entryFile": "libs/clusterd/src/index.ts",
+        "external": ["react/jsx-runtime"],
+        "compiler": "tsc",
+        "outputFileName": "index.js",
+        "rollupConfig": "libs/clusterd/rollup.config.js",
+        "assets": [
+          {
+            "glob": "libs/clusterd/*.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      },
+      "configurations": {}
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/clusterd"],
+      "options": {
+        "jestConfig": "libs/clusterd/jest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/clusterd/rollup.config.js
+++ b/libs/clusterd/rollup.config.js
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const preserveDirectives = require('rollup-plugin-preserve-directives')
+
+// https://github.com/rollup/rollup/issues/4699#issuecomment-1465302665
+function getRollupOptions(options) {
+  return {
+    ...options,
+    output: {
+      ...options.output,
+      preserveModules: true,
+      format: 'esm',
+      sourcemap: true,
+    },
+    plugins: options.plugins.concat(preserveDirectives.default()),
+  }
+}
+
+module.exports = getRollupOptions

--- a/libs/clusterd/tsconfig.json
+++ b/libs/clusterd/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/clusterd/tsconfig.lib.json
+++ b/libs/clusterd/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "node",
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts"
+    ]
+  },
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/libs/clusterd/tsconfig.spec.json
+++ b/libs/clusterd/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,7 +47,8 @@
       "@siafoundation/sia-central-mock": ["libs/sia-central-mock/src/index.ts"],
       "@siafoundation/types": ["libs/types/src/index.ts"],
       "@siafoundation/units": ["libs/units/src/index.ts"],
-      "@siafoundation/walletd-mock": ["libs/walletd-mock/src/index.ts"]
+      "@siafoundation/walletd-mock": ["libs/walletd-mock/src/index.ts"],
+      "@siafoundation/clusterd": ["libs/clusterd/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
> Tests pass on final e2e PR: #726

- Extract clusterd control methods from `renterd-e2e` into a library for use across `renterd`, `hostd`, and `walletd` e2e test suites.