### PR TITLE
refactor(renterd): migrate to events APIs and remove other deprecated APIs

### DIFF
--- a/.changeset/beige-cycles-change.md
+++ b/.changeset/beige-cycles-change.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The transactions list now includes more details such as specific transaction types and maturity height for locked siacoin.

--- a/.changeset/cold-poems-appear.md
+++ b/.changeset/cold-poems-appear.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Removed deprecated wallet transactions and pending transactions APIs.

--- a/.changeset/fifty-dots-do.md
+++ b/.changeset/fifty-dots-do.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Authed layout, wallet balance, and wallet layout actions now require immature balance value.

--- a/.changeset/poor-berries-sin.md
+++ b/.changeset/poor-berries-sin.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Added wallet events and pending events APIs.

--- a/.changeset/silent-icons-rule.md
+++ b/.changeset/silent-icons-rule.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Removed deprecated wallet discard, fund, sign, and outputs APIs.

--- a/apps/hostd/contexts/transactions/index.tsx
+++ b/apps/hostd/contexts/transactions/index.tsx
@@ -113,7 +113,7 @@ function useTransactionsMain() {
     sortField,
     sortDirection,
     resetDefaultColumnVisibility,
-  } = useTableState('walletd/v0/events', {
+  } = useTableState('hostd/v0/events', {
     columns,
     columnsDefaultVisible,
     sortOptions,

--- a/apps/renterd-e2e/src/specs/wallet.spec.ts
+++ b/apps/renterd-e2e/src/specs/wallet.spec.ts
@@ -7,7 +7,7 @@ import BigNumber from 'bignumber.js'
 import { setSwitchByLabel } from '../fixtures/switchValue'
 
 test.beforeEach(async ({ page }) => {
-  await beforeTest(page, false)
+  await beforeTest(page)
 })
 
 test('send siacoin with include fee off', async ({ page }) => {
@@ -66,20 +66,35 @@ test('send siacoin with include fee off', async ({ page }) => {
   await expect(sendDialog.getByTestId('transactionId')).toBeVisible()
 
   // List.
-  // TODO: Add this after we migrate to the new events API.
-  // await sendDialog.getByRole('button', { name: 'Close' }).click()
-  // await expect(page.getByTestId('eventsTable')).toBeVisible()
-  // await expect(
-  //   page.getByTestId('eventsTable').locator('tbody tr').first()
-  // ).toBeVisible()
-  // await expect(
-  //   page
-  //     .getByTestId('eventsTable')
-  //     .locator('tbody tr')
-  //     .first()
-  //     .getByTestId('amount')
-  //     .getByText(`-${amountWithFeeString}`)
-  // ).toBeVisible()
+  await sendDialog.getByRole('button', { name: 'Close' }).click()
+  await expect(page.getByTestId('eventsTable')).toBeVisible()
+  await expect(
+    page.getByTestId('eventsTable').locator('tbody tr').first()
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('eventsTable')
+      .locator('tbody tr')
+      .first()
+      .getByTestId('amount')
+      .getByText(`-${amountWithFeeString}`)
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('eventsTable')
+      .locator('tbody tr')
+      .first()
+      .getByTestId('type')
+      .getByText('siacoin transfer')
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('eventsTable')
+      .locator('tbody tr')
+      .first()
+      .getByTestId('fee')
+      .getByText('12.000 mS')
+  ).toBeVisible()
 })
 
 test('send siacoin with include fee on', async ({ page }) => {
@@ -139,18 +154,33 @@ test('send siacoin with include fee on', async ({ page }) => {
   await expect(sendDialog.getByTestId('transactionId')).toBeVisible()
 
   // List.
-  // TODO: Add this after we migrate to the new events API.
-  // await sendDialog.getByRole('button', { name: 'Close' }).click()
-  // await expect(page.getByTestId('eventsTable')).toBeVisible()
-  // await expect(
-  //   page.getByTestId('eventsTable').locator('tbody tr').first()
-  // ).toBeVisible()
-  // await expect(
-  //   page
-  //     .getByTestId('eventsTable')
-  //     .locator('tbody tr')
-  //     .first()
-  //     .getByTestId('amount')
-  //     .getByText(`-${amountWithFeeString}`)
-  // ).toBeVisible()
+  await sendDialog.getByRole('button', { name: 'Close' }).click()
+  await expect(page.getByTestId('eventsTable')).toBeVisible()
+  await expect(
+    page.getByTestId('eventsTable').locator('tbody tr').first()
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('eventsTable')
+      .locator('tbody tr')
+      .first()
+      .getByTestId('amount')
+      .getByText(`-${amountString}`)
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('eventsTable')
+      .locator('tbody tr')
+      .first()
+      .getByTestId('type')
+      .getByText('siacoin transfer')
+  ).toBeVisible()
+  await expect(
+    page
+      .getByTestId('eventsTable')
+      .locator('tbody tr')
+      .first()
+      .getByTestId('fee')
+      .getByText('12.000 mS')
+  ).toBeVisible()
 })

--- a/apps/renterd/components/RenterdAuthedLayout.tsx
+++ b/apps/renterd/components/RenterdAuthedLayout.tsx
@@ -28,6 +28,7 @@ export function RenterdAuthedLayout(
           spendable: new BigNumber(wallet.data.spendable),
           confirmed: new BigNumber(wallet.data.confirmed),
           unconfirmed: new BigNumber(wallet.data.unconfirmed),
+          immature: new BigNumber(wallet.data.immature),
         }
       }
       {...props}

--- a/apps/renterd/components/Wallet/StateError.tsx
+++ b/apps/renterd/components/Wallet/StateError.tsx
@@ -1,0 +1,15 @@
+import { Text } from '@siafoundation/design-system'
+import { MisuseOutline32 } from '@siafoundation/react-icons'
+
+export function StateError() {
+  return (
+    <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
+      <Text>
+        <MisuseOutline32 className="scale-[200%]" />
+      </Text>
+      <Text color="subtle" className="text-center max-w-[500px]">
+        Error fetching transactions.
+      </Text>
+    </div>
+  )
+}

--- a/apps/renterd/components/Wallet/StateNoneMatching.tsx
+++ b/apps/renterd/components/Wallet/StateNoneMatching.tsx
@@ -1,0 +1,15 @@
+import { Text } from '@siafoundation/design-system'
+import { Filter32 } from '@siafoundation/react-icons'
+
+export function StateNoneMatching() {
+  return (
+    <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
+      <Text>
+        <Filter32 className="scale-[200%]" />
+      </Text>
+      <Text color="subtle" className="text-center max-w-[500px]">
+        No transactions matching filters.
+      </Text>
+    </div>
+  )
+}

--- a/apps/renterd/components/Wallet/StateNoneYet.tsx
+++ b/apps/renterd/components/Wallet/StateNoneYet.tsx
@@ -1,0 +1,15 @@
+import { Text } from '@siafoundation/design-system'
+import { Money32 } from '@siafoundation/react-icons'
+
+export function StateNoneYet() {
+  return (
+    <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
+      <Text>
+        <Money32 className="scale-[200%]" />
+      </Text>
+      <Text color="subtle" className="text-center max-w-[500px]">
+        The wallet has no transactions yet.
+      </Text>
+    </div>
+  )
+}

--- a/apps/renterd/components/Wallet/WalletFilterBar.tsx
+++ b/apps/renterd/components/Wallet/WalletFilterBar.tsx
@@ -1,9 +1,14 @@
-import { WalletSyncWarning } from '@siafoundation/design-system'
+import {
+  PaginatorUnknownTotal,
+  WalletSyncWarning,
+} from '@siafoundation/design-system'
 import { useSyncStatus } from '../../hooks/useSyncStatus'
+import { useTransactions } from '../../contexts/transactions'
 
 export function WalletFilterBar() {
   const { isSynced, syncPercent, isWalletSynced, walletScanPercent } =
     useSyncStatus()
+  const { offset, limit, pageCount, dataState } = useTransactions()
   return (
     <div className="flex gap-2 w-full">
       <WalletSyncWarning
@@ -13,6 +18,12 @@ export function WalletFilterBar() {
         walletScanPercent={walletScanPercent}
       />
       <div className="flex-1" />
+      <PaginatorUnknownTotal
+        offset={offset}
+        limit={limit}
+        pageTotal={pageCount}
+        isLoading={dataState === 'loading'}
+      />
     </div>
   )
 }

--- a/apps/renterd/contexts/transactions/columns.tsx
+++ b/apps/renterd/contexts/transactions/columns.tsx
@@ -1,0 +1,175 @@
+import {
+  Text,
+  TableColumn,
+  ValueCopyable,
+  LoadingDots,
+  ValueScFiat,
+  ValueSf,
+  Tooltip,
+  Badge,
+} from '@siafoundation/design-system'
+import { humanDate, getTxTypeLabel } from '@siafoundation/units'
+import { CellContext, EventData, TableColumnId } from './types'
+import { Locked16, Unlocked16 } from '@siafoundation/react-icons'
+
+type EventsTableColumn = TableColumn<TableColumnId, EventData, CellContext> & {
+  fixed?: boolean
+  category?: string
+}
+
+export const columns: EventsTableColumn[] = [
+  {
+    id: 'transactionId',
+    label: 'transaction ID',
+    category: 'general',
+    render: ({ data: { id }, context }) => {
+      if (!id) {
+        return null
+      }
+      return (
+        <ValueCopyable
+          size="12"
+          value={id}
+          label="transaction ID"
+          type="transaction"
+          siascanUrl={context.siascanUrl}
+        />
+      )
+    },
+  },
+  {
+    id: 'type',
+    label: 'type',
+    category: 'general',
+    fixed: true,
+    render: ({ data: { txType } }) => {
+      return <Badge size="small">{getTxTypeLabel(txType)}</Badge>
+    },
+  },
+  {
+    id: 'height',
+    label: 'height',
+    category: 'general',
+    contentClassName: 'justify-end',
+    render: ({ data: { height, pending, maturityHeight, isMature } }) => {
+      if (pending) {
+        return (
+          <Text size="12" ellipsis>
+            <LoadingDots />
+          </Text>
+        )
+      }
+      if (!height) {
+        return null
+      }
+      if (height && maturityHeight && maturityHeight > height) {
+        return (
+          <Tooltip
+            content={
+              isMature
+                ? 'The maturity height has been reached.'
+                : 'The maturity height has not been reached, therefore the output is still locked.'
+            }
+          >
+            <div className="flex flex-col gap-[5px]">
+              <div className="flex justify-end">
+                <Text
+                  size="12"
+                  font="mono"
+                  ellipsis
+                  color={isMature ? 'green' : 'red'}
+                  className="flex gap-1 items-center"
+                >
+                  {isMature ? <Unlocked16 /> : <Locked16 />}
+                  {maturityHeight.toLocaleString()}
+                </Text>
+              </div>
+              <div className="flex justify-between items-end gap-1">
+                <div className="pl-[8px] pb-[6px]">
+                  <div className="border-l border-b border-gray-800 dark:border-graydark-800 h-[20px] w-[7px]" />
+                </div>
+                <Text size="12" font="mono" color="subtle" ellipsis>
+                  {height.toLocaleString()}
+                </Text>
+              </div>
+            </div>
+          </Tooltip>
+        )
+      }
+      return (
+        <Text size="12" font="mono" ellipsis>
+          {height.toLocaleString()}
+        </Text>
+      )
+    },
+  },
+  {
+    id: 'timestamp',
+    label: 'timestamp',
+    category: 'general',
+    contentClassName: 'justify-end',
+    render: ({ data: { timestamp, pending } }) => {
+      if (pending) {
+        return (
+          <Text size="12" ellipsis>
+            <LoadingDots />
+          </Text>
+        )
+      }
+      return (
+        <Text size="12" ellipsis>
+          {humanDate(timestamp, { timeStyle: 'short' })}
+        </Text>
+      )
+    },
+  },
+  {
+    id: 'amount',
+    label: 'amount',
+    category: 'general',
+    contentClassName: 'w-[120px] justify-end',
+    render: ({ data: { amountSc, amountSf } }) => {
+      if (!amountSc) {
+        return null
+      }
+      return (
+        <div className="flex flex-col gap-2 items-end">
+          {!amountSc.isZero() && (
+            <ValueScFiat displayBoth size="12" value={amountSc} />
+          )}
+          {!!amountSf && <ValueSf size="12" value={amountSf} />}
+        </div>
+      )
+    },
+  },
+  {
+    id: 'fee',
+    label: 'fee',
+    category: 'general',
+    contentClassName: 'w-[120px] justify-end',
+    render: ({ data: { fee } }) => {
+      if (!fee) {
+        return null
+      }
+      return <ValueScFiat displayBoth size="12" variant="value" value={fee} />
+    },
+  },
+  {
+    id: 'contractId',
+    label: 'contract ID',
+    category: 'general',
+    render: ({ data: { contractId }, context }) => {
+      if (!contractId) {
+        return null
+      }
+      return (
+        <ValueCopyable
+          size="12"
+          value={contractId}
+          label="contract ID"
+          siascanUrl={context.siascanUrl}
+        />
+      )
+    },
+  },
+]

--- a/apps/renterd/contexts/transactions/types.ts
+++ b/apps/renterd/contexts/transactions/types.ts
@@ -1,0 +1,52 @@
+import { TxType } from '@siafoundation/units'
+import { WalletEventType } from '@siafoundation/types'
+import BigNumber from 'bignumber.js'
+
+export type CellContext = {
+  siascanUrl: string
+}
+
+export type EventData = {
+  id: string
+  transactionId?: string
+  timestamp: number
+  height?: number
+  maturityHeight?: number
+  isMature?: boolean
+  pending: boolean
+  type: WalletEventType
+  txType: TxType
+  fee?: BigNumber
+  amountSc?: BigNumber
+  amountSf?: number
+  contractId?: string
+  className?: string
+}
+
+export type TableColumnId =
+  | 'transactionId'
+  | 'type'
+  | 'height'
+  | 'timestamp'
+  | 'amount'
+  | 'fee'
+  | 'contractId'
+
+export const columnsDefaultVisible: TableColumnId[] = [
+  'transactionId',
+  'type',
+  'height',
+  'timestamp',
+  'amount',
+  'fee',
+]
+
+export type SortField = 'id'
+
+export const defaultSortField: SortField = 'id'
+
+export const sortOptions: {
+  id: SortField
+  label: string
+  category: string
+}[] = []

--- a/libs/design-system/src/app/AppAuthedLayout/Sidenav.tsx
+++ b/libs/design-system/src/app/AppAuthedLayout/Sidenav.tsx
@@ -24,6 +24,7 @@ type Props = {
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
+    immature: BigNumber
   }
   isSynced: boolean
   lock?: () => void

--- a/libs/design-system/src/app/AppAuthedLayout/SidenavItemWallet.tsx
+++ b/libs/design-system/src/app/AppAuthedLayout/SidenavItemWallet.tsx
@@ -14,6 +14,7 @@ type Props = {
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
+    immature: BigNumber
   }
   isSynced: boolean
   routes: Routes

--- a/libs/design-system/src/app/AppAuthedLayout/index.tsx
+++ b/libs/design-system/src/app/AppAuthedLayout/index.tsx
@@ -32,7 +32,7 @@ type Props = {
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
-    immature?: BigNumber
+    immature: BigNumber
   }
   scroll?: boolean
   routes: {

--- a/libs/design-system/src/app/WalletBalance.tsx
+++ b/libs/design-system/src/app/WalletBalance.tsx
@@ -15,7 +15,7 @@ export function WalletBalance({
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
-    immature?: BigNumber
+    immature: BigNumber
   }
   isSynced: boolean
   syncingMessage?: string

--- a/libs/design-system/src/app/WalletBalanceSideNav.tsx
+++ b/libs/design-system/src/app/WalletBalanceSideNav.tsx
@@ -12,6 +12,7 @@ export function WalletBalanceSideNav({
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
+    immature: BigNumber
   }
   isSynced: boolean
   syncingMessage?: string

--- a/libs/design-system/src/app/WalletBalanceTip.tsx
+++ b/libs/design-system/src/app/WalletBalanceTip.tsx
@@ -14,7 +14,7 @@ export function WalletBalanceTip({
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
-    immature?: BigNumber
+    immature: BigNumber
   }
   children: React.ReactNode
 }) {

--- a/libs/design-system/src/app/WalletLayoutActions.tsx
+++ b/libs/design-system/src/app/WalletLayoutActions.tsx
@@ -12,7 +12,7 @@ type Props = {
     unconfirmed: BigNumber
     confirmed: BigNumber
     spendable: BigNumber
-    immature?: BigNumber
+    immature: BigNumber
   }
   receiveSiacoin?: () => void
   sendSiacoin: () => void

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -173,20 +173,14 @@ import {
   TxPoolTransactionsPayload,
   TxPoolTransactionsResponse,
   UploadPackingSettings,
-  WalletAddressesParams,
-  WalletAddressesPayload,
-  WalletAddressesResponse,
-  WalletDiscardParams,
-  WalletDiscardPayload,
-  WalletDiscardResponse,
-  WalletFundParams,
-  WalletFundPayload,
-  WalletFundResponse,
   WalletMetricsParams,
   WalletMetricsPayload,
   WalletMetricsResponse,
   WalletParams,
   WalletPayload,
+  WalletEventsParams,
+  WalletEventsPayload,
+  WalletEventsResponse,
   WalletPendingParams,
   WalletPendingPayload,
   WalletPendingResponse,
@@ -203,15 +197,6 @@ import {
   WalletSendParams,
   WalletSendPayload,
   WalletSendResponse,
-  WalletSignParams,
-  WalletSignPayload,
-  WalletSignResponse,
-  WalletTransactionsParams,
-  WalletTransactionsPayload,
-  WalletTransactionsResponse,
-  WalletUtxoParams,
-  WalletUtxoPayload,
-  WalletUtxoResponse,
   busAlertsDismissRoute,
   busAlertsRoute,
   busBucketNamePolicyRoute,
@@ -260,21 +245,16 @@ import {
   busTxpoolBroadcastRoute,
   busTxpoolRecommendedFeeRoute,
   busTxpoolTransactionsRoute,
-  busWalletAddressesRoute,
-  busWalletDiscardRoute,
-  busWalletFundRoute,
-  busWalletOutputsRoute,
   busWalletPendingRoute,
   busWalletPrepareFormRoute,
   busWalletRedistributeRoute,
   busWalletRoute,
   busWalletSendRoute,
-  busWalletSignRoute,
-  busWalletTransactionsRoute,
   busAutopilotsRoute,
   AutopilotsParams,
   AutopilotsPayload,
   AutopilotsResponse,
+  busWalletEventsRoute,
 } from '@siafoundation/renterd-types'
 import { buildRequestHandler, initAxios } from '@siafoundation/request'
 import { AxiosRequestConfig } from 'axios'
@@ -338,46 +318,26 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       'get',
       busWalletRoute
     ),
-    walletAddresses: buildRequestHandler<
-      WalletAddressesParams,
-      WalletAddressesPayload,
-      WalletAddressesResponse
-    >(axios, 'get', busWalletAddressesRoute),
-    walletTransactions: buildRequestHandler<
-      WalletTransactionsParams,
-      WalletTransactionsPayload,
-      WalletTransactionsResponse
-    >(axios, 'get', busWalletTransactionsRoute),
-    walletUtxos: buildRequestHandler<
-      WalletUtxoParams,
-      WalletUtxoPayload,
-      WalletUtxoResponse
-    >(axios, 'get', busWalletOutputsRoute),
-    walletFund: buildRequestHandler<
-      WalletFundParams,
-      WalletFundPayload,
-      WalletFundResponse
-    >(axios, 'post', busWalletFundRoute),
+    walletEvents: buildRequestHandler<
+      WalletEventsParams,
+      WalletEventsPayload,
+      WalletEventsResponse
+    >(axios, 'get', busWalletEventsRoute),
+    walletPending: buildRequestHandler<
+      WalletPendingParams,
+      WalletPendingPayload,
+      WalletPendingResponse
+    >(axios, 'get', busWalletPendingRoute),
     walletSend: buildRequestHandler<
       WalletSendParams,
       WalletSendPayload,
       WalletSendResponse
     >(axios, 'post', busWalletSendRoute),
-    walletSign: buildRequestHandler<
-      WalletSignParams,
-      WalletSignPayload,
-      WalletSignResponse
-    >(axios, 'post', busWalletSignRoute),
     walletRedistribute: buildRequestHandler<
       WalletRedistributeParams,
       WalletRedistributePayload,
       WalletRedistributeResponse
     >(axios, 'post', busWalletRedistributeRoute),
-    walletDiscard: buildRequestHandler<
-      WalletDiscardParams,
-      WalletDiscardPayload,
-      WalletDiscardResponse
-    >(axios, 'post', busWalletDiscardRoute),
     walletPrepareForm: buildRequestHandler<
       WalletPrepareFormParams,
       WalletPrepareFormPayload,
@@ -388,11 +348,6 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       WalletPrepareRenewPayload,
       WalletPrepareRenewResponse
     >(axios, 'post', '/bus/wallet/prepare/form'),
-    walletPending: buildRequestHandler<
-      WalletPendingParams,
-      WalletPendingPayload,
-      WalletPendingResponse
-    >(axios, 'get', busWalletPendingRoute),
     hosts: buildRequestHandler<HostsParams, HostsPayload, HostsResponse>(
       axios,
       'post',

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -152,14 +152,6 @@ import {
   TxPoolRecommendedFeeResponse,
   TxPoolTransactionsParams,
   TxPoolTransactionsResponse,
-  WalletAddressesParams,
-  WalletAddressesResponse,
-  WalletDiscardParams,
-  WalletDiscardPayload,
-  WalletDiscardResponse,
-  WalletFundParams,
-  WalletFundPayload,
-  WalletFundResponse,
   WalletMetricsParams,
   WalletMetricsResponse,
   WalletParams,
@@ -175,13 +167,6 @@ import {
   WalletRedistributePayload,
   WalletRedistributeResponse,
   WalletResponse,
-  WalletSignParams,
-  WalletSignPayload,
-  WalletSignResponse,
-  WalletTransactionsParams,
-  WalletTransactionsResponse,
-  WalletUtxoParams,
-  WalletUtxoResponse,
   busBucketRoute,
   busBucketNamePolicyRoute,
   busBucketNameRoute,
@@ -218,17 +203,11 @@ import {
   busTxpoolBroadcastRoute,
   busTxpoolRecommendedFeeRoute,
   busTxpoolTransactionsRoute,
-  busWalletAddressesRoute,
-  busWalletDiscardRoute,
-  busWalletFundRoute,
-  busWalletOutputsRoute,
   busWalletPendingRoute,
   busWalletPrepareFormRoute,
   busWalletPrepareRenewRoute,
   busWalletRedistributeRoute,
   busWalletRoute,
-  busWalletSignRoute,
-  busWalletTransactionsRoute,
   busAlertsRoute,
   busAlertsDismissRoute,
   busSlabKeyObjectsRoute,
@@ -262,6 +241,9 @@ import {
   busAutopilotsRoute,
   AutopilotsParams,
   AutopilotsResponse,
+  WalletEventsParams,
+  WalletEventsResponse,
+  busWalletEventsRoute,
 } from '@siafoundation/renterd-types'
 
 // state
@@ -410,45 +392,19 @@ export function useWallet(args?: HookArgsSwr<WalletParams, WalletResponse>) {
   return useGetSwr({ ...args, route: busWalletRoute })
 }
 
-export function useWalletAddresses(
-  args?: HookArgsSwr<WalletAddressesParams, WalletAddressesResponse>
-) {
-  return useGetSwr({ ...args, route: busWalletAddressesRoute })
-}
-
-export function useWalletTransactions(
-  args: HookArgsSwr<WalletTransactionsParams, WalletTransactionsResponse>
+export function useWalletEvents(
+  args: HookArgsSwr<WalletEventsParams, WalletEventsResponse>
 ) {
   return useGetSwr({
     ...args,
-    route: busWalletTransactionsRoute,
+    route: busWalletEventsRoute,
   })
 }
 
-export function useWalletUtxos(
-  args?: HookArgsSwr<WalletUtxoParams, WalletUtxoResponse>
+export function useWalletPending(
+  args?: HookArgsSwr<WalletPendingParams, WalletPendingResponse>
 ) {
-  return useGetSwr({ ...args, route: busWalletOutputsRoute })
-}
-
-export function useWalletFund(
-  args?: HookArgsCallback<
-    WalletFundParams,
-    WalletFundPayload,
-    WalletFundResponse
-  >
-) {
-  return usePostFunc({ ...args, route: busWalletFundRoute })
-}
-
-export function useWalletSign(
-  args?: HookArgsCallback<
-    WalletSignParams,
-    WalletSignPayload,
-    WalletSignResponse
-  >
-) {
-  return usePostFunc({ ...args, route: busWalletSignRoute })
+  return useGetSwr({ ...args, route: busWalletPendingRoute })
 }
 
 export function useWalletSend(
@@ -479,16 +435,6 @@ export function useWalletRedistribute(
   return usePostFunc({ ...args, route: busWalletRedistributeRoute })
 }
 
-export function useWalletDiscard(
-  args?: HookArgsCallback<
-    WalletDiscardParams,
-    WalletDiscardPayload,
-    WalletDiscardResponse
-  >
-) {
-  return usePostFunc({ ...args, route: busWalletDiscardRoute })
-}
-
 export function useWalletPrepareForm(
   args?: HookArgsCallback<
     WalletPrepareFormParams,
@@ -507,12 +453,6 @@ export function useWalletPrepareRenew(
   >
 ) {
   return usePostFunc({ ...args, route: busWalletPrepareRenewRoute })
-}
-
-export function useWalletPending(
-  args?: HookArgsSwr<WalletPendingParams, WalletPendingResponse>
-) {
-  return useGetSwr({ ...args, route: busWalletPendingRoute })
 }
 
 export function useHosts(

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -3,11 +3,10 @@ import {
   PublicKey,
   Transaction,
   FileContractRevision,
-  OutputID,
-  CoveredFields,
   FileContractID,
   Block,
   TransactionID,
+  WalletEvent,
 } from '@siafoundation/types'
 import {
   Autopilot,
@@ -18,9 +17,7 @@ import {
   HostSettings,
   Obj,
   PartialSlab,
-  SiacoinElement,
   SlabSlice,
-  WalletTransaction,
 } from './types'
 
 export const busStateRoute = '/bus/state'
@@ -34,17 +31,12 @@ export const busTxpoolTransactionsRoute = '/bus/txpool/transactions'
 export const busTxpoolBroadcastRoute = '/bus/txpool/broadcast'
 export const busTxpoolRecommendedFeeRoute = '/bus/txpool/recommendedfee'
 export const busWalletRoute = '/bus/wallet'
-export const busWalletAddressesRoute = '/bus/wallet/addresses'
-export const busWalletTransactionsRoute = '/bus/wallet/transactions'
-export const busWalletOutputsRoute = '/bus/wallet/outputs'
-export const busWalletFundRoute = '/bus/wallet/fund'
-export const busWalletSignRoute = '/bus/wallet/sign'
-export const busWalletSendRoute = '/bus/wallet/send'
+export const busWalletEventsRoute = '/bus/wallet/events'
+export const busWalletPendingRoute = '/bus/wallet/pending'
 export const busWalletRedistributeRoute = '/bus/wallet/redistribute'
-export const busWalletDiscardRoute = '/bus/wallet/discard'
+export const busWalletSendRoute = '/bus/wallet/send'
 export const busWalletPrepareFormRoute = '/bus/wallet/prepare/form'
 export const busWalletPrepareRenewRoute = '/bus/wallet/prepare/renew'
-export const busWalletPendingRoute = '/bus/wallet/pending'
 export const busHostsRoute = '/bus/hosts'
 export const busHostHostKeyRoute = '/bus/host/:hostKey'
 export const busHostsHostKeyRoute = '/bus/hosts/:hostKey'
@@ -155,47 +147,27 @@ export type TxPoolBroadcastResponse = unknown
 
 export type WalletParams = void
 export type WalletPayload = void
-export type WalletResponse = {
-  scanHeight: number
-  address: string
+export type WalletBalance = {
   confirmed: string
   unconfirmed: string
   spendable: string
+  immature: string
+}
+export type WalletResponse = WalletBalance & {
+  scanHeight: number
+  address: string
 }
 
-export type WalletAddressesParams = void
-export type WalletAddressesPayload = void
-export type WalletAddressesResponse = string[]
-
-export type WalletTransactionsParams = {
-  offset?: number
+export type WalletEventsParams = {
   limit?: number
+  offset?: number
 }
-export type WalletTransactionsPayload = void
-export type WalletTransactionsResponse = WalletTransaction[]
+export type WalletEventsPayload = void
+export type WalletEventsResponse = WalletEvent[]
 
-export type WalletUtxoParams = void
-export type WalletUtxoPayload = void
-export type WalletUtxoResponse = SiacoinElement[]
-
-export type WalletFundParams = void
-export type WalletFundPayload = {
-  transaction: Transaction
-  amount: Currency
-}
-export type WalletFundResponse = {
-  transaction: Transaction
-  toSign?: OutputID[]
-  dependsOn?: Transaction[]
-}
-
-export type WalletSignParams = void
-export type WalletSignPayload = {
-  transaction: Transaction
-  toSign?: OutputID[]
-  coveredFields: CoveredFields
-}
-export type WalletSignResponse = Transaction
+export type WalletPendingParams = void
+export type WalletPendingPayload = void
+export type WalletPendingResponse = WalletEvent[]
 
 export type WalletSendParams = void
 export type WalletSendPayload = {
@@ -212,10 +184,6 @@ export type WalletRedistributePayload = {
   outputs: number
 }
 export type WalletRedistributeResponse = Transaction
-
-export type WalletDiscardParams = void
-export type WalletDiscardPayload = Transaction
-export type WalletDiscardResponse = void
 
 export type WalletPrepareFormParams = void
 export type WalletPrepareFormPayload = {
@@ -243,10 +211,6 @@ export type WalletPrepareRenewResponse = {
   transactionSet?: Transaction[]
   finalPayment: Currency
 }
-
-export type WalletPendingParams = void
-export type WalletPendingPayload = void
-export type WalletPendingResponse = Transaction[]
 
 // hosts
 


### PR DESCRIPTION
> All checks pass on final api-breakers PR: https://github.com/SiaFoundation/web/pull/743

This PR corresponds to the changes in: https://github.com/SiaFoundation/renterd/pull/1478

### Updates
- Removed deprecated wallet transactions and pending transactions APIs.
- Added wallet events and pending events APIs.
- Removed deprecated wallet discard, fund, sign, and outputs APIs.
- The renterd transactions list is now includes more details such as specific transaction types and maturity height for locked siacoin.