### PR TITLE
refactor: explored-types: add id to ExplorerTransaction type

### DIFF
--- a/.changeset/beige-ducks-knock.md
+++ b/.changeset/beige-ducks-knock.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/explored-types': minor
+---
+
+Added id field to ExplorerTransaction type.

--- a/libs/explored-types/src/types.ts
+++ b/libs/explored-types/src/types.ts
@@ -153,6 +153,7 @@ export type ExplorerFileContractRevision = ExplorerFileContract & {
  * to explorerd.
  */
 export type ExplorerTransaction = {
+  id: string
   siacoinInputs: SiacoinInput[]
   siacoinOutputs: ExplorerSiacoinOutput[]
   siafundInputs: SiafundInput[]


### PR DESCRIPTION
Matching the change made here: https://github.com/SiaFoundation/explored/pull/75.

We made need to restart/redeploy the public explored build with the linked change in mind to fully unblock me on this.