### PR TITLE
fix(renterd): stop sending invalid evaluations before initial validation

### DIFF
--- a/.changeset/forty-bananas-return.md
+++ b/.changeset/forty-bananas-return.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the app was sending invalid autopilot evaluation requests before all the required data was entered by the user.

--- a/apps/renterd/contexts/config/useForm.tsx
+++ b/apps/renterd/contexts/config/useForm.tsx
@@ -33,7 +33,15 @@ export function useForm({ resources }: { resources: ResourcesMaybeLoaded }) {
       defaultValue: 'basic',
     })
 
-  // Trigger input validation on configViewMode change because many field validation
+  // Trigger validation when the form is first setup.
+  // This is necessary because otherwise the form will not validate until the
+  // actual fields are rendered on screen, but we use isValid for other things
+  // such as deciding whether to submit autopilot config evaluations.
+  useEffect(() => {
+    form.trigger()
+  }, [form])
+
+  // Trigger validation on configViewMode change because many field validation
   // objects switch from required to not required.
   useEffect(() => {
     form.trigger()


### PR DESCRIPTION
- Fixed an issue where the app was sending invalid autopilot evaluation requests before all the required data was entered by the user.

