### PR TITLE
fix(website): renterd and walletd provide latest full release

### DIFF
--- a/.changeset/smooth-buses-pump.md
+++ b/.changeset/smooth-buses-pump.md
@@ -1,0 +1,6 @@
+---
+'website': minor
+'@siafoundation/data-sources': minor
+---
+
+The latest walletd and renterd releases no longer include prereleases.

--- a/libs/data-sources/src/lib/github.ts
+++ b/libs/data-sources/src/lib/github.ts
@@ -183,10 +183,10 @@ export type GitHubRelease = {
 export async function getGitHubRenterdLatestDaemonRelease(): Promise<GitHubRelease | null> {
   try {
     const response = await axios.get(
-      'https://api.github.com/repos/SiaFoundation/renterd/releases?per_page=1'
+      'https://api.github.com/repos/SiaFoundation/renterd/releases/latest'
     )
-    if (response.data.length) {
-      return response.data[0]
+    if (response.data) {
+      return response.data
     } else {
       return null
     }
@@ -215,10 +215,10 @@ export async function getGitHubHostdLatestDaemonRelease(): Promise<GitHubRelease
 export async function getGitHubWalletdLatestDaemonRelease(): Promise<GitHubRelease | null> {
   try {
     const response = await axios.get(
-      'https://api.github.com/repos/SiaFoundation/walletd/releases?per_page=1'
+      'https://api.github.com/repos/SiaFoundation/walletd/releases/latest'
     )
-    if (response.data.length) {
-      return response.data[0]
+    if (response.data) {
+      return response.data
     } else {
       return null
     }


### PR DESCRIPTION
- The latest walletd and renterd releases no longer include prereleases.
