### PR TITLE
Use working directory instead of package for go test

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -203,7 +203,7 @@ jobs:
         module: [./renterd, ./hostd, ./walletd]
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Git
@@ -222,4 +222,4 @@ jobs:
         uses: n8maninger/action-golang-test@v2
         with:
           args: '-race'
-          package: ${{ matrix.module }}/...
+          working-directory: ${{ matrix.module }}


### PR DESCRIPTION
Since we don't have a `go.work` file any more, `go test` needs to use the package working directory. Should fix all this
![Screenshot 2024-09-05 at 11 51 57 AM](https://github.com/user-attachments/assets/03d9cfdc-dab9-4359-ad65-ba75fd30465a)
