### PR TITLE
fix(walletd): generate seed address no prefix

### DIFF
--- a/.changeset/light-onions-clean.md
+++ b/.changeset/light-onions-clean.md
@@ -1,0 +1,5 @@
+---
+'walletd': patch
+---
+
+Updated the seed wallet address generation process to strip the address prefix, which matches the recent API change.

--- a/apps/walletd/dialogs/WalletAddressesGenerateSeedDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletAddressesGenerateSeedDialog/index.tsx
@@ -3,6 +3,7 @@ import {
   Dialog,
   FieldNumber,
   FormSubmitButton,
+  stripPrefix,
   triggerErrorToast,
   triggerSuccessToast,
   useDialogFormHelpers,
@@ -179,7 +180,7 @@ export function WalletAddressesGenerateSeedDialog({
             id: walletId,
           },
           payload: {
-            address: suh.address,
+            address: stripPrefix(suh.address),
             description: '',
             // TODO: add spendPolicy?
             metadata,


### PR DESCRIPTION
- Updated the seed wallet address generation process to strip the address prefix, which matches the recent API change.

