### PR TITLE
chore: resolve various warnings

### DIFF
--- a/.changeset/eight-kids-cheer.md
+++ b/.changeset/eight-kids-cheer.md
@@ -1,0 +1,5 @@
+---
+'website': patch
+---
+
+Added a max height and radius for hosts on the host map.

--- a/.changeset/five-bobcats-grin.md
+++ b/.changeset/five-bobcats-grin.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+The Dialog now supports providing a title or description that is visually hidden but still announced by assistive technology.

--- a/.changeset/late-drinks-protect.md
+++ b/.changeset/late-drinks-protect.md
@@ -1,0 +1,5 @@
+---
+'website': patch
+---
+
+Fixed hydration mismatch warnings related to the random selection of a host on the globe.

--- a/.changeset/late-readers-play.md
+++ b/.changeset/late-readers-play.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue with the uploads list loading and empty states.

--- a/.changeset/mean-zebras-impress.md
+++ b/.changeset/mean-zebras-impress.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fixed a warning caused by animation props being passed to non-animated graphs.

--- a/.changeset/perfect-nails-tell.md
+++ b/.changeset/perfect-nails-tell.md
@@ -1,0 +1,5 @@
+---
+'website': patch
+---
+
+Fixed a hydration mismatch warning related to the ThemeRadio in footer.

--- a/.changeset/quick-horses-love.md
+++ b/.changeset/quick-horses-love.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Adjusted tooltip to only wrap content with Paragraph if prop is a string or React.Fragment.

--- a/.changeset/red-kangaroos-nail.md
+++ b/.changeset/red-kangaroos-nail.md
@@ -1,0 +1,5 @@
+---
+'walletd': patch
+---
+
+Fixed an issue where the app would try to fetch from an invalid URL when first initializing.

--- a/.changeset/six-cougars-sell.md
+++ b/.changeset/six-cougars-sell.md
@@ -1,0 +1,6 @@
+---
+'hostd': patch
+'renterd': patch
+---
+
+Added explicit aria descriptions to some primary dialogs.

--- a/.changeset/stale-windows-walk.md
+++ b/.changeset/stale-windows-walk.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fixed a 1 pixel gap that would show between the top of the Table and its sticky header when scrolling.

--- a/.changeset/sweet-timers-fry.md
+++ b/.changeset/sweet-timers-fry.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fixed warnings caused by the Dialog description prop and aria-describedby.

--- a/apps/hostd/contexts/volumes/columns.tsx
+++ b/apps/hostd/contexts/volumes/columns.tsx
@@ -53,7 +53,7 @@ export const columns: VolumesTableColumn[] = [
             'available'
           ) : (
             <>
-              <Text>unavailable</Text>
+              <Text size="12">unavailable</Text>
               <div className="flex flex-col">
                 {data.errors?.map((reason) => (
                   <Text key={reason} size="10" noWrap>

--- a/apps/hostd/dialogs/VolumeCreateDialog.tsx
+++ b/apps/hostd/dialogs/VolumeCreateDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Paragraph,
   Dialog,
   GBToSectors,
   triggerErrorToast,
@@ -211,6 +210,7 @@ export function VolumeCreateDialog({ trigger, open, onOpenChange }: Props) {
   return (
     <Dialog
       title="Create Volume"
+      description="Create a new volume. Select a system directory and specific the size of the volume."
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {
@@ -230,10 +230,6 @@ export function VolumeCreateDialog({ trigger, open, onOpenChange }: Props) {
       }
     >
       <div className="flex flex-col gap-4">
-        <Paragraph size="14">
-          Create a new volume. Select a system directory and specific the size
-          of the volume.
-        </Paragraph>
         <FieldText name="name" form={form} fields={fields} />
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-1">

--- a/apps/renterd/components/Contracts/index.tsx
+++ b/apps/renterd/components/Contracts/index.tsx
@@ -74,7 +74,7 @@ export function Contracts() {
             height: listHeight,
           }}
         >
-          <ScrollArea className="z-0" id="scroll-hosts">
+          <ScrollArea className="z-0">
             <div
               className={cx(showDetailView ? 'pb-6 px-6' : 'p-6', 'min-w-fit')}
             >

--- a/apps/renterd/components/Files/FilesStatsMenuShared/FilesStatsMenuSize.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenuShared/FilesStatsMenuSize.tsx
@@ -36,8 +36,8 @@ export function FilesStatsMenuSize() {
     <Tooltip
       side="bottom"
       content={
-        <Text className="flex justify-between gap-6">
-          <Text className="flex flex-col gap-1">
+        <div className="flex justify-between gap-6">
+          <div className="flex flex-col gap-1">
             <Text size="12" color="subtle">
               size of all files
             </Text>
@@ -53,8 +53,8 @@ export function FilesStatsMenuSize() {
             <Text size="12" color="subtle">
               total storage utilization
             </Text>
-          </Text>
-          <Text className="flex flex-col gap-1 items-end">
+          </div>
+          <div className="flex flex-col gap-1 items-end">
             <Text size="12">{humanBytes(stats.data.totalObjectsSize)}</Text>
             <Text size="12">{humanBytes(stats.data.totalSectorsSize)}</Text>
             {!!averageRedundancyFactor && (
@@ -64,8 +64,8 @@ export function FilesStatsMenuSize() {
             )}
             <Separator className="w-full my-1" />
             <Text size="12">{humanBytes(stats.data.totalUploadedSize)}</Text>
-          </Text>
-        </Text>
+          </div>
+        </div>
       }
     >
       <Text size="12" font="mono">

--- a/apps/renterd/components/Hosts/HostMap/HostItem.tsx
+++ b/apps/renterd/components/Hosts/HostMap/HostItem.tsx
@@ -90,26 +90,42 @@ export function HostItem({
     <Tooltip
       content={
         <div className="flex flex-col gap-1">
-          <Text color="contrast" weight="bold">
+          <Text size="12" color="contrast" weight="bold">
             {countryCodeEmoji(host.country_code)} {host.country_code}
           </Text>
           <div className="flex gap-2">
             <div className="flex flex-col gap-1">
-              <Text color="subtle">storage</Text>
-              <Text color="subtle">download</Text>
-              <Text color="subtle">upload</Text>
+              <Text size="12" color="subtle">
+                storage
+              </Text>
+              <Text size="12" color="subtle">
+                download
+              </Text>
+              <Text size="12" color="subtle">
+                upload
+              </Text>
             </div>
             <div className="flex flex-col gap-1">
-              <Text color="contrast">
+              <Text size="12" color="contrast">
                 {humanBytes(host.settings?.total_storage || 0)}
               </Text>
-              <Text color="contrast">{getDownloadSpeed(host)}</Text>
-              <Text color="contrast">{getUploadSpeed(host)}</Text>
+              <Text size="12" color="contrast">
+                {getDownloadSpeed(host)}
+              </Text>
+              <Text size="12" color="contrast">
+                {getUploadSpeed(host)}
+              </Text>
             </div>
             <div className="flex flex-col gap-1">
-              <Text color="contrast">{storageCost}</Text>
-              <Text color="contrast">{downloadCost}</Text>
-              <Text color="contrast">{uploadCost}</Text>
+              <Text size="12" color="contrast">
+                {storageCost}
+              </Text>
+              <Text size="12" color="contrast">
+                {downloadCost}
+              </Text>
+              <Text size="12" color="contrast">
+                {uploadCost}
+              </Text>
             </div>
           </div>
         </div>

--- a/apps/renterd/components/Keys/KeysCreateDialog.tsx
+++ b/apps/renterd/components/Keys/KeysCreateDialog.tsx
@@ -6,7 +6,6 @@ import {
   FormSubmitButton,
   ConfigFields,
   useOnInvalid,
-  Paragraph,
   Button,
 } from '@siafoundation/design-system'
 import { useCallback, useMemo } from 'react'
@@ -159,6 +158,7 @@ export function KeysCreateDialog({ trigger, open, onOpenChange }: Props) {
   return (
     <Dialog
       title="Create S3 key"
+      description="Create a new S3 authentication key."
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {
@@ -178,7 +178,6 @@ export function KeysCreateDialog({ trigger, open, onOpenChange }: Props) {
       }
     >
       <div className="flex flex-col gap-4">
-        <Paragraph>Create a new S3 authentication key.</Paragraph>
         <div className="flex flex-col gap-2">
           <FieldText name="name" form={form} fields={fields} />
           <FieldText name="secret" form={form} fields={fields} />

--- a/apps/renterd/contexts/contracts/columns.tsx
+++ b/apps/renterd/contexts/contracts/columns.tsx
@@ -192,37 +192,37 @@ export const columns: ContractsTableColumn[] = [
           content={
             <div className="flex flex-col gap-1.5">
               <div className="flex">
-                <Text className="flex-1" weight="medium">
+                <Text size="12" className="flex-1" weight="medium">
                   pending
                 </Text>
-                <Text className="flex-[2]" color="subtle">
+                <Text size="12" className="flex-[2]" color="subtle">
                   Contract has been added.
                 </Text>
               </div>
               <Separator className="w-full" />
               <div className="flex">
-                <Text className="flex-1" weight="medium">
+                <Text size="12" className="flex-1" weight="medium">
                   active
                 </Text>
-                <Text className="flex-[2]" color="subtle">
+                <Text size="12" className="flex-[2]" color="subtle">
                   Contract has appeared on chain.
                 </Text>
               </div>
               <Separator className="w-full" />
               <div className="flex">
-                <Text className="flex-1" weight="medium">
+                <Text size="12" className="flex-1" weight="medium">
                   complete
                 </Text>
-                <Text className="flex-[2]" color="subtle">
+                <Text size="12" className="flex-[2]" color="subtle">
                   Storage proof has appeared on chain.
                 </Text>
               </div>
               <Separator className="w-full" />
               <div className="flex">
-                <Text className="flex-1" weight="medium">
+                <Text size="12" className="flex-1" weight="medium">
                   failed
                 </Text>
-                <Text className="flex-[2]" color="subtle">
+                <Text size="12" className="flex-[2]" color="subtle">
                   Storage proof was not submitted before the end of proof
                   window.
                 </Text>

--- a/apps/renterd/contexts/uploads/index.tsx
+++ b/apps/renterd/contexts/uploads/index.tsx
@@ -40,6 +40,11 @@ function useUploadsMain() {
   const response = useMultipartUploadListUploads({
     disabled: !activeBucket,
     payload: payload as MultipartUploadListUploadsPayload,
+    config: {
+      swr: {
+        keepPreviousData: true,
+      },
+    },
   })
 
   const abortAll = useCallback(async () => {
@@ -64,9 +69,9 @@ function useUploadsMain() {
     )
   }, [response.data, apiBusUploadAbort, activeBucket, uploadsMap])
 
-  const dataset: ObjectUploadData[] | undefined = useMemo(() => {
+  const dataset: ObjectUploadData[] = useMemo(() => {
     if (!response.data?.uploads || !activeBucket?.name) {
-      return undefined
+      return []
     }
     return response.data.uploads.map((upload) => {
       const id = upload.uploadID

--- a/apps/renterd/dialogs/FilesBucketCreateDialog.tsx
+++ b/apps/renterd/dialogs/FilesBucketCreateDialog.tsx
@@ -1,5 +1,4 @@
 import {
-  Paragraph,
   Dialog,
   triggerErrorToast,
   triggerSuccessToast,
@@ -77,6 +76,7 @@ export function FilesBucketCreateDialog({
   return (
     <Dialog
       title="Create Bucket"
+      description="A bucket is an isolated collection of files."
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {
@@ -91,9 +91,6 @@ export function FilesBucketCreateDialog({
       onSubmit={form.handleSubmit(onSubmit, onInvalid)}
     >
       <div className="flex flex-col gap-4">
-        <Paragraph size="14">
-          A bucket is an isolated collection of files.
-        </Paragraph>
         <FieldText name="name" form={form} fields={fields} autoComplete="off" />
         <FormSubmitButton form={form}>Create bucket</FormSubmitButton>
       </div>

--- a/apps/walletd/components/Wallet/WalletActionsMenu.tsx
+++ b/apps/walletd/components/Wallet/WalletActionsMenu.tsx
@@ -22,6 +22,7 @@ export function WalletActionsMenu() {
   const { openDialog } = useDialog()
   const walletId = router.query.id as string
   const balance = useWalletBalance({
+    disabled: !walletId,
     params: {
       id: walletId,
     },

--- a/apps/website/components/HostMap/Globe.tsx
+++ b/apps/website/components/HostMap/Globe.tsx
@@ -17,7 +17,7 @@ import { useTheme } from 'next-themes'
 import { useElementSize } from 'usehooks-ts'
 
 type Props = {
-  activeHost: SiaCentralPartialHost
+  activeHost?: SiaCentralPartialHost
   selectActiveHost: (public_key: string) => void
   hosts: SiaCentralPartialHost[]
   rates: {
@@ -56,7 +56,9 @@ function GlobeComponent({ activeHost, hosts, rates, selectActiveHost }: Props) {
   }, [])
 
   const moveToActiveHost = useCallback(() => {
-    moveToHost(activeHost)
+    if (activeHost) {
+      moveToHost(activeHost)
+    }
   }, [moveToHost, activeHost])
 
   useEffect(() => {
@@ -110,6 +112,9 @@ function GlobeComponent({ activeHost, hosts, rates, selectActiveHost }: Props) {
   }, [hosts])
 
   const activeRoutes = useMemo(() => {
+    if (!activeHost) {
+      return []
+    }
     let routes: Route[] = []
     for (let i = 0; i < hosts.length; i++) {
       const host = hosts[i]
@@ -212,8 +217,11 @@ function distanceBetweenHosts(
 
 function doesIncludeActiveHost(
   route: Route,
-  activeHost: SiaCentralPartialHost
+  activeHost?: SiaCentralPartialHost
 ) {
+  if (!activeHost) {
+    return false
+  }
   return (
     route.dst.public_key === activeHost.public_key ||
     route.src.public_key === activeHost.public_key

--- a/apps/website/components/HostMap/HostItem.tsx
+++ b/apps/website/components/HostMap/HostItem.tsx
@@ -22,7 +22,7 @@ import {
 
 type Props = {
   host: SiaCentralPartialHost
-  activeHost: SiaCentralPartialHost
+  activeHost?: SiaCentralPartialHost
   setRef?: (el: HTMLButtonElement) => void
   selectActiveHost: (public_key: string) => void
   rates: {
@@ -90,7 +90,12 @@ export function HostItem({
       content={
         <div className="flex flex-col gap-1">
           <div className="w-full flex justify-between items-center">
-            <Text color="contrast" weight="bold" className="text-start">
+            <Text
+              size="12"
+              color="contrast"
+              weight="bold"
+              className="text-start"
+            >
               {countryCodeEmoji(host.country_code)} {host.country_code}
             </Text>
             <LinkButton
@@ -105,21 +110,37 @@ export function HostItem({
           </div>
           <div className="flex gap-2">
             <div className="flex flex-col gap-1">
-              <Text color="subtle">storage</Text>
-              <Text color="subtle">download</Text>
-              <Text color="subtle">upload</Text>
+              <Text size="12" color="subtle">
+                storage
+              </Text>
+              <Text size="12" color="subtle">
+                download
+              </Text>
+              <Text size="12" color="subtle">
+                upload
+              </Text>
             </div>
             <div className="flex flex-col gap-1">
-              <Text color="contrast">
+              <Text size="12" color="contrast">
                 {humanBytes(host.settings.total_storage)}
               </Text>
-              <Text color="contrast">{getDownloadSpeed(host)}</Text>
-              <Text color="contrast">{getUploadSpeed(host)}</Text>
+              <Text size="12" color="contrast">
+                {getDownloadSpeed(host)}
+              </Text>
+              <Text size="12" color="contrast">
+                {getUploadSpeed(host)}
+              </Text>
             </div>
             <div className="flex flex-col gap-1">
-              <Text color="contrast">{storageCost}</Text>
-              <Text color="contrast">{downloadCost}</Text>
-              <Text color="contrast">{uploadCost}</Text>
+              <Text size="12" color="contrast">
+                {storageCost}
+              </Text>
+              <Text size="12" color="contrast">
+                {downloadCost}
+              </Text>
+              <Text size="12" color="contrast">
+                {uploadCost}
+              </Text>
             </div>
           </div>
         </div>

--- a/apps/website/components/HostMap/index.tsx
+++ b/apps/website/components/HostMap/index.tsx
@@ -32,9 +32,14 @@ export function HostMap({ className, hosts, rates }: Props) {
   const scrollRef = useRef<HTMLDivElement>()
   const refs = useRef([]) // to store refs for all items
 
-  const [activeIndex, setActiveIndex] = useState<number>(
-    random(0, hosts.length - 1)
-  )
+  const [activeIndex, setActiveIndex] = useState<number>()
+
+  // Once page loads set a random active index. This avoids hydration issues.
+  useEffect(() => {
+    setActiveIndex(random(0, hosts.length - 1))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const activeHost = useMemo(() => hosts[activeIndex], [hosts, activeIndex])
   const [reset, setReset] = useState<string>()
   const selectActiveHostByIndex = useCallback(

--- a/apps/website/components/Layout/Footer.tsx
+++ b/apps/website/components/Layout/Footer.tsx
@@ -1,4 +1,5 @@
 import {
+  ClientSideOnly,
   Link,
   Logo,
   SiteMap,
@@ -64,7 +65,11 @@ export function Footer() {
               {webLinks.email}
             </Link>
             <div className="flex-1" />
-            <ThemeRadio className="hidden md:flex" />
+            <ClientSideOnly
+              fallback={<div className="w-[80px] h-[16px]"></div>}
+            >
+              <ThemeRadio className="hidden md:flex" />
+            </ClientSideOnly>
           </div>
         </div>
       </SectionSolid>

--- a/apps/website/components/Map/Globe.tsx
+++ b/apps/website/components/Map/Globe.tsx
@@ -149,7 +149,9 @@ export function Globe({
         pointAltitude={(h: SiaCentralPartialHost) => {
           let radius = 0
           radius = h.settings.total_storage / 1e15
-          return Math.max(radius, 0.005)
+          const minSize = 0.005
+          const maxSize = 0.1
+          return Math.min(Math.max(radius, minSize), maxSize)
         }}
         pointsTransitionDuration={0}
         pointColor={(h: SiaCentralPartialHost) =>
@@ -160,7 +162,9 @@ export function Globe({
         pointRadius={(h: SiaCentralPartialHost) => {
           let radius = 0
           radius = h.settings.total_storage / 1e13 / 3
-          return Math.max(radius, 0.2)
+          const minSize = 0.2
+          const maxSize = 2
+          return Math.min(Math.max(radius, minSize), maxSize)
         }}
         onPointHover={(h: SiaCentralPartialHost) => {
           if (!h) {

--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -12,6 +12,7 @@
     "@siafoundation/units": "^3.2.0",
     "@siafoundation/types": "^0.6.0",
     "@siafoundation/next": "^0.1.3",
+    "@radix-ui/react-visually-hidden": "^1.1.0",
     "swr": "^2.1.1",
     "class-variance-authority": "^0.7.0",
     "bignumber.js": "^9.0.2",

--- a/libs/design-system/src/app/SyncerConnectPeerDialog.tsx
+++ b/libs/design-system/src/app/SyncerConnectPeerDialog.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Paragraph } from '../core/Paragraph'
 import { triggerErrorToast, triggerSuccessToast } from '../lib/toast'
 import { Response } from '@siafoundation/react-core'
 import { Dialog } from '../core/Dialog'
@@ -80,6 +79,7 @@ export function SyncerConnectPeerDialog({
     <Dialog
       trigger={trigger}
       title="Connect peer"
+      description="Connect to a peer by IP address."
       open={open}
       onOpenChange={handleOpenChange}
       contentVariants={{
@@ -95,7 +95,6 @@ export function SyncerConnectPeerDialog({
       }
     >
       <div className="flex flex-col gap-4">
-        <Paragraph size="14">Connect to a peer by IP address.</Paragraph>
         <FieldText form={form} fields={fields} name="address" size="medium" />
       </div>
     </Dialog>

--- a/libs/design-system/src/app/WalletBalanceTip.tsx
+++ b/libs/design-system/src/app/WalletBalanceTip.tsx
@@ -29,8 +29,10 @@ export function WalletBalanceTip({
         <div className="flex flex-col justify-center gap-2">
           <div className="flex gap-4">
             <div className="flex flex-col flex-1">
-              <Text>spendable</Text>
-              <Text color="subtle">All confirmed outputs not in-use.</Text>
+              <Text size="12">spendable</Text>
+              <Text size="12" color="subtle">
+                All confirmed outputs not in-use.
+              </Text>
             </div>
             <div className="flex justify-end">
               <ValueScFiat
@@ -45,8 +47,8 @@ export function WalletBalanceTip({
               <Separator className="w-full" />
               <div className="flex gap-4">
                 <div className="flex flex-col flex-1">
-                  <Text>immature</Text>
-                  <Text color="subtle">
+                  <Text size="12">immature</Text>
+                  <Text size="12" color="subtle">
                     All confirmed but still locked outputs.
                   </Text>
                 </div>
@@ -63,8 +65,10 @@ export function WalletBalanceTip({
           <Separator className="w-full" />
           <div className="flex gap-4">
             <div className="flex flex-col flex-1">
-              <Text>confirmed</Text>
-              <Text color="subtle">All confirmed outputs.</Text>
+              <Text size="12">confirmed</Text>
+              <Text size="12" color="subtle">
+                All confirmed outputs.
+              </Text>
             </div>
             <div className="flex justify-end">
               <ValueScFiat
@@ -77,8 +81,10 @@ export function WalletBalanceTip({
           <Separator className="w-full" />
           <div className="flex gap-4">
             <div className="flex flex-col flex-1">
-              <Text>unconfirmed</Text>
-              <Text color="subtle">All unconfirmed outputs not in-use.</Text>
+              <Text size="12">unconfirmed</Text>
+              <Text size="12" color="subtle">
+                All unconfirmed outputs not in-use.
+              </Text>
             </div>
             <div className="flex justify-end">
               <ValueScFiat

--- a/libs/design-system/src/components/ChartXY/ChartXYGraph.tsx
+++ b/libs/design-system/src/components/ChartXY/ChartXYGraph.tsx
@@ -10,12 +10,14 @@ import { cx } from 'class-variance-authority'
 import { groupBy } from '@technically/lodash'
 import { ChartConfig, ChartPoint } from './types'
 import { humanDate } from '@siafoundation/units'
+import { AnimationTrajectory } from '@visx/react-spring'
 
 export function ChartXYGraph<Key extends string, Cat extends string>({
   id,
   width,
   height,
   accessors,
+  useAnimatedComponents,
   animationTrajectory,
   curve,
   data,
@@ -104,11 +106,15 @@ export function ChartXYGraph<Key extends string, Cat extends string>({
         )
       })}
       <Grid
-        key={`grid-${animationTrajectory}`} // force animate on update
+        // Force animate on update.
+        {...getAnimationProps({
+          key: 'grid',
+          useAnimatedComponents,
+          animationTrajectory,
+        })}
         rows={false}
         columns={true}
         strokeDasharray="1,3"
-        animationTrajectory={animationTrajectory}
         numTicks={numTicks}
       />
       {renderBarStack && (
@@ -190,10 +196,14 @@ export function ChartXYGraph<Key extends string, Cat extends string>({
         </>
       )}
       <Axis
-        key={`time-axis-${animationTrajectory}`}
+        // Force animate on update.
+        {...getAnimationProps({
+          key: 'time-axis',
+          useAnimatedComponents,
+          animationTrajectory,
+        })}
         orientation={xAxisOrientation}
         numTicks={numTicks}
-        animationTrajectory={animationTrajectory}
         tickFormat={(d) => humanDate(d)}
         tickLength={12}
         tickLabelProps={(p) => ({
@@ -206,7 +216,12 @@ export function ChartXYGraph<Key extends string, Cat extends string>({
         })}
       />
       <Axis
-        key={`temp-axis-${animationTrajectory}`}
+        // Force animate on update.
+        {...getAnimationProps({
+          key: 'temp-axis',
+          useAnimatedComponents,
+          animationTrajectory,
+        })}
         label={
           stackOffset == null
             ? 'SC'
@@ -218,7 +233,6 @@ export function ChartXYGraph<Key extends string, Cat extends string>({
         numTicks={numTicks}
         tickLength={12}
         // rangePadding={0}
-        animationTrajectory={animationTrajectory}
         // values don't make sense in stream graph
         // tickFormat={stackOffset === 'wiggle' ? () => '' : undefined}
         tickFormat={config.formatTickY}
@@ -401,4 +415,23 @@ export function getColor<Key extends string, Cat extends string>(
   return config.data[key].pattern
     ? `url(#pattern-${idKey})`
     : `url(#gradient-${idKey})`
+}
+
+function getAnimationProps({
+  key,
+  useAnimatedComponents,
+  animationTrajectory,
+}: {
+  key: string
+  useAnimatedComponents: boolean
+  animationTrajectory?: AnimationTrajectory
+}) {
+  return useAnimatedComponents && animationTrajectory
+    ? {
+        key: `${key}-${animationTrajectory}`,
+        animationTrajectory,
+      }
+    : {
+        key,
+      }
 }

--- a/libs/design-system/src/components/ChartXY/useChartXY.tsx
+++ b/libs/design-system/src/components/ChartXY/useChartXY.tsx
@@ -250,6 +250,7 @@ export function useChartXY<Key extends string, Cat extends string>(
   return {
     id,
     accessors,
+    useAnimatedComponents,
     animationTrajectory,
     config,
     scales,

--- a/libs/design-system/src/components/Table/index.tsx
+++ b/libs/design-system/src/components/Table/index.tsx
@@ -201,7 +201,7 @@ export function Table<
         >
           <thead
             className={cx(
-              'sticky top-0 z-20 bg-white dark:bg-graydark-100',
+              'sticky -top-px z-20 bg-white dark:bg-graydark-100',
               'shadow-border-b shadow-gray-400 dark:shadow-graydark-300'
             )}
           >

--- a/libs/design-system/src/core/Dialog.tsx
+++ b/libs/design-system/src/core/Dialog.tsx
@@ -5,6 +5,7 @@ import { cva, cx } from 'class-variance-authority'
 import { panelStyles } from './Panel'
 import { useOpen } from '../hooks/useOpen'
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { Close24 } from '@siafoundation/react-icons'
 import { Button } from './Button'
@@ -54,7 +55,9 @@ export const Dialog = React.forwardRef<
       onOpenChange: _onOpenChange,
       onSubmit,
       title,
+      titleVisuallyHidden,
       description,
+      descriptionVisuallyHidden,
       containerVariants,
       contentVariants,
       controls,
@@ -90,7 +93,16 @@ export const Dialog = React.forwardRef<
         <AnimatePresence>
           {open ? (
             <DialogPrimitive.Portal forceMount>
-              <DialogPrimitive.Content asChild forceMount ref={ref}>
+              <DialogPrimitive.Content
+                asChild
+                forceMount
+                ref={ref}
+                // aria-describedby must be explicitly set to undefined if a
+                // description is not provided.
+                {...(description === undefined
+                  ? { 'aria-describedby': undefined }
+                  : {})}
+              >
                 <div className="fixed w-full h-full top-0 left-0 z-20">
                   <DialogPrimitive.Overlay
                     onClick={() => onOpenChange(false)}
@@ -155,6 +167,8 @@ type ContentProps = {
   onSubmit?: React.FormEventHandler<HTMLFormElement>
   title?: React.ReactNode
   description?: React.ReactNode
+  titleVisuallyHidden?: boolean
+  descriptionVisuallyHidden?: boolean
   controls?: React.ReactNode
   children?: React.ReactNode
   contentVariants?: VariantProps<typeof contentStyles>
@@ -170,6 +184,8 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(
       onSubmit,
       title,
       description,
+      titleVisuallyHidden,
+      descriptionVisuallyHidden,
       controls,
       contentVariants,
       closeClassName,
@@ -195,13 +211,19 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         className={contentStyles(contentVariants as any)}
       >
-        {title && (
-          <DialogPrimitive.Title
-            className={dialogTitleStyles({ showSeparator })}
-          >
-            {title}
-          </DialogPrimitive.Title>
-        )}
+        {title ? (
+          titleVisuallyHidden ? (
+            <VisuallyHidden.Root>
+              <DialogPrimitive.Title>{title}</DialogPrimitive.Title>
+            </VisuallyHidden.Root>
+          ) : (
+            <DialogPrimitive.Title
+              className={dialogTitleStyles({ showSeparator })}
+            >
+              {title}
+            </DialogPrimitive.Title>
+          )
+        ) : null}
         <ScrollArea
           style={{
             height: dynamicHeight ? `${height}px` : undefined,
@@ -209,13 +231,21 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(
           }}
         >
           <div ref={heightRef} className={cx('p-4', bodyClassName)}>
-            {description && (
-              <DialogPrimitive.Description
-                className={dialogDescriptionStyles()}
-              >
-                {description}
-              </DialogPrimitive.Description>
-            )}
+            {description ? (
+              descriptionVisuallyHidden ? (
+                <VisuallyHidden.Root>
+                  <DialogPrimitive.Description>
+                    {description}
+                  </DialogPrimitive.Description>
+                </VisuallyHidden.Root>
+              ) : (
+                <DialogPrimitive.Description
+                  className={dialogDescriptionStyles()}
+                >
+                  {description}
+                </DialogPrimitive.Description>
+              )
+            ) : null}
             {children}
           </div>
         </ScrollArea>

--- a/libs/design-system/src/core/Tooltip.tsx
+++ b/libs/design-system/src/core/Tooltip.tsx
@@ -14,6 +14,8 @@ type TooltipProps = Omit<
   'content'
 > & {
   children: React.ReactElement
+  /** The content to display in the tooltip.
+   * If a string or React.Fragment is passed the content will be wrapped in a Paragraph. */
   content: React.ReactNode
 }
 
@@ -44,6 +46,7 @@ export function Tooltip({
     open: _open,
     onOpenChange: _onOpenChange,
   })
+
   return (
     <TooltipPrimitive.Root
       open={open}
@@ -90,7 +93,11 @@ export function Tooltip({
                     panelStyles()
                   )}
                 >
-                  <Paragraph size="12">{content}</Paragraph>
+                  {typeof content === 'string' || Array.isArray(content) ? (
+                    <Paragraph size="12">{content}</Paragraph>
+                  ) : (
+                    content
+                  )}
                 </div>
               </motion.div>
             </TooltipPrimitive.Content>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-switch": "^1.1.1",
         "@radix-ui/react-tabs": "^1.1.1",
         "@radix-ui/react-tooltip": "1.0.0",
+        "@radix-ui/react-visually-hidden": "^1.1.0",
         "@react-spring/web": "^9.7.3",
         "@siacentral/ledgerjs-sia": "^1.1.0",
         "@tailwindcss/container-queries": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-switch": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.1",
     "@radix-ui/react-tooltip": "1.0.0",
+    "@radix-ui/react-visually-hidden": "^1.1.0",
     "@react-spring/web": "^9.7.3",
     "@siacentral/ledgerjs-sia": "^1.1.0",
     "@tailwindcss/container-queries": "^0.1.1",


### PR DESCRIPTION
> This PR cleans up all existing warnings and a few tiny bugs, the radix-ui upgrade added some warnings so I thought it was a good time for this.

- all apps
  - Fixed a warning caused by animation props being passed to non-animated graphs.
  - Fixed warnings around dialog description and aria-describedby.
     - The Dialog now supports providing a title or description that is visually hidden but still announced by assistive technology.
    - Added explicit aria descriptions to some primary dialogs.
  - Adjusted tooltip to only wrap content with Paragraph if prop is a string or React.Fragment.
  - Fixed instances/warnings where content included `div` elements which are not allowed inside a `p`.
  - Fixed a 1 pixel gap that would show between the top of the Table and its sticky header when scrolling.
- renterd
  - Fixed an issue with the uploads list loading and empty states.
- walletd
  - Fixed an issue where the app would try to fetch from an invalid URL when first initializing.
  - There is a duplicate key warning in the walletd transactions list, this was caused by a walletd bug which is now fixed, no change required.
- website
  - Added a max height and radius for hosts on the host map.
  - Fixed hydration mismatch warnings related to the random selection of a host on the globe.
  - Fixed a hydration mismatch warning related to the ThemeRadio in footer.

