### PR TITLE
refactor: standardize syncer peers response data

### DIFF
--- a/.changeset/loud-doors-learn.md
+++ b/.changeset/loud-doors-learn.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/hostd-types': minor
+---
+
+The syncer peers response now includes more information and matches walletd.

--- a/.changeset/thirty-nails-raise.md
+++ b/.changeset/thirty-nails-raise.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/walletd-types': minor
+---
+
+The syncer peers response type updated to include address rather than addr.

--- a/apps/walletd/components/Node/index.tsx
+++ b/apps/walletd/components/Node/index.tsx
@@ -46,7 +46,7 @@ export function Node() {
         <div className="flex-1">
           <PeerList
             isLoading={peers.isValidating}
-            peers={peers.data?.map((p) => p.addr)}
+            peers={peers.data?.map((p) => p.address)}
             connectPeer={() => openDialog('connectPeer')}
           />
         </div>

--- a/libs/hostd-types/src/api.ts
+++ b/libs/hostd-types/src/api.ts
@@ -131,7 +131,12 @@ export type IndexTipResponse = ChainIndex
 
 type Peer = {
   address: string
+  inbound: boolean
   version: string
+  firstSeen?: string
+  connectedSince?: string
+  syncedBlocks?: number
+  syncDuration?: number
 }
 
 export type SyncerPeersParams = void

--- a/libs/walletd-mock/src/mocks/peers.ts
+++ b/libs/walletd-mock/src/mocks/peers.ts
@@ -4,7 +4,7 @@ import { Page } from 'playwright'
 export function getMockPeersResponse(): SyncerPeersResponse {
   return [
     {
-      addr: '51.81.242.140:9881',
+      address: '51.81.242.140:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T17:14:43Z',
@@ -12,7 +12,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 1321006459,
     },
     {
-      addr: '3.36.68.121:9881',
+      address: '3.36.68.121:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T13:39:10Z',
@@ -20,7 +20,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 4230014834,
     },
     {
-      addr: '185.200.116.131:9807',
+      address: '185.200.116.131:9807',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T17:14:43Z',
@@ -29,7 +29,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 6018991169,
     },
     {
-      addr: '62.30.63.90:9881',
+      address: '62.30.63.90:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T13:39:10Z',
@@ -37,7 +37,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 6341708209,
     },
     {
-      addr: '43.203.121.70:9881',
+      address: '43.203.121.70:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T17:14:44Z',
@@ -46,7 +46,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 6860545337,
     },
     {
-      addr: '23.239.8.40:9881',
+      address: '23.239.8.40:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T13:39:10Z',
@@ -54,7 +54,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 580416082,
     },
     {
-      addr: '141.94.161.198:9881',
+      address: '141.94.161.198:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T13:39:10Z',
@@ -63,7 +63,7 @@ export function getMockPeersResponse(): SyncerPeersResponse {
       syncDuration: 4894896166,
     },
     {
-      addr: '64.227.180.244:9881',
+      address: '64.227.180.244:9881',
       inbound: false,
       version: '1.5.4',
       firstSeen: '2024-03-20T13:39:25Z',

--- a/libs/walletd-types/src/types.ts
+++ b/libs/walletd-types/src/types.ts
@@ -1,7 +1,7 @@
 import { SpendPolicy, UnlockConditions } from '@siafoundation/types'
 
 export type GatewayPeer = {
-  addr: string
+  address: string
   inbound: boolean
   version: string
   firstSeen?: string


### PR DESCRIPTION
- hostd: The syncer peers response now includes more information and matches walletd.
- walletd: The syncer peers response type updated to include address rather than addr.
