### PR TITLE
feat(renterd): contract multiselect

### DIFF
--- a/.changeset/eighty-papayas-notice.md
+++ b/.changeset/eighty-papayas-notice.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contract graphs are now explicitly toggled open with the action button in the navbar.

--- a/.changeset/light-pens-turn.md
+++ b/.changeset/light-pens-turn.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The contracts table now supports multi-select.

--- a/apps/renterd/components/Contracts/ContractContextMenu.tsx
+++ b/apps/renterd/components/Contracts/ContractContextMenu.tsx
@@ -49,7 +49,12 @@ export function ContractContextMenu({
     <DropdownMenu
       trigger={
         trigger || (
-          <Button variant="ghost" icon="hover" {...buttonProps}>
+          <Button
+            aria-label="contract context menu"
+            icon="hover"
+            size="none"
+            {...buttonProps}
+          >
             <CaretDown16 />
           </Button>
         )

--- a/apps/renterd/components/Contracts/index.tsx
+++ b/apps/renterd/components/Contracts/index.tsx
@@ -81,7 +81,6 @@ export function Contracts() {
               sortDirection={sortDirection}
               sortField={sortField}
               toggleSort={toggleSort}
-              focusId={selectedContract?.id}
               rowSize="default"
             />
           </div>

--- a/apps/renterd/contexts/contracts/columns.tsx
+++ b/apps/renterd/contexts/contracts/columns.tsx
@@ -11,6 +11,7 @@ import {
   Separator,
   Button,
   LoadingDots,
+  Checkbox,
 } from '@siafoundation/design-system'
 import {
   ArrowUpLeft16,
@@ -40,7 +41,14 @@ export const columns: ContractsTableColumn[] = [
     id: 'actions',
     label: '',
     fixed: true,
-    cellClassName: 'w-[50px] !pl-2 !pr-4 [&+*]:!pl-0',
+    contentClassName: '!pl-3 !pr-4',
+    cellClassName: 'w-[20px] !pl-0 !pr-0',
+    heading: ({ context: { multiSelect } }) => (
+      <Checkbox
+        onClick={multiSelect.onSelectPage}
+        checked={multiSelect.isPageAllSelected}
+      />
+    ),
     render: ({ data: { id, hostIp, hostKey } }) => (
       <ContractContextMenu id={id} hostAddress={hostIp} hostKey={hostKey} />
     ),

--- a/apps/renterd/contexts/contracts/types.ts
+++ b/apps/renterd/contexts/contracts/types.ts
@@ -1,6 +1,7 @@
 import { ContractState, ContractUsability } from '@siafoundation/renterd-types'
 import BigNumber from 'bignumber.js'
 import { useFilteredStats } from './useFilteredStats'
+import { MultiSelect } from '@siafoundation/design-system'
 
 export type ContractTableContext = {
   currentHeight: number
@@ -15,11 +16,11 @@ export type ContractTableContext = {
   isFetchingPrunableSizeAll: boolean
   // totals
   filteredStats: ReturnType<typeof useFilteredStats>
+  multiSelect: MultiSelect<ContractData>
 }
 
-export type ContractDataWithoutPrunable = {
+export type ContractData = {
   id: string
-  onClick: () => void
   hostIp: string
   hostKey: string
   state: ContractState
@@ -42,14 +43,25 @@ export type ContractDataWithoutPrunable = {
   spendingSectorRoots: BigNumber
   spendingFundAccount: BigNumber
   size: BigNumber
-}
 
-export type ContractData = ContractDataWithoutPrunable & {
+  // selectable
+  onClick: (e: React.MouseEvent<HTMLTableRowElement>) => void
+  isSelected: boolean
+
+  // prunable
   prunableSize?: BigNumber
   isFetchingPrunableSize: boolean
   hasFetchedPrunableSize: boolean
   fetchPrunableSize: () => void
 }
+
+export type ContractDataWithoutPrunable = Omit<
+  ContractData,
+  | 'prunableSize'
+  | 'isFetchingPrunableSize'
+  | 'hasFetchedPrunableSize'
+  | 'fetchPrunableSize'
+>
 
 export type TableColumnId =
   | 'actions'

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -9,7 +9,7 @@ import {
 } from '@siafoundation/renterd-react'
 import { ContractData } from '../contracts/types'
 import { SiaCentralHost } from '@siafoundation/sia-central-types'
-import { objectEntries } from '@siafoundation/design-system'
+import { Maybe, objectEntries } from '@siafoundation/design-system'
 
 export function useDataset({
   response,
@@ -21,7 +21,7 @@ export function useDataset({
   onHostSelect,
 }: {
   response: ReturnType<typeof useHosts>
-  allContracts: ContractData[]
+  allContracts: Maybe<ContractData[]>
   allowlist: ReturnType<typeof useHostsAllowlist>
   blocklist: ReturnType<typeof useHostsBlocklist>
   isAllowlistActive: boolean
@@ -61,7 +61,7 @@ export function useDataset({
   ])
 }
 
-function getHostFields(host: Host, allContracts: ContractData[]) {
+function getHostFields(host: Host, allContracts: Maybe<ContractData[]>) {
   return {
     id: host.publicKey,
     netAddress: host.netAddress,


### PR DESCRIPTION
- The contracts table now supports multi-select.
- The contract graphs are now explicitly toggled open with the action button in the navbar.
  - This is a bit less jarring and also necessary since now selecting a row is primarily for taking action or multi-select, rather than specifically viewing the contract detail graphs.

### Notes
- Screenshot of this in action in child PR: https://github.com/SiaFoundation/web/pull/828