### PR TITLE
refactor(renterd): migrate hosts APIs

### DIFF
--- a/.changeset/early-bobcats-fry.md
+++ b/.changeset/early-bobcats-fry.md
@@ -1,0 +1,6 @@
+---
+'renterd': patch
+'@siafoundation/renterd-react': patch
+---
+
+Fixed a bug optimistically updating last scan information when initiating a host scan.

--- a/.changeset/eighty-eagles-taste.md
+++ b/.changeset/eighty-eagles-taste.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The hosts explorer now uses the new combined hosts API.

--- a/.changeset/fair-carrots-reflect.md
+++ b/.changeset/fair-carrots-reflect.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Added the bus list autopilots API.

--- a/.changeset/late-onions-hammer.md
+++ b/.changeset/late-onions-hammer.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Added new combined hosts API.

--- a/.changeset/tiny-mails-guess.md
+++ b/.changeset/tiny-mails-guess.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Removed deprecated search hosts and autopilot hosts APIs.

--- a/apps/renterd-e2e/src/specs/hosts.spec.ts
+++ b/apps/renterd-e2e/src/specs/hosts.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+import { navigateToHosts } from '../fixtures/navigate'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
+import { getHostRowByIndex } from '../fixtures/hosts'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page, {
+    hostdCount: 3,
+  })
+})
+
+test.afterEach(async () => {
+  await afterTest()
+})
+
+test('hosts explorer shows all hosts', async ({ page }) => {
+  await navigateToHosts({ page })
+
+  const row1 = await getHostRowByIndex(page, 0)
+  const row2 = await getHostRowByIndex(page, 1)
+  const row3 = await getHostRowByIndex(page, 2)
+  await expect(row1).toBeVisible()
+  await expect(row2).toBeVisible()
+  await expect(row3).toBeVisible()
+})

--- a/apps/renterd/contexts/config/useOnValid.tsx
+++ b/apps/renterd/contexts/config/useOnValid.tsx
@@ -14,7 +14,7 @@ import { transformUp } from './transformUp'
 import { delay, useMutate } from '@siafoundation/react-core'
 import { Resources } from './resources'
 import { useSyncContractSet } from './useSyncContractSet'
-import { autopilotHostsRoute } from '@siafoundation/renterd-types'
+import { busHostsRoute } from '@siafoundation/renterd-types'
 
 export function useOnValid({
   resources,
@@ -133,9 +133,9 @@ export function useOnValid({
         if (firstTimeSettingConfig) {
           const refreshHostsAfterDelay = async () => {
             await delay(5_000)
-            mutate((key) => key.startsWith(autopilotHostsRoute))
+            mutate((key) => key.startsWith(busHostsRoute))
             await delay(5_000)
-            mutate((key) => key.startsWith(autopilotHostsRoute))
+            mutate((key) => key.startsWith(busHostsRoute))
           }
           refreshHostsAfterDelay()
         }

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -21,7 +21,8 @@ import { format, formatDistance, formatRelative } from 'date-fns'
 import { HostContextMenu } from '../../components/Hosts/HostContextMenu'
 import { useWorkflows } from '@siafoundation/react-core'
 import {
-  AutopilotHost,
+  HostPriceTable,
+  HostSettings,
   RhpScanPayload,
   workerRhpScanRoute,
 } from '@siafoundation/renterd-types'
@@ -135,15 +136,15 @@ export const columns: HostsTableColumn[] = (
         return (
           <Tooltip
             side="right"
-            content={data.usable ? 'Host is usable' : 'Host is not usable'}
+            content={data.isUsable ? 'Host is usable' : 'Host is not usable'}
           >
             <div className="flex gap-2 items-center">
               <div className="mt-[5px]">
                 <Text
-                  aria-label={data.usable ? 'usable' : 'not usable'}
-                  color={data.usable ? 'green' : 'red'}
+                  aria-label={data.isUsable ? 'usable' : 'not usable'}
+                  color={data.isUsable ? 'green' : 'red'}
                 >
-                  {data.usable ? (
+                  {data.isUsable ? (
                     <CheckboxCheckedFilled16 />
                   ) : (
                     <WarningSquareFilled16 />
@@ -182,15 +183,15 @@ export const columns: HostsTableColumn[] = (
           <Tooltip
             side="right"
             content={
-              data.gouging
+              data.isGouging
                 ? 'Host is price gouging'
                 : 'Host is not price gouging'
             }
           >
             <div className="flex gap-2 items-center">
               <div className="mt-[5px]">
-                <Text color={!data.gouging ? 'subtle' : 'red'}>
-                  {!data.gouging ? (
+                <Text color={!data.isGouging ? 'subtle' : 'red'}>
+                  {!data.isGouging ? (
                     <UndefinedFilled16 />
                   ) : (
                     <WarningSquareFilled16 />
@@ -1078,9 +1079,7 @@ function getFullLabelAndTip(col: HostsTableColumn): {
   }
 }
 
-type Key =
-  | keyof AutopilotHost['host']['priceTable']
-  | keyof AutopilotHost['host']['settings']
+type Key = keyof HostPriceTable | keyof HostSettings
 
 function makeRenderSc(section: 'priceTable' | 'settings', name: Key) {
   return memo(function RenderPriceTableNumber({ data }: { data: HostData }) {

--- a/apps/renterd/contexts/hosts/status.ts
+++ b/apps/renterd/contexts/hosts/status.ts
@@ -18,7 +18,7 @@ export const hostColors = {
 
 export function getHostStatus(h: HostData) {
   // active and unusable
-  if (h.activeContractsCount.gt(0) && !h.usable) {
+  if (h.activeContractsCount.gt(0) && !h.isUsable) {
     return {
       status: 'activeAndUnusable',
       ...hostColors.activeAndUnusable,

--- a/apps/renterd/contexts/hosts/types.tsx
+++ b/apps/renterd/contexts/hosts/types.tsx
@@ -1,4 +1,4 @@
-import { AutopilotHost } from '@siafoundation/renterd-types'
+import { HostPriceTable, HostSettings } from '@siafoundation/renterd-types'
 import BigNumber from 'bignumber.js'
 import { ContractData } from '../contracts/types'
 
@@ -22,7 +22,6 @@ export type HostData = {
   totalInteractions: BigNumber
   totalScans: BigNumber
   // autopilot
-  score: BigNumber
   scoreBreakdown: {
     age: BigNumber
     collateral: BigNumber
@@ -32,17 +31,29 @@ export type HostData = {
     uptime: BigNumber
     version: BigNumber
   }
-  unusableReasons: string[]
   gougingBreakdown: {
     contractErr?: string
     downloadErr?: string
     gougingErr?: string
     uploadErr?: string
+    pruneErr?: string
   }
-  priceTable?: AutopilotHost['host']['priceTable']
-  settings?: AutopilotHost['host']['settings']
-  gouging: boolean
-  usable: boolean
+  usabilityBreakdown: {
+    blocked: boolean
+    gouging: boolean
+    lowScore: boolean
+    notAcceptingContracts: boolean
+    notAnnounced: boolean
+    notCompletingScan: boolean
+    offline: boolean
+    redundantIP: boolean
+  }
+  score: BigNumber
+  isGouging: boolean
+  isUsable: boolean
+  priceTable?: HostPriceTable
+  unusableReasons?: string[]
+  settings?: HostSettings
   activeContractsCount: BigNumber
   activeContracts: ContractData[]
   // merged in from sia central API

--- a/libs/clusterd/src/index.ts
+++ b/libs/clusterd/src/index.ts
@@ -100,8 +100,9 @@ export async function waitForContracts({
   await waitFor(
     async () => {
       await mine(1)
-      const hosts = await bus.hostsSearch({
+      const hosts = await bus.hosts({
         data: {
+          autopilotID: 'autopilot',
           filterMode: 'allowed',
           usabilityMode: 'usable',
           limit: 50,

--- a/libs/renterd-js/README.md
+++ b/libs/renterd-js/README.md
@@ -51,8 +51,9 @@ export async function example() {
     },
   })
 
-  const hosts = await autopilot.hostsSearch({
+  const hosts = await bus.hosts({
     data: {
+      autopilotID: 'autopilot',
       filterMode: 'allowed',
       usabilityMode: 'usable',
       addressContains: 'example.com',
@@ -63,7 +64,7 @@ export async function example() {
   })
 
   hosts.data.forEach((host) => {
-    console.log(host.host.publicKey, host.host.priceTable)
+    console.log(host.publicKey, host.priceTable)
   })
 
   await worker.objectUpload({
@@ -85,5 +86,8 @@ export async function example() {
       bucket: 'my-bucket',
     },
   })
+
+  const state = await autopilot.state()
+  console.log(state.data.migrating)
 }
 ```

--- a/libs/renterd-js/src/autopilot.ts
+++ b/libs/renterd-js/src/autopilot.ts
@@ -8,9 +8,6 @@ import {
   AutopilotConfigUpdateParams,
   AutopilotConfigUpdatePayload,
   AutopilotConfigUpdateResponse,
-  AutopilotHostsSearchParams,
-  AutopilotHostsSearchPayload,
-  AutopilotHostsSearchResponse,
   AutopilotStateParams,
   AutopilotStatePayload,
   AutopilotStateResponse,
@@ -18,7 +15,6 @@ import {
   AutopilotTriggerPayload,
   AutopilotTriggerResponse,
   autopilotConfigRoute,
-  autopilotHostsRoute,
   autopilotStateRoute,
   autopilotTriggerRoute,
 } from '@siafoundation/renterd-types'
@@ -54,11 +50,6 @@ export function Autopilot({
       AutopilotConfigEvaluatePayload,
       AutopilotConfigEvaluateResponse
     >(axios, 'post', autopilotConfigRoute),
-    hostsSearch: buildRequestHandler<
-      AutopilotHostsSearchParams,
-      AutopilotHostsSearchPayload,
-      AutopilotHostsSearchResponse
-    >(axios, 'post', autopilotHostsRoute),
     trigger: buildRequestHandler<
       AutopilotTriggerParams,
       AutopilotTriggerPayload,

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -94,9 +94,9 @@ import {
   HostsBlocklistUpdateParams,
   HostsBlocklistUpdatePayload,
   HostsBlocklistUpdateResponse,
-  HostsSearchParams,
-  HostsSearchPayload,
-  HostsSearchResponse,
+  HostsParams,
+  HostsPayload,
+  HostsResponse,
   MultipartUploadAbortParams,
   MultipartUploadAbortPayload,
   MultipartUploadAbortResponse,
@@ -247,7 +247,7 @@ import {
   busObjectsKeyRoute,
   busObjectsListRoute,
   busObjectsRenameRoute,
-  busSearchHostsRoute,
+  busHostsRoute,
   busSearchObjectsRoute,
   busSettingKeyRoute,
   busSettingsRoute,
@@ -271,6 +271,10 @@ import {
   busWalletSendRoute,
   busWalletSignRoute,
   busWalletTransactionsRoute,
+  busAutopilotsRoute,
+  AutopilotsParams,
+  AutopilotsPayload,
+  AutopilotsResponse,
 } from '@siafoundation/renterd-types'
 import { buildRequestHandler, initAxios } from '@siafoundation/request'
 import { AxiosRequestConfig } from 'axios'
@@ -284,6 +288,11 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       BusStatePayload,
       BusStateResponse
     >(axios, 'get', busStateRoute),
+    autopilots: buildRequestHandler<
+      AutopilotsParams,
+      AutopilotsPayload,
+      AutopilotsResponse
+    >(axios, 'get', busAutopilotsRoute),
     consensusState: buildRequestHandler<
       ConsensusStateParams,
       ConsensusStatePayload,
@@ -384,11 +393,11 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       WalletPendingPayload,
       WalletPendingResponse
     >(axios, 'get', busWalletPendingRoute),
-    hostsSearch: buildRequestHandler<
-      HostsSearchParams,
-      HostsSearchPayload,
-      HostsSearchResponse
-    >(axios, 'post', busSearchHostsRoute),
+    hosts: buildRequestHandler<HostsParams, HostsPayload, HostsResponse>(
+      axios,
+      'post',
+      busHostsRoute
+    ),
     host: buildRequestHandler<HostParams, HostPayload, HostResponse>(
       axios,
       'get',

--- a/libs/renterd-js/src/example.ts
+++ b/libs/renterd-js/src/example.ts
@@ -40,8 +40,9 @@ export async function example() {
     },
   })
 
-  const hosts = await autopilot.hostsSearch({
+  const hosts = await bus.hosts({
     data: {
+      autopilotID: 'autopilot-id',
       filterMode: 'allowed',
       usabilityMode: 'usable',
       addressContains: 'example.com',
@@ -52,7 +53,7 @@ export async function example() {
   })
 
   hosts.data.forEach((host) => {
-    console.log(host.host.publicKey, host.host.priceTable)
+    console.log(host.publicKey, host.priceTable)
   })
 
   await worker.objectUpload({
@@ -74,4 +75,7 @@ export async function example() {
       bucket: 'my-bucket',
     },
   })
+
+  const state = await autopilot.state()
+  console.log(state.data.migrating)
 }

--- a/libs/renterd-react/src/autopilot.ts
+++ b/libs/renterd-react/src/autopilot.ts
@@ -17,16 +17,12 @@ import {
   AutopilotConfigEvaluateParams,
   AutopilotConfigEvaluatePayload,
   AutopilotConfigEvaluateResponse,
-  AutopilotHostsSearchParams,
-  AutopilotHostsSearchPayload,
-  AutopilotHostsSearchResponse,
   AutopilotStateParams,
   AutopilotStateResponse,
   AutopilotTriggerParams,
   AutopilotTriggerPayload,
   AutopilotTriggerResponse,
   autopilotConfigRoute,
-  autopilotHostsRoute,
   autopilotStateRoute,
   autopilotTriggerRoute,
 } from '@siafoundation/renterd-types'
@@ -79,19 +75,6 @@ export function useAutopilotConfigEvaluate(
   >
 ) {
   return usePostSwr({ ...args, route: autopilotConfigRoute })
-}
-
-export function useAutopilotHostsSearch(
-  args?: HookArgsWithPayloadSwr<
-    AutopilotHostsSearchParams,
-    AutopilotHostsSearchPayload,
-    AutopilotHostsSearchResponse
-  >
-) {
-  return usePostSwr({
-    ...args,
-    route: autopilotHostsRoute,
-  })
 }
 
 export function useAutopilotTrigger(

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -88,9 +88,9 @@ import {
   HostsBlocklistUpdateParams,
   HostsBlocklistUpdatePayload,
   HostsBlocklistUpdateResponse,
-  HostsSearchParams,
-  HostsSearchPayload,
-  HostsSearchResponse,
+  HostsParams,
+  HostsPayload,
+  HostsResponse,
   MultipartUploadAbortParams,
   MultipartUploadAbortPayload,
   MultipartUploadAbortResponse,
@@ -206,7 +206,7 @@ import {
   busObjectsKeyRoute,
   busObjectsListRoute,
   busObjectsRenameRoute,
-  busSearchHostsRoute,
+  busHostsRoute,
   busSearchObjectsRoute,
   busSettingKeyRoute,
   busSettingsRoute,
@@ -259,6 +259,9 @@ import {
   WalletSendPayload,
   WalletSendResponse,
   busWalletSendRoute,
+  busAutopilotsRoute,
+  AutopilotsParams,
+  AutopilotsResponse,
 } from '@siafoundation/renterd-types'
 
 // state
@@ -269,6 +272,17 @@ export function useBusState(
   return useGetSwr({
     ...args,
     route: busStateRoute,
+  })
+}
+
+// autopilots
+
+export function useAutopilots(
+  args?: HookArgsSwr<AutopilotsParams, AutopilotsResponse>
+) {
+  return useGetSwr({
+    ...args,
+    route: busAutopilotsRoute,
   })
 }
 
@@ -501,16 +515,12 @@ export function useWalletPending(
   return useGetSwr({ ...args, route: busWalletPendingRoute })
 }
 
-export function useHostsSearch(
-  args: HookArgsWithPayloadSwr<
-    HostsSearchParams,
-    HostsSearchPayload,
-    HostsSearchResponse
-  >
+export function useHosts(
+  args: HookArgsWithPayloadSwr<HostsParams, HostsPayload, HostsResponse>
 ) {
   return usePostSwr({
     ...args,
-    route: busSearchHostsRoute,
+    route: busHostsRoute,
   })
 }
 
@@ -555,7 +565,7 @@ export function useHostsAllowlistUpdate(
     async (mutate) => {
       mutate((key) => {
         const matches = [
-          busSearchHostsRoute,
+          busHostsRoute,
           busHostsAllowlistRoute,
           busContractsRoute,
         ]
@@ -577,7 +587,7 @@ export function useHostsBlocklistUpdate(
     async (mutate) => {
       mutate((key) => {
         const matches = [
-          busSearchHostsRoute,
+          busHostsRoute,
           busHostsBlocklistRoute,
           busContractsRoute,
         ]

--- a/libs/renterd-react/src/worker.ts
+++ b/libs/renterd-react/src/worker.ts
@@ -11,8 +11,6 @@ import {
   AccountResetDriftParams,
   AccountResetDriftPayload,
   AccountResetDriftResponse,
-  AutopilotHost,
-  Host,
   MultipartUploadPartParams,
   MultipartUploadPartPayload,
   MultipartUploadPartResponse,
@@ -27,9 +25,8 @@ import {
   RhpScanResponse,
   WorkerStateParams,
   WorkerStateResponse,
-  autopilotHostsRoute,
   busObjectsRoute,
-  busSearchHostsRoute,
+  busHostsRoute,
   workerAccountIdResetdriftRoute,
   workerMultipartKeyRoute,
   workerObjectsKeyRoute,
@@ -121,52 +118,31 @@ export function useRhpScan(
       // is debounced so if the user rescans multiple hosts in quick
       // succession the list is optimistically updated n times followed
       // by a single network revalidate.
-      mutate<AutopilotHost[]>(
-        (key) => key.startsWith(autopilotHostsRoute),
+      mutate<Host[]>(
+        (key) => key.startsWith(busHostsRoute),
         (data) =>
-          data?.map((aph) => {
-            if (aph.host.publicKey === hostKey) {
+          data?.map((h) => {
+            if (h.publicKey === hostKey) {
               return {
-                ...aph,
+                ...h,
                 host: {
-                  ...aph.host,
+                  ...h,
                   interactions: {
-                    ...aph.host.interactions,
-                    LastScan: new Date().toISOString(),
-                    LastScanSuccess: !response.data.scanError,
+                    ...h.interactions,
+                    lastScan: new Date().toISOString(),
+                    lastScanSuccess: !response.data.scanError,
                   },
                   settings: response.data.settings,
                 },
               }
             }
-            return aph
-          }),
-        false
-      )
-      mutate<Host[]>(
-        (key) => key.startsWith(busSearchHostsRoute),
-        (data) =>
-          data?.map((host) => {
-            if (host.publicKey === hostKey) {
-              return {
-                ...host,
-                interactions: {
-                  ...host.interactions,
-                  LastScan: new Date().toISOString(),
-                  LastScanSuccess: !response.data.scanError,
-                },
-                settings: response.data.settings,
-              }
-            }
-            return host
+            return h
           }),
         false
       )
       debouncedListRevalidate(() => {
         mutate(
-          (key) =>
-            key.startsWith(autopilotHostsRoute) ||
-            key.startsWith(busSearchHostsRoute),
+          (key) => key.startsWith(busHostsRoute),
           (d) => d,
           true
         )

--- a/libs/renterd-types/src/autopilot.ts
+++ b/libs/renterd-types/src/autopilot.ts
@@ -1,17 +1,12 @@
-import {
-  AutopilotConfig,
-  GougingSettings,
-  Host,
-  RedundancySettings,
-} from './types'
-import { HostsSearchPayload, BusStateResponse } from './bus'
+import { AutopilotConfig, GougingSettings, RedundancySettings } from './types'
+import { BusStateResponse } from './bus'
 
 export const autopilotStateRoute = '/autopilot/state'
 export const autopilotConfigRoute = '/autopilot/config'
-export const autopilotHostsRoute = '/autopilot/hosts'
 export const autopilotTriggerRoute = '/autopilot/trigger'
 
 type AutopilotStatus = {
+  id: string
   configured: boolean
   migrating: boolean
   migratingLastStart: string
@@ -62,35 +57,6 @@ export type AutopilotConfigEvaluateResponse = {
   }
   recommendation?: ConfigRecommendation
 }
-
-export type AutopilotHost = {
-  host: Host
-  checks?: {
-    score: number
-    scoreBreakdown: {
-      age: number
-      collateral: number
-      interactions: number
-      storageRemaining: number
-      prices: number
-      uptime: number
-      version: number
-    }
-    unusableReasons: string[]
-    gougingBreakdown: {
-      contractErr?: string
-      downloadErr?: string
-      gougingErr?: string
-      uploadErr?: string
-    }
-    gouging: boolean
-    usable: boolean
-  }
-}
-
-export type AutopilotHostsSearchParams = void
-export type AutopilotHostsSearchPayload = HostsSearchPayload
-export type AutopilotHostsSearchResponse = AutopilotHost[]
 
 export type AutopilotTriggerParams = void
 export type AutopilotTriggerPayload = { forceScan: boolean }

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -10,6 +10,7 @@ import {
   TransactionID,
 } from '@siafoundation/types'
 import {
+  Autopilot,
   ConsensusState,
   Contract,
   ContractRevision,
@@ -23,6 +24,7 @@ import {
 } from './types'
 
 export const busStateRoute = '/bus/state'
+export const busAutopilotsRoute = '/bus/autopilots'
 export const busConsensusStateRoute = '/bus/consensus/state'
 export const busConsensusAcceptblockRoute = '/bus/consensus/acceptblock'
 export const busSyncerPeersRoute = '/bus/syncer/peers'
@@ -43,7 +45,7 @@ export const busWalletDiscardRoute = '/bus/wallet/discard'
 export const busWalletPrepareFormRoute = '/bus/wallet/prepare/form'
 export const busWalletPrepareRenewRoute = '/bus/wallet/prepare/renew'
 export const busWalletPendingRoute = '/bus/wallet/pending'
-export const busSearchHostsRoute = '/bus/search/hosts'
+export const busHostsRoute = '/bus/hosts'
 export const busHostHostKeyRoute = '/bus/host/:hostKey'
 export const busHostsHostKeyRoute = '/bus/hosts/:hostKey'
 export const busHostsBlocklistRoute = '/bus/hosts/blocklist'
@@ -104,6 +106,12 @@ export type BusStatePayload = void
 export type BusStateResponse = BuildState & {
   startTime: number
 }
+
+// autopilots
+
+export type AutopilotsParams = void
+export type AutopilotsPayload = void
+export type AutopilotsResponse = Autopilot[]
 
 // consensus
 
@@ -242,18 +250,20 @@ export type WalletPendingResponse = Transaction[]
 
 // hosts
 
-export type HostsSearchParams = void
-export type HostsSearchFilterMode = 'all' | 'allowed' | 'blocked'
+export type HostsParams = void
+export type HostsFilterMode = 'all' | 'allowed' | 'blocked'
 export type HostsUsabilityMode = 'all' | 'usable' | 'unusable'
-export type HostsSearchPayload = {
-  filterMode: HostsSearchFilterMode
+export type HostsPayload = {
+  autopilotID?: string
+  filterMode: HostsFilterMode
   usabilityMode?: HostsUsabilityMode
   addressContains?: string
   keyIn?: string[]
   offset?: number
   limit?: number
+  maxLastScan?: string
 }
-export type HostsSearchResponse = Host[]
+export type HostsResponse = Host[]
 
 export type HostParams = { hostKey: string }
 export type HostPayload = Host

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -241,6 +241,42 @@ export type Host = {
   scanned: boolean
   priceTable?: HostPriceTable
   settings?: HostSettings
+  blocked: boolean
+  storedData: number
+  resolvedAddresses?: string[]
+  subnets?: string[]
+  checks?: Record<string, HostAutopilotChecks>
+}
+
+export type HostAutopilotChecks = {
+  score: number
+  usable: boolean
+  scoreBreakdown: {
+    age: number
+    collateral: number
+    interactions: number
+    storageRemaining: number
+    prices: number
+    uptime: number
+    version: number
+  }
+  gougingBreakdown: {
+    contractErr?: string
+    downloadErr?: string
+    gougingErr?: string
+    uploadErr?: string
+    pruneErr?: string
+  }
+  usabilityBreakdown: {
+    blocked: boolean
+    gouging: boolean
+    lowScore: boolean
+    notAcceptingContracts: boolean
+    notAnnounced: boolean
+    notCompletingScan: boolean
+    offline: boolean
+    redundantIP: boolean
+  }
 }
 
 export type SiacoinElement = {
@@ -273,6 +309,12 @@ export type AutopilotContractsConfig = {
 export type AutopilotConfig = {
   hosts: AutopilotHostsConfig
   contracts: AutopilotContractsConfig
+}
+
+export type Autopilot = {
+  id: string
+  config: AutopilotConfig
+  currentPeriod: number
 }
 
 export type WalletTransaction = {


### PR DESCRIPTION
> All checks pass on final api-breakers PR: https://github.com/SiaFoundation/web/pull/743

### Updates
- Removed deprecated search hosts and autopilot hosts APIs
- Added the new combined hosts API.
- The hosts explorer now uses the new combined hosts API.
- Added the bus list autopilots API.
- Fixed a bug optimistically updating last scan information when initiating a host scan.