### PR TITLE
feat(explorer): use explored for the contracts route

### DIFF
--- a/.changeset/neat-goats-talk.md
+++ b/.changeset/neat-goats-talk.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The contracts route now uses explored except for the rates request.

--- a/apps/explorer/app/contract/[id]/page.tsx
+++ b/apps/explorer/app/contract/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { SiaCentralContract } from '@siafoundation/sia-central-types'
 import { ContractView } from '../../../components/ContractView'
 import { Metadata } from 'next'
 import { routes } from '../../../config/routes'
@@ -8,6 +7,7 @@ import { notFound } from 'next/navigation'
 import { stripPrefix, truncate } from '@siafoundation/design-system'
 import { to } from '@siafoundation/request'
 import { explored } from '../../../config/explored'
+import { ChainIndex, ExplorerFileContract } from '@siafoundation/explored-types'
 
 export function generateMetadata({ params }): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
@@ -24,15 +24,15 @@ export function generateMetadata({ params }): Metadata {
 export const revalidate = 0
 
 export default async function Page({ params }) {
-  const id = params?.id as string
-  const [[c, error], [r]] = await Promise.all([
-    to(
-      siaCentral.contract({
-        params: {
-          id,
-        },
-      })
-    ),
+  const id = params?.id
+
+  // Grab the contract and previous revisions data.
+  const [
+    [rate, rateError],
+    [contract, contractError],
+    [previousRevisions, previousRevisionsError],
+    [currentTip, currentTipError],
+  ] = await Promise.all([
     to(
       siaCentral.exchangeRates({
         params: {
@@ -40,100 +40,99 @@ export default async function Page({ params }) {
         },
       })
     ),
-  ])
-
-  if (error) {
-    throw error
-  }
-
-  const contract = c?.contract
-
-  if (!contract) {
-    return notFound()
-  }
-
-  const formationTxnId = getFormationTxnId(contract)
-  const finalRevisionTxnId = contract?.transaction_id || ''
-
-  const [[ft], [rt]] = await Promise.all([
-    to(
-      siaCentral.transaction({
-        params: {
-          id: formationTxnId,
-        },
-      })
-    ),
-    to(
-      siaCentral.transaction({
-        params: {
-          id: finalRevisionTxnId,
-        },
-      })
-    ),
-  ])
-
-  const formationTransaction = ft?.transaction
-  const renewedFrom = formationTransaction?.contract_revisions?.[0]
-  const renewalTransaction = rt?.transaction
-  const renewedTo = renewalTransaction?.storage_contracts?.[0]
-
-  // The following is a temporary addition to satisfy new Transaction
-  // component requirements for the Sia Central phase out on the
-  // transaction route.
-  const [
-    [transaction, transactionError],
-    [transactionChainIndices, transactionChainIndicesError],
-    [currentTip, currentTipError],
-  ] = await Promise.all([
-    to(
-      explored.transactionByID({
-        params: { id: formationTransaction?.id || '' },
-      })
-    ),
-    to(
-      explored.transactionChainIndices({
-        params: { id: formationTransaction?.id || '' },
-      })
-    ),
+    to(explored.contractByID({ params: { id } })),
+    to<ExplorerFileContract[]>(explored.contractRevisions({ params: { id } })),
     to(explored.consensusTip()),
   ])
 
-  if (transactionError) throw transactionError
-  if (transactionChainIndicesError) throw transactionChainIndicesError
+  if (rateError) throw rateError
+
+  if (contractError) throw contractError
+  if (!contract) return notFound()
+
+  if (previousRevisionsError) throw previousRevisionsError
+  if (!previousRevisions)
+    throw new Error('No previousRevisions found in successful request')
+
   if (currentTipError) throw currentTipError
-  if (!transaction || !transactionChainIndices || !currentTip) return notFound()
+  if (!currentTip) throw new Error('No currentTip found in successful request')
+
+  const formationTxnID =
+    previousRevisions[0].transactionID ?? contract.transactionID
+  const finalRevisionTxnID =
+    previousRevisions[previousRevisions.length - 1].transactionID ??
+    contract.transactionID
+
+  // Fetch our formation and finalRevision transaction information.
+  const [
+    [formationTransaction, formationTransactionError],
+    [renewalTransaction, renewalTransactionError],
+  ] = await Promise.all([
+    to(
+      explored.transactionByID({
+        params: {
+          id: formationTxnID,
+        },
+      })
+    ),
+    to(
+      explored.transactionByID({
+        params: {
+          id: finalRevisionTxnID,
+        },
+      })
+    ),
+  ])
+
+  if (formationTransactionError) throw formationTransactionError
+  if (!formationTransaction)
+    throw new Error('No formation transaction found in successful request')
+
+  if (renewalTransactionError) throw renewalTransactionError
+  if (!renewalTransaction)
+    throw new Error('No renewal transaction found in successful request')
+
+  const renewedFromID =
+    formationTransaction.fileContractRevisions?.[0].id ?? null
+  const renewedToID = renewalTransaction.fileContracts?.[0].id ?? null
+
+  const [formationTxnChainIndices, formationTxnChainIndicesError] = await to<
+    ChainIndex[]
+  >(
+    explored.transactionChainIndices({
+      params: { id: formationTransaction.id },
+    })
+  )
+
+  if (formationTxnChainIndicesError) throw formationTxnChainIndicesError
+  if (!formationTxnChainIndices)
+    throw new Error('No formationTxnChainIndices found in successful request')
 
   // Use the first chainIndex from the above call to get our parent block.
   const [parentBlock, parentBlockError] = await to(
-    explored.blockByID({ params: { id: transactionChainIndices[0].id } })
+    explored.blockByID({ params: { id: formationTxnChainIndices[0].id } })
   )
 
   if (parentBlockError) throw parentBlockError
-  if (!parentBlock) return notFound()
+  if (!parentBlock)
+    throw new Error('No parentBlock found in successful request')
 
   return (
     <ContractView
+      previousRevisions={previousRevisions}
+      currentHeight={currentTip.height}
       contract={contract}
-      rates={r?.rates}
-      renewedFrom={renewedFrom}
-      renewedTo={renewedTo}
-      formationTransaction={transaction}
+      rates={rate?.rates}
+      renewedFromID={renewedFromID ? stripPrefix(renewedFromID) : renewedFromID}
+      renewedToID={renewedToID ? stripPrefix(renewedToID) : renewedToID}
+      formationTransaction={formationTransaction}
+      formationTxnChainIndex={formationTxnChainIndices}
       formationTransactionHeaderData={{
-        id: stripPrefix(transaction.id),
-        blockHeight: transactionChainIndices[0].height,
-        confirmations: currentTip.height - transactionChainIndices[0].height,
+        id: stripPrefix(formationTransaction.id),
+        blockHeight: formationTxnChainIndices[0].height,
+        confirmations: currentTip.height - formationTxnChainIndices[0].height,
         timestamp: parentBlock.timestamp,
       }}
     />
   )
-}
-
-function getFormationTxnId(contract: SiaCentralContract) {
-  let id = contract?.transaction_id
-  if (contract?.previous_revisions?.length) {
-    id =
-      contract.previous_revisions[contract.previous_revisions?.length - 1]
-        .transaction_id
-  }
-  return id
 }

--- a/apps/explorer/components/ContractView/index.tsx
+++ b/apps/explorer/components/ContractView/index.tsx
@@ -1,37 +1,48 @@
 import { Container, Separator } from '@siafoundation/design-system'
 import { Transaction } from '../Transaction'
-import {
-  SiaCentralContract,
-  SiaCentralExchangeRates,
-} from '@siafoundation/sia-central-types'
+import { SiaCentralExchangeRates } from '@siafoundation/sia-central-types'
 import { Contract } from '../Contract'
-import { ExplorerTransaction } from '@siafoundation/explored-types'
+import {
+  ChainIndex,
+  ExplorerFileContract,
+  ExplorerTransaction,
+  FileContractID,
+} from '@siafoundation/explored-types'
 import { TransactionHeaderData } from '../Transaction/TransactionHeader'
 
 type Props = {
-  contract: SiaCentralContract
+  previousRevisions: ExplorerFileContract[] | undefined
+  currentHeight: number
+  contract: ExplorerFileContract
   rates?: SiaCentralExchangeRates
-  renewedTo?: SiaCentralContract
-  renewedFrom?: SiaCentralContract
+  renewedToID: FileContractID | null
+  renewedFromID: FileContractID | null
   formationTransaction?: ExplorerTransaction
+  formationTxnChainIndex: ChainIndex[]
   formationTransactionHeaderData?: TransactionHeaderData
 }
 
 export function ContractView({
+  previousRevisions,
+  currentHeight,
   contract,
   rates,
-  renewedFrom,
-  renewedTo,
+  renewedFromID,
+  renewedToID,
   formationTransaction,
+  formationTxnChainIndex,
   formationTransactionHeaderData,
 }: Props) {
   return (
     <>
       <Contract
+        previousRevisions={previousRevisions}
+        currentHeight={currentHeight}
         contract={contract}
         rates={rates}
-        renewedFrom={renewedFrom}
-        renewedTo={renewedTo}
+        renewedFromID={renewedFromID}
+        renewedToID={renewedToID}
+        formationTxnChainIndex={formationTxnChainIndex}
       />
       <Container>
         <Separator className="w-full my-3" color="verySubtle" />

--- a/apps/explorer/lib/contracts.ts
+++ b/apps/explorer/lib/contracts.ts
@@ -1,0 +1,25 @@
+import { ExplorerFileContract } from '@siafoundation/explored-types'
+
+export const CONTRACT_STATUS = {
+  IN_PROGRESS: 'in progress',
+  OBLIGATION_SUCCESSFUL: 'obligation succeeded',
+  OBLIGATION_FAILURE: 'obligation failure',
+} as const
+
+type ObjectValues<T> = T[keyof T]
+
+type ContractStatus = ObjectValues<typeof CONTRACT_STATUS>
+
+export function determineContractStatus({
+  resolved,
+  valid,
+  validProofOutputs,
+  missedProofOutputs,
+}: ExplorerFileContract): ContractStatus {
+  if (!resolved) return 'in progress'
+
+  const successful =
+    valid || validProofOutputs?.[1].value === missedProofOutputs?.[1].value
+
+  return successful ? 'obligation succeeded' : 'obligation failure'
+}

--- a/apps/explorer/lib/time.ts
+++ b/apps/explorer/lib/time.ts
@@ -1,0 +1,11 @@
+import { blockHeightToTime, humanDate } from '@siafoundation/units'
+
+export function blockHeightToHumanDate(
+  currentHeight: number,
+  timeInMS: number
+) {
+  return humanDate(blockHeightToTime(currentHeight, timeInMS), {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}


### PR DESCRIPTION
## Questions/Points of Concern (Updated 10/23)

* The exact timestamp for negotiation, expiration, proof deadline, and payout are a bit off from Sia Central, but I believe that's expected. We're doing this on the client side now with respective block heights. The difference is not significant but I don't know how exact these are expected to be. `blockHeightToHumanDate` in `lib/contracts` would be the relevant pipe they are all flowing through.

* Payout is also a little different, too. I've never seen more that a few cents, but wanted to call that out, too. As far as I know, that's a difference on the explored side.

* Do the resolved from/to buttons work as we would expect? I believe so but it's hard to find good test contracts that have both. I've only see one or the other. It shouldn't matter, but I like to visually/manually test as much as I can and couldn't find multiple contract renewals.

* Does the status make sense (in progress, obligation successful, obligation failed)? This is another one where I'd ideally find one of every kind but that's a little more detailed understanding than I may have right now.

* The network calls at the top of the Contract next page, their order, and their error handling.I may not have them all ordered the most optimal way and then: are we only returning `notFound()` on an absent contract record? There may be a better way to do all of this, but we have multiple chained calls that rely on previous.

Comparing to a contract page through Sia Central, we're very close, I think. ~~I've left two review comments open down below with two other things to discuss.~~

