### PR TITLE
refactor(renterd-libs): move autopilot routes

### DIFF
--- a/.changeset/selfish-queens-fold.md
+++ b/.changeset/selfish-queens-fold.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+The host checks field is now just HostAutopilotChecks.

--- a/.changeset/ten-lies-draw.md
+++ b/.changeset/ten-lies-draw.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Autopilot config routes moved to the bus.

--- a/.changeset/violet-peas-press.md
+++ b/.changeset/violet-peas-press.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+Removed the autopilotID parameter from the hosts API.

--- a/apps/hostd-e2e/project.json
+++ b/apps/hostd-e2e/project.json
@@ -9,7 +9,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          // "cd internal/cluster && go get -u go.sia.tech/hostd@master",
+          "cd internal/cluster && go get -u go.sia.tech/hostd@master",
           "cd internal/cluster && go get -u go.sia.tech/renterd@dev",
           "cd internal/cluster && go get -u go.sia.tech/walletd@master",
           "cd internal/cluster && go mod tidy",

--- a/apps/renterd-e2e/project.json
+++ b/apps/renterd-e2e/project.json
@@ -9,7 +9,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          // "cd internal/cluster && go get -u go.sia.tech/hostd@master",
+          "cd internal/cluster && go get -u go.sia.tech/hostd@master",
           "cd internal/cluster && go get -u go.sia.tech/renterd@dev",
           "cd internal/cluster && go get -u go.sia.tech/walletd@master",
           "cd internal/cluster && go mod tidy",

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -14,7 +14,6 @@ import { objectEntries } from '@siafoundation/design-system'
 export function useDataset({
   response,
   allContracts,
-  autopilotID,
   allowlist,
   blocklist,
   isAllowlistActive,
@@ -22,7 +21,6 @@ export function useDataset({
   onHostSelect,
 }: {
   response: ReturnType<typeof useHosts>
-  autopilotID?: string
   allContracts: ContractData[]
   allowlist: ReturnType<typeof useHostsAllowlist>
   blocklist: ReturnType<typeof useHostsBlocklist>
@@ -47,16 +45,13 @@ export function useDataset({
           blocklist: block,
           isAllowlistActive,
         }),
-        ...getAutopilotFields(
-          autopilotID ? host.checks?.[autopilotID] : undefined
-        ),
+        ...getAutopilotFields(host.checks),
         location: sch?.location,
         countryCode: sch?.country_code,
       }
     })
   }, [
     onHostSelect,
-    autopilotID,
     response.data,
     allContracts,
     allowlist.data,

--- a/apps/renterd/contexts/hosts/index.tsx
+++ b/apps/renterd/contexts/hosts/index.tsx
@@ -179,7 +179,6 @@ function useHostsMain() {
   const dataset = useDataset({
     response,
     allContracts,
-    autopilotID: autopilotState.data?.id,
     allowlist,
     blocklist,
     isAllowlistActive,

--- a/apps/walletd-e2e/project.json
+++ b/apps/walletd-e2e/project.json
@@ -9,7 +9,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          // "cd internal/cluster && go get -u go.sia.tech/hostd@master",
+          "cd internal/cluster && go get -u go.sia.tech/hostd@master",
           "cd internal/cluster && go get -u go.sia.tech/renterd@dev",
           "cd internal/cluster && go get -u go.sia.tech/walletd@master",
           "cd internal/cluster && go mod tidy",

--- a/libs/clusterd/src/index.ts
+++ b/libs/clusterd/src/index.ts
@@ -104,7 +104,6 @@ export async function waitForContracts({
       await mine(1)
       const hosts = await bus.hosts({
         data: {
-          autopilotID: 'autopilot',
           filterMode: 'allowed',
           usabilityMode: 'usable',
           limit: 50,

--- a/libs/renterd-js/README.md
+++ b/libs/renterd-js/README.md
@@ -53,7 +53,6 @@ export async function example() {
 
   const hosts = await bus.hosts({
     data: {
-      autopilotID: 'autopilot',
       filterMode: 'allowed',
       usabilityMode: 'usable',
       addressContains: 'example.com',

--- a/libs/renterd-js/src/autopilot.ts
+++ b/libs/renterd-js/src/autopilot.ts
@@ -2,21 +2,15 @@ import {
   AutopilotConfigEvaluateParams,
   AutopilotConfigEvaluatePayload,
   AutopilotConfigEvaluateResponse,
-  AutopilotConfigParams,
-  AutopilotConfigPayload,
-  AutopilotConfigResponse,
-  AutopilotConfigUpdateParams,
-  AutopilotConfigUpdatePayload,
-  AutopilotConfigUpdateResponse,
   AutopilotStateParams,
   AutopilotStatePayload,
   AutopilotStateResponse,
   AutopilotTriggerParams,
   AutopilotTriggerPayload,
   AutopilotTriggerResponse,
-  autopilotConfigRoute,
   autopilotStateRoute,
   autopilotTriggerRoute,
+  autopilotConfigEvaluateRoute,
 } from '@siafoundation/renterd-types'
 import { buildRequestHandler, initAxios } from '@siafoundation/request'
 
@@ -35,21 +29,11 @@ export function Autopilot({
       AutopilotStatePayload,
       AutopilotStateResponse
     >(axios, 'get', autopilotStateRoute),
-    config: buildRequestHandler<
-      AutopilotConfigParams,
-      AutopilotConfigPayload,
-      AutopilotConfigResponse
-    >(axios, 'get', autopilotConfigRoute),
-    configUpdate: buildRequestHandler<
-      AutopilotConfigUpdateParams,
-      AutopilotConfigUpdatePayload,
-      AutopilotConfigUpdateResponse
-    >(axios, 'put', autopilotConfigRoute),
     configEvaluate: buildRequestHandler<
       AutopilotConfigEvaluateParams,
       AutopilotConfigEvaluatePayload,
       AutopilotConfigEvaluateResponse
-    >(axios, 'post', autopilotConfigRoute),
+    >(axios, 'post', autopilotConfigEvaluateRoute),
     trigger: buildRequestHandler<
       AutopilotTriggerParams,
       AutopilotTriggerPayload,

--- a/libs/renterd-js/src/bus.ts
+++ b/libs/renterd-js/src/bus.ts
@@ -256,6 +256,13 @@ import {
   HostScanPayload,
   HostScanResponse,
   busHostHostKeyScanRoute,
+  AutopilotConfigParams,
+  AutopilotConfigPayload,
+  AutopilotConfigResponse,
+  AutopilotConfigUpdateParams,
+  AutopilotConfigUpdatePayload,
+  AutopilotConfigUpdateResponse,
+  busAutopilotRoute,
 } from '@siafoundation/renterd-types'
 import { buildRequestHandler, initAxios } from '@siafoundation/request'
 
@@ -598,5 +605,15 @@ export function Bus({ api, password }: { api: string; password?: string }) {
       MultipartUploadAddPartPayload,
       MultipartUploadAddPartResponse
     >(axios, 'post', busMultipartPartRoute),
+    autopilotConfig: buildRequestHandler<
+      AutopilotConfigParams,
+      AutopilotConfigPayload,
+      AutopilotConfigResponse
+    >(axios, 'get', busAutopilotRoute),
+    autopilotConfigUpdate: buildRequestHandler<
+      AutopilotConfigUpdateParams,
+      AutopilotConfigUpdatePayload,
+      AutopilotConfigUpdateResponse
+    >(axios, 'put', busAutopilotRoute),
   }
 }

--- a/libs/renterd-js/src/example.ts
+++ b/libs/renterd-js/src/example.ts
@@ -42,7 +42,6 @@ export async function example() {
 
   const hosts = await bus.hosts({
     data: {
-      autopilotID: 'autopilot-id',
       filterMode: 'allowed',
       usabilityMode: 'usable',
       addressContains: 'example.com',

--- a/libs/renterd-react/src/autopilot.ts
+++ b/libs/renterd-react/src/autopilot.ts
@@ -1,19 +1,12 @@
 import {
   useGetSwr,
   usePostSwr,
-  usePutFunc,
   HookArgsSwr,
   HookArgsCallback,
   HookArgsWithPayloadSwr,
-  delay,
   usePostFunc,
 } from '@siafoundation/react-core'
 import {
-  AutopilotConfigParams,
-  AutopilotConfigResponse,
-  AutopilotConfigUpdateParams,
-  AutopilotConfigUpdatePayload,
-  AutopilotConfigUpdateResponse,
   AutopilotConfigEvaluateParams,
   AutopilotConfigEvaluatePayload,
   AutopilotConfigEvaluateResponse,
@@ -22,9 +15,9 @@ import {
   AutopilotTriggerParams,
   AutopilotTriggerPayload,
   AutopilotTriggerResponse,
-  autopilotConfigRoute,
   autopilotStateRoute,
   autopilotTriggerRoute,
+  autopilotConfigEvaluateRoute,
 } from '@siafoundation/renterd-types'
 
 export function useAutopilotState(
@@ -36,37 +29,6 @@ export function useAutopilotState(
   })
 }
 
-export function useAutopilotConfig(
-  args?: HookArgsSwr<AutopilotConfigParams, AutopilotConfigResponse>
-) {
-  return useGetSwr({
-    ...args,
-    route: autopilotConfigRoute,
-  })
-}
-
-export function useAutopilotConfigUpdate(
-  args?: HookArgsCallback<
-    AutopilotConfigUpdateParams,
-    AutopilotConfigUpdatePayload,
-    AutopilotConfigUpdateResponse
-  >
-) {
-  return usePutFunc(
-    { ...args, route: autopilotConfigRoute },
-    async (mutate) => {
-      mutate((key) => key === autopilotConfigRoute)
-      // Might need a delay before revalidating status which returns whether
-      // or not autopilot is configured.
-      const func = async () => {
-        await delay(1000)
-        mutate((key) => key === autopilotStateRoute)
-      }
-      func()
-    }
-  )
-}
-
 export function useAutopilotConfigEvaluate(
   args: HookArgsWithPayloadSwr<
     AutopilotConfigEvaluateParams,
@@ -74,7 +36,7 @@ export function useAutopilotConfigEvaluate(
     AutopilotConfigEvaluateResponse
   >
 ) {
-  return usePostSwr({ ...args, route: autopilotConfigRoute })
+  return usePostSwr({ ...args, route: autopilotConfigEvaluateRoute })
 }
 
 export function useAutopilotTrigger(

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -21,6 +21,12 @@ import {
   AlertsDismissResponse,
   AlertsParams,
   AlertsResponse,
+  AutopilotConfigParams,
+  AutopilotConfigResponse,
+  AutopilotConfigUpdateParams,
+  AutopilotConfigUpdatePayload,
+  AutopilotConfigUpdateResponse,
+  busAutopilotRoute,
   BucketCreateParams,
   BucketCreatePayload,
   BucketCreateResponse,
@@ -247,6 +253,7 @@ import {
   HostScanResponse,
   busHostHostKeyScanRoute,
   Host,
+  autopilotStateRoute,
 } from '@siafoundation/renterd-types'
 
 // state
@@ -1023,4 +1030,34 @@ export function useMultipartUploadAddPart(
       })
     }
   )
+}
+
+// autopilot
+
+export function useAutopilotConfig(
+  args?: HookArgsSwr<AutopilotConfigParams, AutopilotConfigResponse>
+) {
+  return useGetSwr({
+    ...args,
+    route: busAutopilotRoute,
+  })
+}
+
+export function useAutopilotConfigUpdate(
+  args?: HookArgsCallback<
+    AutopilotConfigUpdateParams,
+    AutopilotConfigUpdatePayload,
+    AutopilotConfigUpdateResponse
+  >
+) {
+  return usePutFunc({ ...args, route: busAutopilotRoute }, async (mutate) => {
+    mutate((key) => key === busAutopilotRoute)
+    // Might need a delay before revalidating status which returns whether
+    // or not autopilot is configured.
+    const func = async () => {
+      await delay(1000)
+      mutate((key) => key === autopilotStateRoute)
+    }
+    func()
+  })
 }

--- a/libs/renterd-types/src/autopilot.ts
+++ b/libs/renterd-types/src/autopilot.ts
@@ -2,8 +2,9 @@ import { BuildState } from './bus'
 import { AutopilotConfig, SettingsGouging, SettingsRedundancy } from './types'
 
 export const autopilotStateRoute = '/autopilot/state'
-export const autopilotConfigRoute = '/autopilot/config'
+export const autopilotConfigEvaluateRoute = '/autopilot/config/evaluate'
 export const autopilotTriggerRoute = '/autopilot/trigger'
+export const busAutopilotRoute = '/bus/autopilot'
 
 type AutopilotStatus = {
   id: string

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -225,7 +225,6 @@ export type HostsParams = void
 export type HostsFilterMode = 'all' | 'allowed' | 'blocked'
 export type HostsUsabilityMode = 'all' | 'usable' | 'unusable'
 export type HostsPayload = {
-  autopilotID?: string
   filterMode: HostsFilterMode
   usabilityMode?: HostsUsabilityMode
   addressContains?: string

--- a/libs/renterd-types/src/types.ts
+++ b/libs/renterd-types/src/types.ts
@@ -186,7 +186,7 @@ export type Host = {
   storedData: number
   resolvedAddresses?: string[]
   subnets?: string[]
-  checks?: Record<string, HostAutopilotChecks>
+  checks?: HostAutopilotChecks
 }
 
 export type HostAutopilotChecks = {


### PR DESCRIPTION
- Autopilot config routes moved to the bus.
- The host checks field is now just HostAutopilotChecks.
- Removed the autopilotID parameter from the hosts API.