### PR TITLE
feat(renterd): list objects allows fetching across buckets

### DIFF
--- a/.changeset/neat-foxes-carry.md
+++ b/.changeset/neat-foxes-carry.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+The list objects API now includes a slabEncryptionKey parameter.

--- a/.changeset/spotty-sheep-raise.md
+++ b/.changeset/spotty-sheep-raise.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+The list objects API bucket parameter is now optional, and bucket is returned in in the object metadata.

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -400,14 +400,15 @@ export type BucketDeletePayload = void
 export type BucketDeleteResponse = void
 
 export type ObjectListParams = {
+  bucket?: string
   prefix?: string
-  bucket: string
   delimiter?: string
   limit?: number
   marker?: string
   sortBy?: 'name' | 'health' | 'size'
   sortDir?: 'asc' | 'desc'
   substring?: string
+  slabEncryptionKey?: string
 }
 export type ObjectListPayload = void
 export type ObjectListResponse = {

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -108,6 +108,7 @@ export type ObjectObject = {
 }
 
 export type ObjectMetadata = {
+  bucket: string
   key: string
   size: number
   health: number

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,8 +561,7 @@
       "license": "MIT",
       "dependencies": {
         "@siafoundation/renterd-types": "0.7.0",
-        "@siafoundation/request": "0.2.0",
-        "axios": "^0.27.2"
+        "@siafoundation/request": "0.2.0"
       }
     },
     "libs/renterd-react": {
@@ -33968,8 +33967,7 @@
       "version": "file:libs/renterd-js",
       "requires": {
         "@siafoundation/renterd-types": "0.7.0",
-        "@siafoundation/request": "0.2.0",
-        "axios": "^0.27.2"
+        "@siafoundation/request": "0.2.0"
       }
     },
     "@siafoundation/renterd-react": {


### PR DESCRIPTION
Relates to https://github.com/SiaFoundation/renterd/pull/1517

- The list objects API now includes a slabEncryptionKey parameter.
- The list objects API bucket parameter is now optional, and bucket is returned in in the object metadata.
