### PR TITLE
refactor(renterd): remove default bucket

### DIFF
--- a/.changeset/fluffy-ligers-accept.md
+++ b/.changeset/fluffy-ligers-accept.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The bucket list now has an empty state.

--- a/.changeset/gentle-grapes-roll.md
+++ b/.changeset/gentle-grapes-roll.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The cmdk menu now has an two separate files search options, one for across all buckets and one for the current bucket.

--- a/.changeset/honest-books-push.md
+++ b/.changeset/honest-books-push.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+It is now possible to delete a bucket named 'default'.

--- a/.changeset/many-numbers-mate.md
+++ b/.changeset/many-numbers-mate.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Updated to the new objects remove API.

--- a/.changeset/proud-rules-breathe.md
+++ b/.changeset/proud-rules-breathe.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The file search feature can now search across all buckets.

--- a/.changeset/silver-months-glow.md
+++ b/.changeset/silver-months-glow.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+The command menu now opens via Ctrl+K on Linux and Windows.

--- a/.changeset/wild-hats-battle.md
+++ b/.changeset/wild-hats-battle.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Adjusted the name of the objects rename API.

--- a/apps/hostd/components/CmdKDialog/index.tsx
+++ b/apps/hostd/components/CmdKDialog/index.tsx
@@ -21,7 +21,7 @@ export function CmdKDialog({ open, onOpenChange, setOpen }: Props) {
       return
     }
     const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && e.metaKey) {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         setOpen()
       }
     }

--- a/apps/renterd-e2e/src/fixtures/buckets.ts
+++ b/apps/renterd-e2e/src/fixtures/buckets.ts
@@ -6,7 +6,7 @@ import { deleteDirectory, deleteFile } from './files'
 
 export async function createBucket(page: Page, name: string) {
   await navigateToBuckets({ page })
-  await page.getByText('Create bucket').click()
+  await page.getByText('Create bucket').first().click()
   await fillTextInputByName(page, 'name', name)
   await page.locator('input[name=name]').press('Enter')
   await expect(page.getByRole('dialog')).toBeHidden()

--- a/apps/renterd-e2e/src/fixtures/cmdk.ts
+++ b/apps/renterd-e2e/src/fixtures/cmdk.ts
@@ -1,0 +1,10 @@
+import { Page, expect } from '@playwright/test'
+
+export async function openCmdkMenu(page: Page) {
+  const isMac = process.platform === 'darwin'
+  const modifier = isMac ? 'Meta' : 'Control'
+  await page.keyboard.press(`${modifier}+k`)
+  const dialog = page.getByRole('dialog')
+  await expect(dialog.locator('div[cmdk-root]')).toBeVisible()
+  return dialog
+}

--- a/apps/renterd-e2e/src/fixtures/files.ts
+++ b/apps/renterd-e2e/src/fixtures/files.ts
@@ -69,10 +69,17 @@ export async function openDirectory(page: Page, path: string) {
 }
 
 export async function navigateToParentDirectory(page: Page) {
-  await page.getByRole('cell', { name: '..' }).click()
+  const isEmpty = await page
+    .getByText('The current directory does not contain any files yet')
+    .isVisible()
+  if (isEmpty) {
+    await page.getByRole('button', { name: 'Back' }).click()
+  } else {
+    await page.getByRole('cell', { name: '..' }).click()
+  }
 }
 
-export async function crateDirectory(page: Page, name: string) {
+export async function createDirectory(page: Page, name: string) {
   await expect(page.getByLabel('Create directory')).toBeVisible()
   await page.getByLabel('Create directory').click()
   await fillTextInputByName(page, 'name', name)
@@ -86,7 +93,7 @@ export async function createDirectoryIfNotExists(page: Page, name: string) {
     .getByTestId(name)
     .isVisible()
   if (!exists) {
-    await crateDirectory(page, name)
+    await createDirectory(page, name)
   }
 }
 

--- a/apps/renterd-e2e/src/specs/buckets.spec.ts
+++ b/apps/renterd-e2e/src/specs/buckets.spec.ts
@@ -4,7 +4,6 @@ import {
   bucketInList,
   createBucket,
   deleteBucket,
-  deleteBucketIfExists,
   openBucketContextMenu,
 } from '../fixtures/buckets'
 import { afterTest, beforeTest } from '../fixtures/beforeTest'
@@ -18,19 +17,25 @@ test.afterEach(async () => {
 })
 
 test('can change a buckets policy', async ({ page }) => {
+  const bucketName = 'bucket1'
   await navigateToBuckets({ page })
-  await openBucketContextMenu(page, 'default')
+  await expect(page.getByText('Create a bucket to get started.')).toBeVisible()
+  await createBucket(page, bucketName)
+  await openBucketContextMenu(page, bucketName)
   await page.getByRole('menuitem', { name: 'Change policy' }).click()
-  await page.getByRole('heading', { name: 'Change Policy: default' }).click()
+  await page
+    .getByRole('heading', { name: `Change Policy: ${bucketName}` })
+    .click()
   await page.getByRole('combobox').selectOption('public')
   await page.getByRole('button', { name: 'Update policy' }).click()
   await expect(page.getByText('Bucket policy has been updated')).toBeVisible()
-  await bucketInList(page, 'default')
+  await bucketInList(page, bucketName)
 })
 
 test('can create and delete a bucket', async ({ page }) => {
+  const bucketName = 'my-new-bucket'
   await navigateToBuckets({ page })
-  await deleteBucketIfExists(page, 'my-new-bucket')
-  await createBucket(page, 'my-new-bucket')
-  await deleteBucket(page, 'my-new-bucket')
+  await expect(page.getByText('Create a bucket to get started.')).toBeVisible()
+  await createBucket(page, bucketName)
+  await deleteBucket(page, bucketName)
 })

--- a/apps/renterd-e2e/src/specs/search.spec.ts
+++ b/apps/renterd-e2e/src/specs/search.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test'
+import { navigateToBuckets } from '../fixtures/navigate'
+import { createBucket, openBucket } from '../fixtures/buckets'
+import { createDirectory } from '../fixtures/files'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
+import { fillTextInputByName } from '../fixtures/textInput'
+import { openCmdkMenu } from '../fixtures/cmdk'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page, {
+    hostdCount: 3,
+  })
+})
+
+test.afterEach(async () => {
+  await afterTest()
+})
+
+test('can search for a file within a bucket via the actions menu', async ({
+  page,
+}) => {
+  test.setTimeout(120_000)
+  await navigateToBuckets({ page })
+  await createBucket(page, 'bucket-1')
+  await openBucket(page, 'bucket-1')
+  await createDirectory(page, 'foobar-1')
+  await createDirectory(page, 'foobar-2')
+  await navigateToBuckets({ page })
+  await createBucket(page, 'bucket-2')
+  await openBucket(page, 'bucket-2')
+  await createDirectory(page, 'foobar-1')
+  await createDirectory(page, 'foobar-2')
+  await page.getByLabel('search files').click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(2)
+  await expect(dialog.getByText('bucket-2')).toBeVisible()
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-1')
+  ).toBeVisible()
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-2')
+  ).toBeVisible()
+  await fillTextInputByName(page, 'search files', 'foobar-1')
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(1)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-1')
+  ).toBeVisible()
+})
+
+test('can search for a file within a bucket via the cmdk menu', async ({
+  page,
+}) => {
+  test.setTimeout(120_000)
+  await navigateToBuckets({ page })
+  await createBucket(page, 'bucket-1')
+  await openBucket(page, 'bucket-1')
+  await createDirectory(page, 'foobar-1')
+  await createDirectory(page, 'foobar-2')
+  await navigateToBuckets({ page })
+  await createBucket(page, 'bucket-2')
+  await openBucket(page, 'bucket-2')
+  await createDirectory(page, 'foobar-1')
+  await createDirectory(page, 'foobar-2')
+  await page.getByLabel('search files').click()
+  const dialog = await openCmdkMenu(page)
+  await fillTextInputByName(page, 'cmdk-input', 'search files in bucket')
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(1)
+  await dialog
+    .locator('div[cmdk-item]')
+    .getByText('search files in bucket')
+    .click()
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(2)
+  await expect(dialog.getByText('bucket-2')).toBeVisible()
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-1')
+  ).toBeVisible()
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-2')
+  ).toBeVisible()
+  await fillTextInputByName(page, 'cmdk-input', 'foobar-1')
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(1)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-1')
+  ).toBeVisible()
+})
+
+test('can search for a file across all buckets', async ({ page }) => {
+  test.setTimeout(120_000)
+  await navigateToBuckets({ page })
+  await createBucket(page, 'bucket-1')
+  await openBucket(page, 'bucket-1')
+  await createDirectory(page, 'foobar-1')
+  await createDirectory(page, 'foobar-2')
+  await navigateToBuckets({ page })
+  await createBucket(page, 'bucket-2')
+  await openBucket(page, 'bucket-2')
+  await createDirectory(page, 'foobar-1')
+  await createDirectory(page, 'foobar-2')
+  await page.focus('body')
+  const dialog = await openCmdkMenu(page)
+  await fillTextInputByName(page, 'cmdk-input', 'search all files')
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(1)
+  await dialog.locator('div[cmdk-item]').getByText('search all files').click()
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('bucket-1')
+  ).toHaveCount(2)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('bucket-2')
+  ).toHaveCount(2)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-1')
+  ).toHaveCount(2)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-2')
+  ).toHaveCount(2)
+  await fillTextInputByName(page, 'cmdk-input', 'foobar-1')
+  await expect(dialog.locator('div[cmdk-item]')).toHaveCount(2)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-1')
+  ).toHaveCount(2)
+  await expect(
+    dialog.locator('div[cmdk-item]').getByText('foobar-2')
+  ).toHaveCount(0)
+})

--- a/apps/renterd/components/CmdKDialog/index.tsx
+++ b/apps/renterd/components/CmdKDialog/index.tsx
@@ -21,7 +21,7 @@ export function CmdKDialog({ open, onOpenChange, setOpen }: Props) {
       return
     }
     const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && e.metaKey) {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         setOpen()
       }
     }

--- a/apps/renterd/components/CmdRoot/index.tsx
+++ b/apps/renterd/components/CmdRoot/index.tsx
@@ -4,6 +4,7 @@ import {
   panelStyles,
   Label,
   Separator,
+  Button,
 } from '@siafoundation/design-system'
 import { Command } from 'cmdk'
 import { WalletCmdGroup } from './WalletCmdGroup'
@@ -74,11 +75,26 @@ export function CmdRoot({ panel }: Props) {
         }
       }}
     >
-      {page && <Label className="px-2">{page.label}</Label>}
+      {!!page && (
+        <Label className="px-2 flex justify-between items-center">
+          {page.label}
+          {page.tag ? (
+            <Button
+              variant="inactive"
+              state="waiting"
+              tabIndex={-1}
+              size="small"
+            >
+              {page.tag}
+            </Button>
+          ) : null}
+        </Label>
+      )}
       <Command.Input
         value={search}
         onValueChange={setSearch}
         className={textFieldStyles({ variant: 'ghost', focus: 'none' })}
+        name="cmdk-input"
         placeholder={
           page?.prompt ||
           (rootPage

--- a/apps/renterd/components/CmdRoot/types.ts
+++ b/apps/renterd/components/CmdRoot/types.ts
@@ -4,5 +4,6 @@ export type Page = {
   namespace: string
   label: string
   prompt?: string
+  tag?: string
   empty?: (props: CmdEmptyProps) => JSX.Element
 }

--- a/apps/renterd/components/Files/BucketContextMenu.tsx
+++ b/apps/renterd/components/Files/BucketContextMenu.tsx
@@ -40,7 +40,6 @@ export function BucketContextMenu({ name }: Props) {
         Change policy
       </DropdownMenuItem>
       <DropdownMenuItem
-        disabled={name === 'default'}
         onSelect={() => {
           openDialog('filesDeleteBucket', name)
         }}

--- a/apps/renterd/components/Files/FilesCmd/index.tsx
+++ b/apps/renterd/components/Files/FilesCmd/index.tsx
@@ -3,11 +3,16 @@ import {
   CommandItemNav,
   CommandItemSearch,
 } from '../../CmdRoot/Item'
-import { FilesSearchCmd, filesSearchPage } from './FilesSearchCmd'
+import {
+  FilesSearchCmd,
+  filesSearchAllPage,
+  getFilesSearchBucketPage,
+} from './FilesSearchCmd'
 import { Page } from '../../CmdRoot/types'
 import { useRouter } from 'next/router'
 import { useDialog } from '../../../contexts/dialog'
 import { routes } from '../../../config/routes'
+import { useFilesManager } from '../../../contexts/filesManager'
 
 export const commandPage = {
   namespace: 'files',
@@ -33,6 +38,7 @@ export function FilesCmd({
 }) {
   const router = useRouter()
   const { closeDialog } = useDialog()
+  const { activeBucket } = useFilesManager()
   return (
     <>
       <CommandItemNav
@@ -63,14 +69,35 @@ export function FilesCmd({
           currentPage={currentPage}
           commandPage={commandPage}
           onSelect={() => {
-            pushPage(filesSearchPage)
+            pushPage(filesSearchAllPage)
             afterSelect()
           }}
         >
-          Search files
+          Search all files
         </CommandItemSearch>
+        {activeBucket ? (
+          <CommandItemSearch
+            currentPage={currentPage}
+            commandPage={commandPage}
+            onSelect={() => {
+              pushPage(getFilesSearchBucketPage(activeBucket.name))
+              afterSelect()
+            }}
+          >
+            Search files in bucket
+          </CommandItemSearch>
+        ) : null}
       </CommandGroup>
       <FilesSearchCmd
+        mode="global"
+        debouncedSearch={debouncedSearch}
+        search={search}
+        currentPage={currentPage}
+        beforeSelect={beforeSelect}
+        afterSelect={afterSelect}
+      />
+      <FilesSearchCmd
+        mode="bucket"
         debouncedSearch={debouncedSearch}
         search={search}
         currentPage={currentPage}

--- a/apps/renterd/components/Files/FilesSearchBucketMenu/index.tsx
+++ b/apps/renterd/components/Files/FilesSearchBucketMenu/index.tsx
@@ -4,6 +4,7 @@ import {
   panelStyles,
   Label,
   Separator,
+  Button,
 } from '@siafoundation/design-system'
 import { Command } from 'cmdk'
 import { useCallback, useState } from 'react'
@@ -11,39 +12,50 @@ import { useDialog } from '../../../contexts/dialog'
 import { useAppRouter, usePathname } from '@siafoundation/next'
 import { routes } from '../../../config/routes'
 import {
+  getFilesSearchBucketPage,
   FilesSearchCmd,
-  filesSearchPage,
 } from '../../Files/FilesCmd/FilesSearchCmd'
 import { useDebounce } from 'use-debounce'
 import { FileSearchEmpty } from '../../Files/FilesCmd/FilesSearchCmd/FileSearchEmpty'
+import { useFilesManager } from '../../../contexts/filesManager'
 
 type Props = {
   panel?: boolean
 }
 
-export function FilesSearchMenu({ panel }: Props) {
+export function FilesSearchBucketMenu({ panel }: Props) {
   const { closeDialog } = useDialog()
   const router = useAppRouter()
   const pathname = usePathname()
   const [search, setSearch] = useState('')
   const [debouncedSearch] = useDebounce(search, 500)
+  const { activeBucket } = useFilesManager()
 
   const beforeSelect = useCallback(() => {
     closeDialog()
   }, [closeDialog])
 
+  const page = getFilesSearchBucketPage(activeBucket?.name)
+
   return (
     <Command
-      label="Files search"
+      label={page.label}
       shouldFilter={false}
       className={cx(panel && panelStyles())}
     >
-      <Label className="px-2">File search</Label>
+      <Label className="px-2 flex justify-between items-center">
+        File search in current bucket
+        <Button variant="inactive" state="waiting" tabIndex={-1} size="small">
+          {activeBucket.name}
+        </Button>
+      </Label>
       <Command.Input
+        aria-label="search files"
+        name="search files"
         value={search}
         onValueChange={setSearch}
         className={textFieldStyles({ variant: 'ghost', focus: 'none' })}
-        placeholder={filesSearchPage.prompt}
+        placeholder={page.prompt}
       />
       <Separator className="my-2" />
       <div className="overflow-hidden">
@@ -55,9 +67,10 @@ export function FilesSearchMenu({ panel }: Props) {
             />
           </Command.Empty>
           <FilesSearchCmd
+            mode="bucket"
             debouncedSearch={debouncedSearch}
             search={search}
-            currentPage={filesSearchPage}
+            currentPage={page}
             beforeSelect={() => {
               beforeSelect()
             }}

--- a/apps/renterd/components/Files/useDirectoryDelete.tsx
+++ b/apps/renterd/components/Files/useDirectoryDelete.tsx
@@ -6,13 +6,13 @@ import {
 import { Delete16 } from '@siafoundation/react-icons'
 import { useDialog } from '../../contexts/dialog'
 import { useCallback } from 'react'
-import { useObjectDelete } from '@siafoundation/renterd-react'
+import { useObjectsRemove } from '@siafoundation/renterd-react'
 import { humanBytes } from '@siafoundation/units'
-import { bucketAndKeyParamsFromPath } from '../../lib/paths'
+import { getBucketFromPath, getKeyFromPath } from '../../lib/paths'
 
 export function useDirectoryDelete() {
   const { openConfirmDialog } = useDialog()
-  const deleteObject = useObjectDelete()
+  const deleteObjects = useObjectsRemove()
 
   return useCallback(
     (path: string, size: number) =>
@@ -37,19 +37,24 @@ export function useDirectoryDelete() {
           </div>
         ),
         onConfirm: async () => {
-          const response = await deleteObject.delete({
-            params: { ...bucketAndKeyParamsFromPath(path), batch: true },
+          const bucket = getBucketFromPath(path)
+          const prefix = getKeyFromPath(path)
+          const response = await deleteObjects.post({
+            payload: {
+              bucket,
+              prefix,
+            },
           })
-
           if (response.error) {
             triggerErrorToast({
               title: 'Error deleting directory',
               body: response.error,
             })
+          } else {
+            triggerSuccessToast({ title: 'Deleted directory' })
           }
-          triggerSuccessToast({ title: 'Deleted directory' })
         },
       }),
-    [openConfirmDialog, deleteObject]
+    [openConfirmDialog, deleteObjects]
   )
 }

--- a/apps/renterd/components/Files/useFileDelete.tsx
+++ b/apps/renterd/components/Files/useFileDelete.tsx
@@ -6,12 +6,12 @@ import {
 import { Delete16 } from '@siafoundation/react-icons'
 import { useDialog } from '../../contexts/dialog'
 import { useCallback } from 'react'
-import { useObjectDelete } from '@siafoundation/renterd-react'
-import { bucketAndKeyParamsFromPath } from '../../lib/paths'
+import { useObjectsRemove } from '@siafoundation/renterd-react'
+import { getBucketFromPath, getKeyFromPath } from '../../lib/paths'
 
 export function useFileDelete() {
   const { openConfirmDialog } = useDialog()
-  const deleteObject = useObjectDelete()
+  const deleteObjects = useObjectsRemove()
 
   return useCallback(
     (path: string) =>
@@ -35,8 +35,13 @@ export function useFileDelete() {
           </div>
         ),
         onConfirm: async () => {
-          const response = await deleteObject.delete({
-            params: bucketAndKeyParamsFromPath(path),
+          const bucket = getBucketFromPath(path)
+          const prefix = getKeyFromPath(path)
+          const response = await deleteObjects.post({
+            payload: {
+              bucket,
+              prefix,
+            },
           })
 
           if (response.error) {
@@ -44,10 +49,11 @@ export function useFileDelete() {
               title: 'Error deleting file',
               body: response.error,
             })
+          } else {
+            triggerSuccessToast({ title: 'Deleted file' })
           }
-          triggerSuccessToast({ title: 'Deleted file' })
         },
       }),
-    [openConfirmDialog, deleteObject]
+    [openConfirmDialog, deleteObjects]
   )
 }

--- a/apps/renterd/components/FilesDirectory/EmptyState/StateNoneYetBuckets.tsx
+++ b/apps/renterd/components/FilesDirectory/EmptyState/StateNoneYetBuckets.tsx
@@ -1,0 +1,27 @@
+import { Button, Text } from '@siafoundation/design-system'
+import { Add16, BucketIcon } from '@siafoundation/react-icons'
+import { useDialog } from '../../../contexts/dialog'
+
+export function StateNoneYetBuckets() {
+  const { openDialog } = useDialog()
+  return (
+    <div className="flex flex-col gap-10 justify-center items-center h-[400px] cursor-pointer">
+      <Text>
+        <BucketIcon className="scale-[200%]" />
+      </Text>
+      <div className="flex flex-col gap-3 items-center">
+        <Text color="subtle" className="text-center max-w-[500px]">
+          Create a bucket to get started. Buckets are distinct storage areas
+          that you can use to organize your files.
+        </Text>
+        <Button
+          onClick={() => openDialog('filesCreateBucket')}
+          tip="Create bucket"
+        >
+          <Add16 />
+          Create bucket
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/renterd/components/FilesDirectory/EmptyState/StateNoneYetFiles.tsx
+++ b/apps/renterd/components/FilesDirectory/EmptyState/StateNoneYetFiles.tsx
@@ -3,7 +3,7 @@ import { CloudUpload32 } from '@siafoundation/react-icons'
 import { routes } from '../../../config/routes'
 import { useFilesManager } from '../../../contexts/filesManager'
 
-export function StateNoneYet() {
+export function StateNoneYetFiles() {
   const {
     activeBucketName: activeBucket,
     activeDirectory,

--- a/apps/renterd/components/FilesDirectory/EmptyState/index.tsx
+++ b/apps/renterd/components/FilesDirectory/EmptyState/index.tsx
@@ -6,11 +6,12 @@ import { useAutopilotNotConfigured } from '../../Files/checks/useAutopilotNotCon
 import { useNotEnoughContracts } from '../../Files/checks/useNotEnoughContracts'
 import { StateError } from './StateError'
 import { StateNoneMatching } from './StateNoneMatching'
-import { StateNoneYet } from './StateNoneYet'
+import { StateNoneYetFiles } from './StateNoneYetFiles'
 import { useFilesManager } from '../../../contexts/filesManager'
+import { StateNoneYetBuckets } from './StateNoneYetBuckets'
 
 export function EmptyState() {
-  const { isViewingRootOfABucket } = useFilesManager()
+  const { isViewingRootOfABucket, isViewingBuckets } = useFilesManager()
   const { dataState } = useFilesDirectory()
 
   const autopilotNotConfigured = useAutopilotNotConfigured()
@@ -24,7 +25,7 @@ export function EmptyState() {
     return <StateError />
   }
 
-  // only show on root directory and when there are no files
+  // Only show on root directory and when there are no files.
   if (
     isViewingRootOfABucket &&
     dataState === 'noneYet' &&
@@ -50,7 +51,7 @@ export function EmptyState() {
     )
   }
 
-  // only show on root directory and when there are no files
+  // Only show on root directory and when there are no files.
   if (
     isViewingRootOfABucket &&
     dataState === 'noneYet' &&
@@ -76,7 +77,10 @@ export function EmptyState() {
   }
 
   if (dataState === 'noneYet') {
-    return <StateNoneYet />
+    if (isViewingBuckets) {
+      return <StateNoneYetBuckets />
+    }
+    return <StateNoneYetFiles />
   }
 
   return null

--- a/apps/renterd/components/FilesDirectory/FilesActionsMenu.tsx
+++ b/apps/renterd/components/FilesDirectory/FilesActionsMenu.tsx
@@ -37,7 +37,11 @@ export function FilesActionsMenu() {
         </Button>
       ) : (
         <>
-          <Button onClick={() => openDialog('filesSearch')} tip="Search files">
+          <Button
+            onClick={() => openDialog('filesSearch')}
+            tip="Search files"
+            aria-label="search files"
+          >
             <Search16 />
           </Button>
           <Button

--- a/apps/renterd/components/FilesFlat/FilesActionsMenu.tsx
+++ b/apps/renterd/components/FilesFlat/FilesActionsMenu.tsx
@@ -8,7 +8,11 @@ export function FilesActionsMenu() {
 
   return (
     <div className="flex gap-2">
-      <Button onClick={() => openDialog('filesSearch')} tip="Search files">
+      <Button
+        onClick={() => openDialog('filesSearch')}
+        tip="Search files"
+        aria-label="search files"
+      >
         <Search16 />
       </Button>
       <FilesViewDropdownMenu />

--- a/apps/renterd/contexts/dialog.tsx
+++ b/apps/renterd/contexts/dialog.tsx
@@ -12,7 +12,7 @@ import { HostsFilterAddressDialog } from '../components/Hosts/HostsFilterAddress
 import { ContractsFilterAddressDialog } from '../components/Contracts/ContractsFilterAddressDialog'
 import { ContractsFilterPublicKeyDialog } from '../components/Contracts/ContractsFilterPublicKeyDialog'
 import { ContractsFilterContractSetDialog } from '../components/Contracts/ContractsFilterContractSetDialog'
-import { FilesSearchDialog } from '../dialogs/FilesSearchDialog'
+import { FilesSearchBucketDialog } from '../dialogs/FilesSearchBucketDialog'
 import { useSyncerConnect, useWallet } from '@siafoundation/renterd-react'
 import { RenterdSendSiacoinDialog } from '../dialogs/RenterdSendSiacoinDialog'
 import { RenterdTransactionDetailsDialog } from '../dialogs/RenterdTransactionDetailsDialog'
@@ -176,7 +176,7 @@ export function Dialogs() {
         open={dialog === 'filesCreateDirectory'}
         onOpenChange={onOpenChange}
       />
-      <FilesSearchDialog
+      <FilesSearchBucketDialog
         open={dialog === 'filesSearch'}
         onOpenChange={onOpenChange}
       />

--- a/apps/renterd/contexts/filesDirectory/move.tsx
+++ b/apps/renterd/contexts/filesDirectory/move.tsx
@@ -8,7 +8,7 @@ import {
   DragCancelEvent,
 } from '@dnd-kit/core'
 import { FullPathSegments, getDirectorySegmentsFromPath } from '../../lib/paths'
-import { useObjectRename } from '@siafoundation/renterd-react'
+import { useObjectsRename } from '@siafoundation/renterd-react'
 import { triggerErrorToast } from '@siafoundation/design-system'
 import { getMoveFileRenameParams } from '../../lib/rename'
 
@@ -31,7 +31,7 @@ export function useMove({
 }: Props) {
   const [draggingObject, setDraggingObject] = useState<ObjectData | null>(null)
   const [, setNavTimeout] = useState<NodeJS.Timeout>()
-  const rename = useObjectRename()
+  const rename = useObjectsRename()
 
   const moveFiles = useCallback(
     async (e: DragEndEvent) => {

--- a/apps/renterd/dialogs/FileRenameDialog.tsx
+++ b/apps/renterd/dialogs/FileRenameDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '@siafoundation/design-system'
 import { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
-import { useObjectRename } from '@siafoundation/renterd-react'
+import { useObjectsRename } from '@siafoundation/renterd-react'
 import { getFilename, isDirectory } from '../lib/paths'
 import { getRenameFileRenameParams } from '../lib/rename'
 import { useFilesDirectory } from '../contexts/filesDirectory'
@@ -68,7 +68,7 @@ export function FileRenameDialog({ trigger, open, onOpenChange }: Props) {
   }, [originalPath])
   const defaultValues = useMemo(() => getDefaultValues(name), [name])
 
-  const objectRename = useObjectRename()
+  const objectRename = useObjectsRename()
   const form = useForm({
     mode: 'all',
     defaultValues,

--- a/apps/renterd/dialogs/FilesBucketDeleteDialog.tsx
+++ b/apps/renterd/dialogs/FilesBucketDeleteDialog.tsx
@@ -30,8 +30,6 @@ function getFields(name: string): ConfigFields<Values, never> {
       validation: {
         required: 'required',
         validate: {
-          notDefault: () =>
-            name !== 'default' || 'cannot delete default bucket',
           equals: (value) => value === name || 'bucket name does not match',
         },
       },

--- a/apps/renterd/dialogs/FilesSearchBucketDialog/index.tsx
+++ b/apps/renterd/dialogs/FilesSearchBucketDialog/index.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@siafoundation/design-system'
-import { FilesSearchMenu } from '../../components/Files/FilesSearchMenu'
+import { FilesSearchBucketMenu } from '../../components/Files/FilesSearchBucketMenu'
 
 type Props = {
   open: boolean
@@ -7,7 +7,11 @@ type Props = {
   trigger?: React.ReactNode
 }
 
-export function FilesSearchDialog({ open, onOpenChange, trigger }: Props) {
+export function FilesSearchBucketDialog({
+  open,
+  onOpenChange,
+  trigger,
+}: Props) {
   return (
     <Dialog
       open={open}
@@ -19,7 +23,7 @@ export function FilesSearchDialog({ open, onOpenChange, trigger }: Props) {
       bodyClassName="!px-1 !py-1"
       closeClassName="hidden"
     >
-      <FilesSearchMenu />
+      <FilesSearchBucketMenu />
     </Dialog>
   )
 }

--- a/libs/react-icons/src/BucketIcon.tsx
+++ b/libs/react-icons/src/BucketIcon.tsx
@@ -1,13 +1,15 @@
 type Props = {
   size?: number
+  className?: string
 }
 
-export function BucketIcon({ size = 24 }: Props) {
+export function BucketIcon({ size = 24, className }: Props) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       height={size}
       width={size}
+      className={className}
       fill="currentColor"
       viewBox="0 0 448 512"
     >

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -116,9 +116,9 @@ import {
   ObjectAddParams,
   ObjectAddPayload,
   ObjectAddResponse,
-  ObjectDeleteParams,
-  ObjectDeletePayload,
-  ObjectDeleteResponse,
+  ObjectsRemoveParams,
+  ObjectsRemovePayload,
+  ObjectsRemoveResponse,
   ObjectsParams,
   ObjectsPayload,
   ObjectsResponse,
@@ -259,6 +259,7 @@ import {
   busSettingsPinnedRoute,
   busSettingsS3Route,
   busSettingsUploadRoute,
+  busObjectsRemoveRoute,
 } from '@siafoundation/renterd-types'
 import { buildRequestHandler, initAxios } from '@siafoundation/request'
 
@@ -486,16 +487,16 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       ObjectAddPayload,
       ObjectAddResponse
     >(axios, 'put', busObjectKeyRoute),
-    objectRename: buildRequestHandler<
+    objectsRename: buildRequestHandler<
       ObjectRenameParams,
       ObjectRenamePayload,
       ObjectRenameResponse
     >(axios, 'post', busObjectsRenameRoute),
-    objectDelete: buildRequestHandler<
-      ObjectDeleteParams,
-      ObjectDeletePayload,
-      ObjectDeleteResponse
-    >(axios, 'delete', busObjectKeyRoute),
+    objectsRemove: buildRequestHandler<
+      ObjectsRemoveParams,
+      ObjectsRemovePayload,
+      ObjectsRemoveResponse
+    >(axios, 'post', busObjectsRemoveRoute),
     objectStats: buildRequestHandler<
       ObjectsStatsParams,
       ObjectsStatsPayload,

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -112,9 +112,9 @@ import {
   ObjectAddParams,
   ObjectAddPayload,
   ObjectAddResponse,
-  ObjectDeleteParams,
-  ObjectDeletePayload,
-  ObjectDeleteResponse,
+  ObjectsRemoveParams,
+  ObjectsRemovePayload,
+  ObjectsRemoveResponse,
   ObjectsParams,
   ObjectsResponse,
   ObjectParams,
@@ -247,6 +247,7 @@ import {
   SettingsUploadUpdatePayload,
   SettingsUploadUpdateResponse,
   SettingsPinnedResponse,
+  busObjectsRemoveRoute,
 } from '@siafoundation/renterd-types'
 
 // state
@@ -716,7 +717,7 @@ export function useObjectAdd(
   return usePutFunc({ ...args, route: busObjectKeyRoute })
 }
 
-export function useObjectRename(
+export function useObjectsRename(
   args?: HookArgsCallback<
     ObjectRenameParams,
     ObjectRenamePayload,
@@ -726,15 +727,15 @@ export function useObjectRename(
   return usePostFunc({ ...args, route: busObjectsRenameRoute })
 }
 
-export function useObjectDelete(
+export function useObjectsRemove(
   args?: HookArgsCallback<
-    ObjectDeleteParams,
-    ObjectDeletePayload,
-    ObjectDeleteResponse
+    ObjectsRemoveParams,
+    ObjectsRemovePayload,
+    ObjectsRemoveResponse
   >
 ) {
-  return useDeleteFunc(
-    { ...args, route: busObjectKeyRoute },
+  return usePostFunc(
+    { ...args, route: busObjectsRemoveRoute },
     async (mutate) => {
       mutate((key) => key.startsWith(busObjectsRoute))
     }

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -66,6 +66,7 @@ export const busBucketNamePolicyRoute = '/bus/bucket/:name/policy'
 export const busObjectsRoute = '/bus/objects'
 export const busObjectsPrefixRoute = '/bus/objects/:prefix'
 export const busObjectKeyRoute = '/bus/object/:key'
+export const busObjectsRemoveRoute = '/bus/objects/remove'
 export const busObjectsRenameRoute = '/bus/objects/rename'
 export const busStatsObjectsRoute = '/bus/stats/objects'
 export const busSettingRoute = '/bus/setting'
@@ -400,7 +401,7 @@ export type BucketDeleteResponse = void
 
 export type ObjectsParams = {
   bucket?: string
-  prefix?: string
+  prefix: string
   delimiter?: string
   limit?: number
   marker?: string
@@ -437,13 +438,12 @@ export type ObjectRenamePayload = {
 }
 export type ObjectRenameResponse = void
 
-export type ObjectDeleteParams = {
-  key: string
+export type ObjectsRemoveParams = void
+export type ObjectsRemovePayload = {
   bucket: string
-  batch?: boolean
+  prefix: string
 }
-export type ObjectDeletePayload = void
-export type ObjectDeleteResponse = void
+export type ObjectsRemoveResponse = void
 
 export type ObjectsStatsParams = void
 export type ObjectsStatsPayload = void


### PR DESCRIPTION
> We now no longer assume a default bucket.

- It is now possible to delete a bucket named 'default'.
- The file search feature can now search across all buckets.
- The bucket list now has an empty state.
- The cmdk menu now has an two separate files search options, one for across all buckets and one for the current bucket.
- Updated to the new objects remove API.
- Adjusted the name of the objects rename API.

