### PR TITLE
fix: renterd nan fit allowance values

### DIFF
--- a/.changeset/stale-actors-hunt.md
+++ b/.changeset/stale-actors-hunt.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the fit allowance suggestions were showing as NaN because all required fields were not filled.

--- a/apps/renterd-e2e/src/specs/config.spec.ts
+++ b/apps/renterd-e2e/src/specs/config.spec.ts
@@ -106,6 +106,12 @@ test('set max prices to fit current allowance', async ({ page }) => {
   await expectTextInputByName(page, 'maxStoragePriceTBMonth', '3,352.941176')
   await expectTextInputByName(page, 'maxUploadPriceTB', '838.235294')
   await expectTextInputByName(page, 'maxDownloadPriceTB', '4,191.176471')
+
+  // If a component of the fit calculation is missing, it should not be shown.
+  await fillTextInputByName(page, 'storageTB', '')
+  await expect(
+    page.getByText('Set max prices to fit current allowance')
+  ).toBeDisabled()
 })
 
 test('set allowance to fit current max prices', async ({ page }) => {
@@ -120,9 +126,16 @@ test('set allowance to fit current max prices', async ({ page }) => {
   await fillTextInputByName(page, 'maxStoragePriceTBMonth', '1500')
   await fillTextInputByName(page, 'maxUploadPriceTB', '1000')
   await fillTextInputByName(page, 'maxDownloadPriceTB', '5000')
+  await page.getByText('Set allowance to fit current max prices').click()
 
-  // The following allownce is fit to the max prices.
-  await expectTextInputByName(page, 'allowanceMonth', '21,000')
+  // The following allowance is fit to the max prices.
+  await expectTextInputByName(page, 'allowanceMonth', '63,333')
+
+  // If a component of the fit calculation is missing, it should not be shown.
+  await fillTextInputByName(page, 'storageTB', '')
+  await expect(
+    page.getByText('Set allowance to fit current max prices')
+  ).toBeDisabled()
 })
 
 test('should show warning if pinning is not fully configured', async ({

--- a/apps/renterd/contexts/config/fieldTips/Allowance.tsx
+++ b/apps/renterd/contexts/config/fieldTips/Allowance.tsx
@@ -136,9 +136,12 @@ export function AllowanceTips({
         <TipAction
           icon={<NextFilled16 />}
           iconColor="contrast"
-          disabled={!allowanceMonth?.gt(0)}
+          disabled={!enabledDerivedPrices}
           tip={fitAllPricesToCurrentAllowanceTipContent}
           onClick={() => {
+            if (!enabledDerivedPrices) {
+              return
+            }
             formSetFields({
               form,
               fields,
@@ -152,13 +155,12 @@ export function AllowanceTips({
         <TipAction
           icon={<PreviousFilled16 />}
           iconColor="contrast"
-          disabled={!pricesInSiacoin}
+          disabled={!enabledAllowance}
           tip="Set the allowance to fit the current max prices for storage, upload, and download."
           onClick={() => {
             if (!enabledAllowance) {
               return
             }
-
             formSetFields({
               form,
               fields,

--- a/apps/renterd/contexts/config/useAllowanceDerivedPricing.tsx
+++ b/apps/renterd/contexts/config/useAllowanceDerivedPricing.tsx
@@ -62,7 +62,7 @@ export function useAllowanceDerivedPricingForEnabledFields({
   maxStoragePriceTBMonthPinned?: BigNumber
   maxDownloadPriceTBPinned?: BigNumber
   maxUploadPriceTBPinned?: BigNumber
-} {
+} | null {
   const { isAutopilotEnabled } = useApp()
   const allowanceMonth = useEnabledAllowanceInSiacoin({
     form,
@@ -91,6 +91,9 @@ export function useAllowanceDerivedPricingForEnabledFields({
         downloadWeight,
         uploadWeight,
       })
+      if (!derivedPricing) {
+        return null
+      }
       // Convert derived siacoin prices to pinned fiat prices.
       const pinnedPricing = exchangeRate
         ? {


### PR DESCRIPTION
- Fixed an issue where the fit allowance suggestions were showing as NaN because all required fields were not filled.
