### PR TITLE
feat(renterd): keys batch operations

### DIFF
--- a/.changeset/calm-flies-punch.md
+++ b/.changeset/calm-flies-punch.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/e2e': minor
+---
+
+Add getTextInputValueByName method.

--- a/.changeset/happy-comics-retire.md
+++ b/.changeset/happy-comics-retire.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The key management table now supports multiselect and batch deletion.

--- a/.changeset/selfish-parrots-applaud.md
+++ b/.changeset/selfish-parrots-applaud.md
@@ -1,0 +1,6 @@
+---
+'hostd': minor
+'renterd': minor
+---
+
+The onboarding wizard is now bottom right aligned.

--- a/.changeset/strong-cherries-change.md
+++ b/.changeset/strong-cherries-change.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/e2e': minor
+---
+
+Add toggleColumnVisibility view preferences method.

--- a/apps/hostd/components/OnboardingBar.tsx
+++ b/apps/hostd/components/OnboardingBar.tsx
@@ -67,7 +67,7 @@ export function OnboardingBar() {
 
   if (maximized) {
     return (
-      <div className="z-20 fixed bottom-5 left-1/2 -translate-x-1/2 flex justify-center">
+      <div className="z-20 fixed bottom-5 right-5 flex justify-center">
         <Panel className="w-[400px] flex flex-col max-h-[600px]">
           <ScrollArea>
             <div className="flex justify-between items-center px-3 py-2 border-b border-gray-200 dark:border-graydark-300">
@@ -232,7 +232,7 @@ export function OnboardingBar() {
     )
   }
   return (
-    <div className="z-30 fixed bottom-5 left-1/2 -translate-x-1/2 flex justify-center">
+    <div className="z-30 fixed bottom-5 right-5 flex justify-center">
       <Button
         onClick={() => setMaximized(true)}
         size="large"

--- a/apps/renterd-e2e/src/fixtures/contracts.ts
+++ b/apps/renterd-e2e/src/fixtures/contracts.ts
@@ -1,10 +1,10 @@
-import { Page, expect } from '@playwright/test'
+import { Page } from '@playwright/test'
 
-export async function getContractRowById(page: Page, id: string) {
+export function getContractRowById(page: Page, id: string) {
   return page.getByTestId('contractsTable').getByTestId(id)
 }
 
-export async function getContractsSummaryRow(page: Page) {
+export function getContractsSummaryRow(page: Page) {
   return page
     .getByTestId('contractsTable')
     .locator('thead')
@@ -12,7 +12,7 @@ export async function getContractsSummaryRow(page: Page) {
     .nth(1)
 }
 
-export async function getContractRowByIndex(page: Page, index: number) {
+export function getContractRowByIndex(page: Page, index: number) {
   return page
     .getByTestId('contractsTable')
     .locator('tbody')
@@ -26,29 +26,4 @@ export async function getContractRows(page: Page) {
     .locator('tbody')
     .getByRole('row')
     .all()
-}
-
-export async function toggleColumnVisibility(
-  page: Page,
-  name: string,
-  visible: boolean
-) {
-  await page.getByLabel('configure view').click()
-  const configureView = page.getByRole('dialog')
-  const columnToggle = configureView.getByRole('checkbox', {
-    name,
-  })
-
-  if (visible) {
-    await expect(columnToggle).toBeVisible()
-    if (!(await columnToggle.isChecked())) {
-      await columnToggle.click()
-    }
-  } else {
-    await expect(columnToggle).toBeHidden()
-    if (await columnToggle.isChecked()) {
-      await columnToggle.click()
-    }
-  }
-  await page.getByLabel('configure view').click()
 }

--- a/apps/renterd-e2e/src/fixtures/hosts.ts
+++ b/apps/renterd-e2e/src/fixtures/hosts.ts
@@ -1,10 +1,10 @@
-import { Locator, Page, expect } from '@playwright/test'
+import { Locator, Page } from '@playwright/test'
 
-export async function getHostRowById(page: Page, id: string) {
+export function getHostRowById(page: Page, id: string) {
   return page.getByTestId('hostsTable').getByTestId(id)
 }
 
-export async function getHostsSummaryRow(page: Page) {
+export function getHostsSummaryRow(page: Page) {
   return page.getByTestId('hostsTable').locator('thead').getByRole('row').nth(1)
 }
 
@@ -32,29 +32,4 @@ export async function openHostContextMenu(page: Page, name: string) {
 
 export async function openRowHostContextMenu(row: Locator) {
   await row.getByTestId('actions').getByRole('button').first().click()
-}
-
-export async function toggleColumnVisibility(
-  page: Page,
-  name: string,
-  visible: boolean
-) {
-  await page.getByLabel('configure view').click()
-  const configureView = page.getByRole('dialog')
-  const columnToggle = configureView.getByRole('checkbox', {
-    name,
-  })
-
-  if (visible) {
-    await expect(columnToggle).toBeVisible()
-    if (!(await columnToggle.isChecked())) {
-      await columnToggle.click()
-    }
-  } else {
-    await expect(columnToggle).toBeHidden()
-    if (await columnToggle.isChecked()) {
-      await columnToggle.click()
-    }
-  }
-  await page.getByLabel('configure view').click()
 }

--- a/apps/renterd-e2e/src/fixtures/keys.ts
+++ b/apps/renterd-e2e/src/fixtures/keys.ts
@@ -1,0 +1,41 @@
+import { Page, expect } from '@playwright/test'
+import { navigateToKeys } from './navigate'
+import { getTextInputValueByName } from '@siafoundation/e2e'
+
+export function getKeyRowById(page: Page, id: string) {
+  return page.getByTestId('keysTable').getByTestId(id)
+}
+
+export function getKeysSummaryRow(page: Page) {
+  return page.getByTestId('keysTable').locator('thead').getByRole('row').nth(1)
+}
+
+export function getKeyRowByIndex(page: Page, index: number) {
+  return page
+    .getByTestId('keysTable')
+    .locator('tbody')
+    .getByRole('row')
+    .nth(index)
+}
+
+export async function getKeyRows(page: Page) {
+  return page.getByTestId('keysTable').locator('tbody').getByRole('row').all()
+}
+
+export async function createKey(page: Page): Promise<string> {
+  await navigateToKeys({ page })
+  await page.getByTestId('navbar').getByText('Create keypair').click()
+  const dialog = page.getByRole('dialog')
+  const accessKeyId = await getTextInputValueByName(page, 'name')
+  await dialog.getByRole('button', { name: 'Create' }).click()
+  const row = getKeyRowById(page, accessKeyId)
+  await expect(dialog).toBeHidden()
+  await expect(row).toBeVisible()
+  return accessKeyId
+}
+
+export async function openKeyContextMenu(page: Page, key: string) {
+  const selector = page.getByTestId(key).getByLabel('key context menu')
+  await expect(selector).toBeVisible()
+  await selector.click()
+}

--- a/apps/renterd-e2e/src/fixtures/navigate.ts
+++ b/apps/renterd-e2e/src/fixtures/navigate.ts
@@ -28,3 +28,11 @@ export async function navigateToHosts({ page }: { page: Page }) {
   await page.getByTestId('sidenav').getByLabel('Hosts').click()
   await expect(page.getByTestId('navbar').getByText('Hosts')).toBeVisible()
 }
+
+export async function navigateToKeys({ page }: { page: Page }) {
+  await page
+    .getByTestId('sidenav')
+    .getByLabel('S3 authentication keypairs')
+    .click()
+  await expect(page.getByTestId('navbar').getByText('Keys')).toBeVisible()
+}

--- a/apps/renterd-e2e/src/specs/contracts.spec.ts
+++ b/apps/renterd-e2e/src/specs/contracts.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test'
+import { toggleColumnVisibility } from '@siafoundation/e2e'
 import { navigateToContracts } from '../fixtures/navigate'
 import { afterTest, beforeTest } from '../fixtures/beforeTest'
 import {
   getContractRowByIndex,
   getContractRows,
   getContractsSummaryRow,
-  toggleColumnVisibility,
 } from '../fixtures/contracts'
 
 test.beforeEach(async ({ page }) => {

--- a/apps/renterd-e2e/src/specs/keys.spec.ts
+++ b/apps/renterd-e2e/src/specs/keys.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+import { afterTest, beforeTest } from '../fixtures/beforeTest'
+import {
+  createKey,
+  getKeyRowById,
+  getKeyRowByIndex,
+  openKeyContextMenu,
+} from '../fixtures/keys'
+
+test.beforeEach(async ({ page }) => {
+  await beforeTest(page)
+})
+
+test.afterEach(async () => {
+  await afterTest()
+})
+
+test('create and delete a key', async ({ page }) => {
+  const key = await createKey(page)
+  const row = getKeyRowById(page, key)
+  await openKeyContextMenu(page, key)
+  await page.getByRole('menu').getByText('Delete').click()
+  const dialog = page.getByRole('dialog')
+  await dialog.getByRole('button', { name: 'Delete' }).click()
+  await expect(row).toBeHidden()
+})
+
+test('batch delete multiple keys', async ({ page }) => {
+  // Create 3 keys. Note: 1 already exists.
+  const key1 = await createKey(page)
+  const key2 = await createKey(page)
+  const key3 = await createKey(page)
+  const row1 = getKeyRowById(page, key1)
+  const row2 = getKeyRowById(page, key2)
+  const row3 = getKeyRowById(page, key3)
+
+  // There are 4 keys total. Get the first and last row.
+  const rowIdx0 = getKeyRowByIndex(page, 0)
+  const rowIdx3 = getKeyRowByIndex(page, 3)
+
+  // Select all 4 keys.
+  await rowIdx0.getByLabel('select key').click()
+  await rowIdx3.getByLabel('select key').click({ modifiers: ['Shift'] })
+
+  // Delete all 4 keys.
+  const menu = page.getByLabel('key multiselect menu')
+  await menu.getByLabel('delete selected keys').click()
+  const dialog = page.getByRole('dialog')
+  await dialog.getByRole('button', { name: 'Delete' }).click()
+  await expect(row1).toBeHidden()
+  await expect(row2).toBeHidden()
+  await expect(row3).toBeHidden()
+  await expect(
+    page.getByText('There are no S3 authentication keypairs yet.')
+  ).toBeVisible()
+})

--- a/apps/renterd/components/Keys/KeyContextMenu.tsx
+++ b/apps/renterd/components/Keys/KeyContextMenu.tsx
@@ -47,14 +47,19 @@ export function KeyContextMenu({ s3Key, contentProps, buttonProps }: Props) {
     if (response.error) {
       triggerErrorToast({ title: 'Error deleting key', body: response.error })
     } else {
-      triggerSuccessToast({ title: `Key ${s3Key} removed` })
+      triggerSuccessToast({ title: `Key ${s3Key} deleted` })
     }
   }, [settingsS3.data, s3Key, settingsS3Update])
 
   return (
     <DropdownMenu
       trigger={
-        <Button variant="ghost" icon="hover" {...buttonProps}>
+        <Button
+          aria-label="key context menu"
+          icon="hover"
+          size="none"
+          {...buttonProps}
+        >
           <CaretDown16 />
         </Button>
       }
@@ -76,12 +81,12 @@ export function KeyContextMenu({ s3Key, contentProps, buttonProps }: Props) {
         onSelect={() => {
           openConfirmDialog({
             title: `Delete key ${truncate(s3Key, 15)}`,
-            action: 'Remove',
+            action: 'Delete',
             variant: 'red',
             body: (
               <div className="flex flex-col gap-1">
                 <Paragraph size="14">
-                  Are you sure you would like to remove the following key?
+                  Are you sure you would like to delete the following key?
                 </Paragraph>
                 <Paragraph size="14" font="mono">
                   {truncate(s3Key, 80)}

--- a/apps/renterd/components/Keys/KeysBatchMenu/KeysBatchDelete.tsx
+++ b/apps/renterd/components/Keys/KeysBatchMenu/KeysBatchDelete.tsx
@@ -1,0 +1,80 @@
+import {
+  Button,
+  Paragraph,
+  triggerSuccessToast,
+  triggerErrorToast,
+} from '@siafoundation/design-system'
+import { Delete16 } from '@siafoundation/react-icons'
+import {
+  useSettingsS3,
+  useSettingsS3Update,
+} from '@siafoundation/renterd-react'
+import { useCallback, useMemo } from 'react'
+import { omit } from '@technically/lodash'
+import { useDialog } from '../../../contexts/dialog'
+import { useKeys } from '../../../contexts/keys'
+
+export function KeysBatchDelete() {
+  const { selectionMap, deselect } = useKeys()
+
+  const ids = useMemo(
+    () => Object.entries(selectionMap).map(([_, item]) => item.id),
+    [selectionMap]
+  )
+  const keys = useMemo(
+    () => Object.entries(selectionMap).map(([_, item]) => item.key),
+    [selectionMap]
+  )
+  const { openConfirmDialog } = useDialog()
+  const settingsS3 = useSettingsS3()
+  const settingsS3Update = useSettingsS3Update()
+  const deleteKeys = useCallback(async () => {
+    if (!settingsS3.data) {
+      triggerErrorToast({ title: 'Error deleting key' })
+      return
+    }
+    const newKeys = omit(settingsS3.data?.authentication.v4Keypairs, keys)
+    const response = await settingsS3Update.put({
+      payload: {
+        ...settingsS3.data,
+        authentication: {
+          ...settingsS3.data.authentication,
+          v4Keypairs: newKeys,
+        },
+      },
+    })
+    deselect(ids)
+    if (response.error) {
+      triggerErrorToast({ title: 'Error deleting keys', body: response.error })
+    } else {
+      triggerSuccessToast({ title: `Keys deleted` })
+    }
+  }, [settingsS3.data, settingsS3Update, deselect, keys, ids])
+
+  return (
+    <Button
+      aria-label="delete selected keys"
+      tip="Delete selected keys"
+      onClick={() => {
+        openConfirmDialog({
+          title: `Delete keys`,
+          action: 'Delete',
+          variant: 'red',
+          body: (
+            <div className="flex flex-col gap-1">
+              <Paragraph size="14">
+                Are you sure you would like to delete the{' '}
+                {ids.length.toLocaleString()} selected keys?
+              </Paragraph>
+            </div>
+          ),
+          onConfirm: async () => {
+            deleteKeys()
+          },
+        })
+      }}
+    >
+      <Delete16 />
+    </Button>
+  )
+}

--- a/apps/renterd/components/Keys/KeysBatchMenu/index.tsx
+++ b/apps/renterd/components/Keys/KeysBatchMenu/index.tsx
@@ -1,0 +1,21 @@
+import { MultiSelectionMenu } from '@siafoundation/design-system'
+import { useKeys } from '../../../contexts/keys'
+import { KeysBatchDelete } from './KeysBatchDelete'
+
+export function KeysBatchMenu() {
+  const { selectionCount, isPageAllSelected, pageCount, deselectAll } =
+    useKeys()
+
+  return (
+    <MultiSelectionMenu
+      isVisible={selectionCount > 0}
+      selectionCount={selectionCount}
+      isPageAllSelected={isPageAllSelected}
+      deselectAll={deselectAll}
+      pageCount={pageCount}
+      entityWord="key"
+    >
+      <KeysBatchDelete />
+    </MultiSelectionMenu>
+  )
+}

--- a/apps/renterd/components/Keys/KeysCreateDialog.tsx
+++ b/apps/renterd/components/Keys/KeysCreateDialog.tsx
@@ -157,8 +157,8 @@ export function KeysCreateDialog({ trigger, open, onOpenChange }: Props) {
 
   return (
     <Dialog
-      title="Create S3 key"
-      description="Create a new S3 authentication key."
+      title="Create S3 keypair"
+      description="Create a new S3 authentication keypair."
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {

--- a/apps/renterd/components/Keys/index.tsx
+++ b/apps/renterd/components/Keys/index.tsx
@@ -8,6 +8,7 @@ import { StateNoneYet } from './StateNoneYet'
 import { KeysActionsMenu } from './KeysActionsMenu'
 import { StateError } from './StateError'
 import { useKeys } from '../../contexts/keys'
+import { KeysBatchMenu } from './KeysBatchMenu'
 
 export function Keys() {
   const { openDialog } = useDialog()
@@ -20,6 +21,7 @@ export function Keys() {
     toggleSort,
     limit,
     dataState,
+    cellContext,
   } = useKeys()
 
   return (
@@ -31,7 +33,9 @@ export function Keys() {
       actions={<KeysActionsMenu />}
     >
       <div className="p-6 min-w-fit">
+        <KeysBatchMenu />
         <Table
+          testId="keysTable"
           isLoading={dataState === 'loading'}
           emptyState={
             dataState === 'noneMatchingFilters' ? (
@@ -45,6 +49,7 @@ export function Keys() {
           sortableColumns={sortableColumns}
           pageSize={limit}
           data={datasetPage}
+          context={cellContext}
           columns={columns}
           sortDirection={sortDirection}
           sortField={sortField}

--- a/apps/renterd/components/OnboardingBar.tsx
+++ b/apps/renterd/components/OnboardingBar.tsx
@@ -70,7 +70,7 @@ export function OnboardingBar() {
 
   if (maximized) {
     return (
-      <div className="z-20 fixed bottom-5 left-1/2 -translate-x-1/2 flex justify-center">
+      <div className="z-20 fixed bottom-5 right-5 flex justify-center">
         <Panel className="w-[400px] flex flex-col max-h-[600px]">
           <ScrollArea>
             <div className="flex justify-between items-center px-3 py-2 border-b border-gray-200 dark:border-graydark-300">
@@ -239,13 +239,13 @@ export function OnboardingBar() {
     )
   }
   return (
-    <div className="z-30 fixed bottom-5 left-1/2 -translate-x-1/2 flex justify-center">
+    <div className="z-30 fixed bottom-5 right-5 flex justify-center">
       <Button
         onClick={() => setMaximized(true)}
         size="large"
         className="flex gap-3 !px-3"
       >
-        <Text className="flex items-center gap-1">
+        <Text size="14" className="flex items-center gap-1">
           <Logo />
           Setup: {completedSteps}/{totalSteps} steps complete
         </Text>

--- a/apps/renterd/contexts/keys/columns.tsx
+++ b/apps/renterd/contexts/keys/columns.tsx
@@ -1,8 +1,13 @@
-import { TableColumn, ValueCopyable } from '@siafoundation/design-system'
-import { KeyData, TableColumnId } from './types'
+import {
+  Checkbox,
+  ControlGroup,
+  TableColumn,
+  ValueCopyable,
+} from '@siafoundation/design-system'
+import { KeyData, CellContext, TableColumnId } from './types'
 import { KeyContextMenu } from '../../components/Keys/KeyContextMenu'
 
-type KeysTableColumn = TableColumn<TableColumnId, KeyData, never> & {
+type KeysTableColumn = TableColumn<TableColumnId, KeyData, CellContext> & {
   fixed?: boolean
   category?: string
 }
@@ -12,8 +17,23 @@ export const columns: KeysTableColumn[] = [
     id: 'actions',
     label: '',
     fixed: true,
-    cellClassName: 'w-[50px] !pl-2 !pr-4 [&+*]:!pl-0',
-    render: ({ data: { key } }) => <KeyContextMenu s3Key={key} />,
+    contentClassName: '!pl-3 !pr-4',
+    cellClassName: 'w-[20px] !pl-0 !pr-0',
+    heading: ({ context: { onSelectPage, isPageAllSelected } }) => (
+      <ControlGroup className="flex h-4">
+        <Checkbox onClick={onSelectPage} checked={isPageAllSelected} />
+      </ControlGroup>
+    ),
+    render: ({ data: { id, key }, context: { selectionMap, onSelect } }) => (
+      <ControlGroup className="flex h-4">
+        <Checkbox
+          aria-label="select key"
+          onClick={(e) => onSelect(id, e)}
+          checked={!!selectionMap[id]}
+        />
+        <KeyContextMenu s3Key={key} />
+      </ControlGroup>
+    ),
   },
   {
     id: 'key',

--- a/apps/renterd/contexts/keys/index.tsx
+++ b/apps/renterd/contexts/keys/index.tsx
@@ -3,10 +3,12 @@ import {
   useDatasetEmptyState,
   useClientFilters,
   useClientFilteredDataset,
+  useMultiSelect,
 } from '@siafoundation/design-system'
 import { useRouter } from 'next/router'
 import { createContext, useContext, useMemo } from 'react'
 import {
+  CellContext,
   KeyData,
   columnsDefaultVisible,
   defaultSortField,
@@ -99,6 +101,27 @@ function useKeysMain() {
     filters
   )
 
+  const {
+    onSelect,
+    deselect,
+    deselectAll,
+    selectionMap,
+    selectionCount,
+    onSelectPage,
+    isPageAllSelected,
+  } = useMultiSelect(dataset)
+
+  const cellContext = useMemo(
+    () =>
+      ({
+        selectionMap,
+        onSelect,
+        onSelectPage,
+        isPageAllSelected,
+      } as CellContext),
+    [selectionMap, onSelect, onSelectPage, isPageAllSelected]
+  )
+
   return {
     dataState,
     limit,
@@ -109,6 +132,13 @@ function useKeysMain() {
     datasetCount: dataset?.length || 0,
     datasetFilteredCount: datasetFiltered?.length || 0,
     columns: filteredTableColumns,
+    selectionMap,
+    selectionCount,
+    onSelectPage,
+    isPageAllSelected,
+    deselect,
+    deselectAll,
+    cellContext,
     dataset,
     datasetPage,
     configurableColumns,

--- a/apps/renterd/contexts/keys/types.ts
+++ b/apps/renterd/contexts/keys/types.ts
@@ -1,10 +1,19 @@
+import { MouseEvent } from 'react'
+
 export type KeyData = {
   id: string
   key: string
   secret: string
 }
 
-export type TableColumnId = 'actions' | 'key' | 'secret'
+export type CellContext = {
+  selectionMap: Record<string, KeyData>
+  onSelect: (id: string, e: MouseEvent<HTMLButtonElement>) => void
+  onSelectPage: () => void
+  isPageAllSelected: boolean | 'indeterminate'
+}
+
+export type TableColumnId = 'selection' | 'actions' | 'key' | 'secret'
 
 export const columnsDefaultVisible: TableColumnId[] = ['key', 'secret']
 

--- a/libs/design-system/src/multi/MultiSelectionMenu.tsx
+++ b/libs/design-system/src/multi/MultiSelectionMenu.tsx
@@ -27,7 +27,7 @@ export function MultiSelectionMenu({
   entityWordPlural?: string
 }) {
   return (
-    <div className="fixed bottom-4 left-0 right-0 flex justify-center p-4 dark">
+    <div className="z-20 fixed bottom-5 left-0 right-0 flex justify-center dark pointer-events-none">
       <AnimatePresence>
         {isVisible && (
           <motion.div
@@ -38,7 +38,7 @@ export function MultiSelectionMenu({
           >
             <Panel
               aria-label={entityWord + ' multiselect menu'}
-              className="pl-3 pr-2 py-2 min-w-[250px] flex gap-2 items-center rounded-lg light:bg-black"
+              className="pl-3 pr-2 py-2 min-w-[250px] flex gap-2 items-center rounded-lg light:bg-black pointer-events-auto"
             >
               {!!selectionCount && (
                 <Text size="14">

--- a/libs/e2e/src/fixtures/preferences.ts
+++ b/libs/e2e/src/fixtures/preferences.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright'
+import { Page, expect } from '@playwright/test'
 import { fillSelectInputByName } from './selectInput'
 import { CurrencyId } from '@siafoundation/react-core'
 
@@ -13,4 +13,29 @@ export async function setCurrencyDisplay(
     await fillSelectInputByName(page, 'currencyFiat', currency)
   }
   await page.getByRole('dialog').getByLabel('close').click()
+}
+
+export async function toggleColumnVisibility(
+  page: Page,
+  name: string,
+  visible: boolean
+) {
+  await page.getByLabel('configure view').click()
+  const configureView = page.getByRole('dialog')
+  const columnToggle = configureView.getByRole('checkbox', {
+    name,
+  })
+
+  if (visible) {
+    await expect(columnToggle).toBeVisible()
+    if (!(await columnToggle.isChecked())) {
+      await columnToggle.click()
+    }
+  } else {
+    await expect(columnToggle).toBeHidden()
+    if (await columnToggle.isChecked()) {
+      await columnToggle.click()
+    }
+  }
+  await page.getByLabel('configure view').click()
 }

--- a/libs/e2e/src/fixtures/textInput.ts
+++ b/libs/e2e/src/fixtures/textInput.ts
@@ -32,3 +32,14 @@ export async function expectTextInputByNameAttribute(
 ) {
   await expect(page.locator(`input[name="${name}"]`)).toHaveAttribute(value)
 }
+
+export async function getTextInputValueByName(
+  page: Page,
+  name: string,
+  waitForValue = true
+) {
+  if (waitForValue) {
+    await expect(page.locator(`input[name="${name}"]`)).toHaveValue(/.*/)
+  }
+  return await page.locator(`input[name="${name}"]`).inputValue()
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/3a1039ab-cbdc-457e-a651-563a846f6bea

- The key management table now supports multiselect and batch deletion.
- The onboarding wizard is now bottom right aligned.