### PR TITLE
ci(e2e): cluster install latest daemons, configure playwright projects and workers

### DIFF
--- a/apps/hostd-e2e/playwright.config.ts
+++ b/apps/hostd-e2e/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     video: 'on-first-retry',
   },
   // Timeout per test.
-  timeout: 60_000,
+  timeout: 120_000,
   expect: {
     // Raise the timeout because it is running against next dev mode
     // which requires compilation the first to a page is visited
@@ -39,24 +39,34 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },
-  // Run the tests serially as they may mutate the state of the same application.
-  workers: 1,
+  // Docs recommend 1 worker on CI: https://playwright.dev/docs/ci#workers
+  workers: process.env.CI ? 1 : undefined,
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        contextOptions: {
+          permissions: ['clipboard-read', 'clipboard-write'],
+        },
+      },
     },
-
-    // Disable firefox and webkit to save time since tests are running serially.
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        launchOptions: {
+          firefoxUserPrefs: {
+            'dom.events.asyncClipboard.readText': true,
+            'dom.events.testing.asyncClipboard': true,
+          },
+        },
+      },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
 
     // Uncomment for mobile browsers support
     /* {

--- a/apps/hostd-e2e/project.json
+++ b/apps/hostd-e2e/project.json
@@ -5,9 +5,25 @@
   "projectType": "application",
   "implicitDependencies": ["hostd"],
   "targets": {
+    "build-cluster": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "cd internal/cluster && go get -u go.sia.tech/hostd@its-happening",
+          "cd internal/cluster && go get -u go.sia.tech/renterd@dev",
+          "cd internal/cluster && go get -u go.sia.tech/walletd@master",
+          "cd internal/cluster && go mod tidy",
+          "cd internal/cluster && go build -o bin/clusterd ./cmd/clusterd || echo 'BUILD FAILED'",
+          "git checkout internal/cluster/go.mod internal/cluster/go.sum",
+          "test ! -f internal/cluster/bin/clusterd && exit 1 || exit 0"
+        ],
+        "parallel": false
+      }
+    },
     "e2e": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/hostd-e2e"],
+      "dependsOn": ["build-cluster"],
       "options": {
         "config": "apps/hostd-e2e/playwright.config.ts"
       }

--- a/apps/renterd-e2e/playwright.config.ts
+++ b/apps/renterd-e2e/playwright.config.ts
@@ -39,20 +39,34 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },
-  workers: process.env.CI ? 4 : undefined,
+  // Docs recommend 1 worker on CI: https://playwright.dev/docs/ci#workers
+  workers: process.env.CI ? 1 : undefined,
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        contextOptions: {
+          permissions: ['clipboard-read', 'clipboard-write'],
+        },
+      },
     },
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: {
+        ...devices['Desktop Firefox'],
+        launchOptions: {
+          firefoxUserPrefs: {
+            'dom.events.asyncClipboard.readText': true,
+            'dom.events.testing.asyncClipboard': true,
+          },
+        },
+      },
     },
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
 
     // Uncomment for mobile browsers support
     /* {

--- a/apps/renterd-e2e/project.json
+++ b/apps/renterd-e2e/project.json
@@ -8,7 +8,16 @@
     "build-cluster": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "go build -C internal/cluster -o bin/clusterd ./cmd/clusterd"
+        "commands": [
+          "cd internal/cluster && go get -u go.sia.tech/hostd@its-happening",
+          "cd internal/cluster && go get -u go.sia.tech/renterd@dev",
+          "cd internal/cluster && go get -u go.sia.tech/walletd@master",
+          "cd internal/cluster && go mod tidy",
+          "cd internal/cluster && go build -o bin/clusterd ./cmd/clusterd || echo 'BUILD FAILED'",
+          "git checkout internal/cluster/go.mod internal/cluster/go.sum",
+          "test ! -f internal/cluster/bin/clusterd && exit 1 || exit 0"
+        ],
+        "parallel": false
       }
     },
     "e2e": {

--- a/apps/walletd-e2e/playwright.config.ts
+++ b/apps/walletd-e2e/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     video: 'on-first-retry',
   },
   // Timeout per test.
-  timeout: 60_000,
+  timeout: 120_000,
   expect: {
     // Raise the timeout because it is running against next dev mode
     // which requires compilation the first to a page is visited
@@ -39,24 +39,34 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
   },
-  // Run the tests serially as they may mutate the state of the same application.
-  workers: 1,
+  // Docs recommend 1 worker on CI: https://playwright.dev/docs/ci#workers
+  workers: process.env.CI ? 1 : undefined,
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        contextOptions: {
+          permissions: ['clipboard-read', 'clipboard-write'],
+        },
+      },
     },
-
-    // Disable firefox and webkit to save time since tests are running serially.
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+        launchOptions: {
+          firefoxUserPrefs: {
+            'dom.events.asyncClipboard.readText': true,
+            'dom.events.testing.asyncClipboard': true,
+          },
+        },
+      },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
 
     // Uncomment for mobile browsers support
     /* {

--- a/apps/walletd-e2e/project.json
+++ b/apps/walletd-e2e/project.json
@@ -5,9 +5,25 @@
   "projectType": "application",
   "implicitDependencies": ["walletd"],
   "targets": {
+    "build-cluster": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "cd internal/cluster && go get -u go.sia.tech/hostd@its-happening",
+          "cd internal/cluster && go get -u go.sia.tech/renterd@dev",
+          "cd internal/cluster && go get -u go.sia.tech/walletd@master",
+          "cd internal/cluster && go mod tidy",
+          "cd internal/cluster && go build -o bin/clusterd ./cmd/clusterd || echo 'BUILD FAILED'",
+          "git checkout internal/cluster/go.mod internal/cluster/go.sum",
+          "test ! -f internal/cluster/bin/clusterd && exit 1 || exit 0"
+        ],
+        "parallel": false
+      }
+    },
     "e2e": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/walletd-e2e"],
+      "dependsOn": ["build-cluster"],
       "options": {
         "config": "apps/walletd-e2e/playwright.config.ts"
       }


### PR DESCRIPTION
> Tests pass on final e2e PR: https://github.com/SiaFoundation/web/pull/726

# clusterd
- Install/override to the latest version of each daemon so that UI changes are always tested against the most recent commit.
- This will error out if the clusterd build fails, which lets us know clusterd needs to be updated.
# playwright
- Configure playwright projects/browser with correct permissions.
- Configure playwright workers to the recommended 1 worker on CI (will be paralellized in later sharding PR)
- Up test timeouts to 120s as clusterd takes up to 30 seconds to initialize and form contracts.