### PR TITLE
fix(design-system): force the ThemeRadio component to render only on the client side

### DIFF
--- a/.changeset/selfish-mice-relax.md
+++ b/.changeset/selfish-mice-relax.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+A wrapping ClientSideOnly component has been created that forces its children to render only on the client side.

--- a/.changeset/unlucky-lobsters-reply.md
+++ b/.changeset/unlucky-lobsters-reply.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The light and dark ThemeRadio footer component now renders only on the client side.

--- a/apps/explorer/components/Layout/Footer.tsx
+++ b/apps/explorer/components/Layout/Footer.tsx
@@ -5,6 +5,7 @@ import {
   Logo,
   ThemeRadio,
   CurrencyFiatSelector,
+  ClientSideOnly,
 } from '@siafoundation/design-system'
 
 export function Footer() {
@@ -49,7 +50,11 @@ export function Footer() {
           <div className="flex-1" />
           <div className="flex-1 flex items-center justify-end gap-6">
             <CurrencyFiatSelector />
-            <ThemeRadio className="hidden md:flex" />
+            <ClientSideOnly
+              fallback={<div className="w-[80px] h-[16px]"></div>}
+            >
+              <ThemeRadio className="hidden md:flex" />
+            </ClientSideOnly>
           </div>
         </div>
       </div>

--- a/libs/design-system/src/components/ClientSideOnly.tsx
+++ b/libs/design-system/src/components/ClientSideOnly.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * A wrapping component that forces its children to render on the client side.
+ */
+export function ClientSideOnly({
+  children,
+  fallback,
+}: {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}) {
+  const [shouldRender, setShouldRender] = useState(false)
+
+  useEffect(() => {
+    setShouldRender(true)
+  }, [])
+
+  if (!shouldRender) return fallback || null
+
+  return children
+}

--- a/libs/design-system/src/components/ThemeRadio.tsx
+++ b/libs/design-system/src/components/ThemeRadio.tsx
@@ -32,6 +32,7 @@ type Props = {
 
 export function ThemeRadio({ className, tooltipClassName, tabIndex }: Props) {
   const { theme, setTheme } = useTheme()
+
   return (
     <RadioGroupPrimitive.Root
       value={theme}

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -76,6 +76,7 @@ export * from './components/PaginatorKnownTotal'
 export * from './components/PaginatorUnknownTotal'
 export * from './components/PaginatorMarker'
 export * from './components/ListWithSeparators'
+export * from './components/ClientSideOnly'
 
 // app
 export * from './app/AppPublicLayout'


### PR DESCRIPTION
This avoids the hydration error/warning we were receiving from the ThemeRadio component, concerning the clash between a client's localStorage theme preference and a server's lack of localStorage.