### PR TITLE
refactor(renterd): remove hostBlockHeightLeeway and migrationSurchargeMultiplier

### DIFF
--- a/.changeset/tasty-bobcats-admire.md
+++ b/.changeset/tasty-bobcats-admire.md
@@ -1,0 +1,8 @@
+---
+'renterd': minor
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+The gouging settings no longer include hostBlockHeightLeeway or migrationSurchargeMultiplier.

--- a/apps/renterd-e2e/src/fixtures/configResetSettings.ts
+++ b/apps/renterd-e2e/src/fixtures/configResetSettings.ts
@@ -60,7 +60,6 @@ export const configResetAllSettings = step(
     await fillTextInputByName(page, 'minPriceTableValidityMinutes', '5')
     await fillTextInputByName(page, 'minAccountExpiryDays', '1')
     await fillTextInputByName(page, 'minMaxEphemeralAccountBalance', '1')
-    await fillTextInputByName(page, 'migrationSurchargeMultiplier', '1')
 
     // redundancy
     await fillTextInputByName(page, 'minShards', '1')

--- a/apps/renterd/components/Config/index.tsx
+++ b/apps/renterd/components/Config/index.tsx
@@ -215,12 +215,6 @@ export function Config() {
           form={form}
           fields={fields}
         />
-        <ConfigurationPanelSetting
-          autoVisibility
-          name="migrationSurchargeMultiplier"
-          form={form}
-          fields={fields}
-        />
       </PanelMenuSection>
       <ConfigurationPanel
         title="Hosts"

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -649,41 +649,6 @@ export function getFields({
         },
       },
     },
-    migrationSurchargeMultiplier: {
-      category: 'gouging',
-      type: 'number',
-      title: 'Migration surcharge multiplier',
-      units: '* download price',
-      placeholder: '10',
-      decimalsLimit: 1,
-      description: (
-        <>
-          Factor that gets applied on the max download price when trying to
-          download migration-critical sectors from a host that is price gouging.
-          For example, when migrating a low-health file, if the download is
-          failing but would potentially succeed with looser gouging settings, we
-          apply the migration surcharge multiplier to overpay on every sector
-          download if it means saving the file/migration.
-        </>
-      ),
-      ...(recommendations.migrationSurchargeMultiplier
-        ? {
-            suggestionLabel: 'Match with more hosts',
-            suggestion:
-              recommendations.migrationSurchargeMultiplier?.targetValue,
-            suggestionTip: 'This value will help you match with more hosts.',
-          }
-        : {
-            suggestion: new BigNumber(10),
-            suggestionTip: 'The default multiplier is 10x the download price.',
-          }),
-      hidden: configViewMode === 'basic',
-      validation: {
-        validate: {
-          required: requiredIfAdvanced(validationContext),
-        },
-      },
-    },
 
     // Redundancy
     minShards: {

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -61,7 +61,6 @@ describe('tansforms', () => {
         minAccountExpiryDays: new BigNumber(1),
         minMaxEphemeralAccountBalance: new BigNumber('1'),
         minPriceTableValidityMinutes: new BigNumber(5),
-        migrationSurchargeMultiplier: new BigNumber(10),
         minShards: new BigNumber(10),
         totalShards: new BigNumber(30),
         maxStoragePriceTBMonthPinned: new BigNumber('5'),
@@ -248,7 +247,6 @@ describe('tansforms', () => {
               minPriceTableValidityMinutes: new BigNumber(5),
               minShards: new BigNumber(10),
               totalShards: new BigNumber(30),
-              migrationSurchargeMultiplier: new BigNumber(10),
               maxStoragePriceTBMonthPinned: new BigNumber('0'),
               maxDownloadPriceTBPinned: new BigNumber('0'),
               maxUploadPriceTBPinned: new BigNumber('0'),
@@ -275,7 +273,6 @@ describe('tansforms', () => {
           minAccountExpiry: 86400000000000,
           minMaxEphemeralAccountBalance: '1000000000000000000000000',
           minPriceTableValidity: 300000000000,
-          migrationSurchargeMultiplier: 10,
         })
       })
     })
@@ -509,7 +506,6 @@ function buildAllResponses() {
       minAccountExpiry: 86400000000000,
       minMaxEphemeralAccountBalance: '1000000000000000000000000',
       minPriceTableValidity: 300000000000,
-      migrationSurchargeMultiplier: 10,
     } as SettingsGouging,
     pinned: {
       currency: 'usd' as CurrencyId,

--- a/apps/renterd/contexts/config/transformDown.ts
+++ b/apps/renterd/contexts/config/transformDown.ts
@@ -115,9 +115,6 @@ export function transformDownGouging({
       gouging.minMaxEphemeralAccountBalance,
       scDecimalPlaces
     ),
-    migrationSurchargeMultiplier: new BigNumber(
-      gouging.migrationSurchargeMultiplier
-    ),
   }
 }
 

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -110,7 +110,6 @@ export function transformUpGouging(
     minMaxEphemeralAccountBalance: toHastings(
       v.minMaxEphemeralAccountBalance
     ).toString(),
-    migrationSurchargeMultiplier: v.migrationSurchargeMultiplier.toNumber(),
   }
 }
 

--- a/apps/renterd/contexts/config/types.ts
+++ b/apps/renterd/contexts/config/types.ts
@@ -41,7 +41,6 @@ export const inputValuesGouging = {
   minPriceTableValidityMinutes: undefined as BigNumber | undefined,
   minAccountExpiryDays: undefined as BigNumber | undefined,
   minMaxEphemeralAccountBalance: undefined as BigNumber | undefined,
-  migrationSurchargeMultiplier: undefined as BigNumber | undefined,
 }
 
 export const inputValuesPinned = {

--- a/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
+++ b/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
@@ -422,7 +422,6 @@ const fieldToHrefId: Record<keyof RecommendableFields, string> = {
   minPriceTableValidityMinutes: 'minPriceTableValidityMinutes',
   minAccountExpiryDays: 'minAccountExpiryDays',
   minMaxEphemeralAccountBalance: 'minMaxEphemeralAccountBalance',
-  migrationSurchargeMultiplier: 'migrationSurchargeMultiplier',
 }
 
 const fieldToLabel: Record<keyof RecommendableFields, string> = {
@@ -438,7 +437,6 @@ const fieldToLabel: Record<keyof RecommendableFields, string> = {
   minPriceTableValidityMinutes: 'min price table validity',
   minAccountExpiryDays: 'min account expiry',
   minMaxEphemeralAccountBalance: 'min max ephemeral account balance',
-  migrationSurchargeMultiplier: 'migration surcharge multiplier',
 }
 
 export const valuesZeroDefaults: Values = {
@@ -468,7 +466,6 @@ export const valuesZeroDefaults: Values = {
   minPriceTableValidityMinutes: new BigNumber(0),
   minAccountExpiryDays: new BigNumber(0),
   minMaxEphemeralAccountBalance: new BigNumber(0),
-  migrationSurchargeMultiplier: new BigNumber(0),
   minShards: new BigNumber(0),
   totalShards: new BigNumber(0),
   pinnedCurrency: 'usd',

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -75,7 +75,6 @@ export type SettingsGouging = {
   minPriceTableValidity: number
   minAccountExpiry: number
   minMaxEphemeralAccountBalance: string
-  migrationSurchargeMultiplier: number
 }
 
 export type SettingsUploadPacking = {


### PR DESCRIPTION
- The gouging settings no longer include migrationSurchargeMultiplier.
  - Pending https://github.com/SiaFoundation/renterd/pull/1696