### PR TITLE
refactor(renterd): autopilot move from configured to enabled

### DIFF
--- a/.changeset/dirty-pianos-laugh.md
+++ b/.changeset/dirty-pianos-laugh.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/renterd-js': minor
+'@siafoundation/renterd-react': minor
+'@siafoundation/renterd-types': minor
+---
+
+The configured boolean was removed from AutopilotState.

--- a/.changeset/five-fireants-nail.md
+++ b/.changeset/five-fireants-nail.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Uploading files is no longer disabled if the user has not configured their settings.

--- a/.changeset/forty-months-sin.md
+++ b/.changeset/forty-months-sin.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The configuration page navbar now has a switch for enabling or disabling autopilot.

--- a/.changeset/honest-rats-cough.md
+++ b/.changeset/honest-rats-cough.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The configuration no longer fills Sia Central network averages for max prices during first time configuration.

--- a/.changeset/selfish-lemons-divide.md
+++ b/.changeset/selfish-lemons-divide.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The file explorer warnings now include a warning for when autopilot is disabled, the warning relating to configuration status was removed.

--- a/.changeset/shy-chicken-judge.md
+++ b/.changeset/shy-chicken-judge.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The onboarding bar no longer shows depending on the status of configuration but the first step still suggests configuring settings and enabling autopilot.

--- a/.changeset/sweet-chicken-suffer.md
+++ b/.changeset/sweet-chicken-suffer.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+If the autopilot is disabling a warning will appear on the bottom dock. The widget includes a switch for re-enabling the autopilot.

--- a/apps/renterd/components/Config/ConfigNav.tsx
+++ b/apps/renterd/components/Config/ConfigNav.tsx
@@ -1,3 +1,11 @@
+import { ConfigEnabledSwitch } from '../ConfigEnabledSwitch'
+
 export function ConfigNav() {
-  return <div className="pl-1"></div>
+  return (
+    <div className="pl-1">
+      <div className="flex items-center gap-2">
+        <ConfigEnabledSwitch size="small" />
+      </div>
+    </div>
+  )
 }

--- a/apps/renterd/components/ConfigEnabledSwitch.tsx
+++ b/apps/renterd/components/ConfigEnabledSwitch.tsx
@@ -1,0 +1,39 @@
+import { Switch, Tooltip } from '@siafoundation/design-system'
+import {
+  useAutopilotConfig,
+  useAutopilotConfigUpdate,
+} from '@siafoundation/renterd-react'
+import { useCallback } from 'react'
+
+type Props = {
+  size: 'small' | 'medium'
+}
+
+export function ConfigEnabledSwitch({ size }: Props) {
+  const autopilotConfigUpdate = useAutopilotConfigUpdate()
+  const autopilotConfig = useAutopilotConfig()
+
+  const toggleEnabled = useCallback(() => {
+    if (!autopilotConfig.data) {
+      return
+    }
+    autopilotConfigUpdate.put({
+      payload: {
+        ...autopilotConfig.data,
+        enabled: !autopilotConfig.data?.enabled,
+      },
+    })
+  }, [autopilotConfig.data, autopilotConfigUpdate])
+
+  return (
+    <Tooltip content="Enable or disable the system autopilot which handles forming contracts and maintaining files.">
+      <div>
+        <Switch
+          size={size}
+          checked={!!autopilotConfig.data?.enabled}
+          onCheckedChange={toggleEnabled}
+        />
+      </div>
+    </Tooltip>
+  )
+}

--- a/apps/renterd/components/DockedControls.tsx
+++ b/apps/renterd/components/DockedControls.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { OnboardingBar } from './OnboardingBar'
 import { TransfersBar } from './TransfersBar'
+import { EnabledBar } from './EnabledBar'
 
 export function DockedControls({ children }: { children?: React.ReactNode }) {
   return (
@@ -8,6 +9,7 @@ export function DockedControls({ children }: { children?: React.ReactNode }) {
       {children}
       <TransfersBar />
       <OnboardingBar />
+      <EnabledBar />
     </div>
   )
 }

--- a/apps/renterd/components/EnabledBar.tsx
+++ b/apps/renterd/components/EnabledBar.tsx
@@ -1,0 +1,38 @@
+import { AppDockedControl, Panel, Text } from '@siafoundation/design-system'
+import { useAutopilotConfig } from '@siafoundation/renterd-react'
+import { ConfigEnabledSwitch } from './ConfigEnabledSwitch'
+import { Warning24 } from '@carbon/icons-react'
+
+export function EnabledBar() {
+  const autopilotConfig = useAutopilotConfig()
+
+  if (!autopilotConfig.data) {
+    return <AppDockedControl />
+  }
+
+  if (autopilotConfig.data.enabled) {
+    return <AppDockedControl />
+  }
+
+  return (
+    <AppDockedControl>
+      <div className="flex justify-center">
+        <Panel className="w-[400px] flex flex-col gap-2 max-h-[600px] p-3">
+          <div className="flex gap-1 items-center">
+            <Text size="18" weight="medium" color="contrast">
+              <Warning24 />
+            </Text>
+            <Text size="18" weight="medium" color="contrast">
+              Autopilot is currently disabled
+            </Text>
+            <div className="flex-1" />
+            <ConfigEnabledSwitch size="medium" />
+          </div>
+          <Text size="12" color="subtle">
+            Enable autopilot to form contracts and maintain files.
+          </Text>
+        </Panel>
+      </div>
+    </AppDockedControl>
+  )
+}

--- a/apps/renterd/components/Files/FilesStatsMenuShared/FilesStatsMenuWarnings.tsx
+++ b/apps/renterd/components/Files/FilesStatsMenuShared/FilesStatsMenuWarnings.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Code,
   Paragraph,
   Popover,
   Separator,
@@ -9,12 +8,12 @@ import {
 import { Warning16 } from '@siafoundation/react-icons'
 import { useMemo } from 'react'
 import { useSyncStatus } from '../../../hooks/useSyncStatus'
-import { useAutopilotNotConfigured } from '../checks/useAutopilotNotConfigured'
+import { useAutopilotNotEnabled } from '../checks/useAutopilotNotConfigured'
 import { useNotEnoughContracts } from '../checks/useNotEnoughContracts'
 
 export function FilesStatsMenuWarnings() {
   const syncStatus = useSyncStatus()
-  const autopilotNotConfigured = useAutopilotNotConfigured()
+  const autopilotNotEnabled = useAutopilotNotEnabled()
   const notEnoughContracts = useNotEnoughContracts()
 
   const syncStatusEl = useMemo(() => {
@@ -34,24 +33,22 @@ export function FilesStatsMenuWarnings() {
     return null
   }, [syncStatus.isSynced])
 
-  const autopilotNotConfiguredEl = useMemo(() => {
-    if (autopilotNotConfigured.active) {
+  const autopilotNotEnabledEl = useMemo(() => {
+    if (autopilotNotEnabled.active) {
       return (
         <div key="autopilotNotConfigured" className="flex flex-col gap-1">
           <Text size="12" font="mono" weight="medium" color="amber">
-            Uploads are disabled until settings are configured.
+            Autopilot is currently disabled.
           </Text>
           <Paragraph size="12">
-            Before you can upload files you must configure your settings. Once
-            configured, <Code>renterd</Code> will find contracts with hosts
-            based on the settings you choose. <Code>renterd</Code> will also
-            repair your data as hosts come and go.
+            Files and contracts will not be automatically maintained while
+            autopilot is disabled.
           </Paragraph>
         </div>
       )
     }
     return null
-  }, [autopilotNotConfigured.active])
+  }, [autopilotNotEnabled.active])
 
   const notEnoughContractsEl = useMemo(() => {
     if (notEnoughContracts.active) {
@@ -73,10 +70,10 @@ export function FilesStatsMenuWarnings() {
 
   const warningList = useMemo(
     () =>
-      [syncStatusEl, autopilotNotConfiguredEl, notEnoughContractsEl].filter(
+      [syncStatusEl, autopilotNotEnabledEl, notEnoughContractsEl].filter(
         Boolean
       ),
-    [syncStatusEl, autopilotNotConfiguredEl, notEnoughContractsEl]
+    [syncStatusEl, autopilotNotEnabledEl, notEnoughContractsEl]
   )
 
   if (warningList.length)

--- a/apps/renterd/components/Files/checks/useAutopilotNotConfigured.tsx
+++ b/apps/renterd/components/Files/checks/useAutopilotNotConfigured.tsx
@@ -1,8 +1,8 @@
-import { useAutopilotState } from '@siafoundation/renterd-react'
+import { useAutopilotConfig } from '@siafoundation/renterd-react'
 
-export function useAutopilotNotConfigured() {
-  const autopilotState = useAutopilotState()
+export function useAutopilotNotEnabled() {
+  const autopilotConfig = useAutopilotConfig()
   return {
-    active: !autopilotState.data?.configured,
+    active: !autopilotConfig.data?.enabled,
   }
 }

--- a/apps/renterd/components/Files/useCanUpload.tsx
+++ b/apps/renterd/components/Files/useCanUpload.tsx
@@ -1,17 +1,10 @@
 import { useSyncStatus } from '../../hooks/useSyncStatus'
 import { useFilesManager } from '../../contexts/filesManager'
-import { useAutopilotNotConfigured } from './checks/useAutopilotNotConfigured'
 import { useNotEnoughContracts } from './checks/useNotEnoughContracts'
 
 export function useCanUpload() {
   const { isViewingABucket } = useFilesManager()
   const syncStatus = useSyncStatus()
-  const autopilotNotConfigured = useAutopilotNotConfigured()
   const notEnoughContracts = useNotEnoughContracts()
-  return (
-    isViewingABucket &&
-    !autopilotNotConfigured.active &&
-    !notEnoughContracts.active &&
-    syncStatus.isSynced
-  )
+  return isViewingABucket && !notEnoughContracts.active && syncStatus.isSynced
 }

--- a/apps/renterd/components/FilesDirectory/EmptyState/index.tsx
+++ b/apps/renterd/components/FilesDirectory/EmptyState/index.tsx
@@ -2,7 +2,7 @@ import { Code, LinkButton, Text } from '@siafoundation/design-system'
 import { CloudUpload32 } from '@siafoundation/react-icons'
 import { routes } from '../../../config/routes'
 import { useFilesDirectory } from '../../../contexts/filesDirectory'
-import { useAutopilotNotConfigured } from '../../Files/checks/useAutopilotNotConfigured'
+import { useAutopilotNotEnabled } from '../../Files/checks/useAutopilotNotConfigured'
 import { useNotEnoughContracts } from '../../Files/checks/useNotEnoughContracts'
 import { StateError } from './StateError'
 import { StateNoneMatching } from './StateNoneMatching'
@@ -14,7 +14,7 @@ export function EmptyState() {
   const { isViewingRootOfABucket, isViewingBuckets } = useFilesManager()
   const { dataState } = useFilesDirectory()
 
-  const autopilotNotConfigured = useAutopilotNotConfigured()
+  const autopilotNotEnabled = useAutopilotNotEnabled()
   const notEnoughContracts = useNotEnoughContracts()
 
   if (dataState === 'noneMatchingFilters') {
@@ -29,7 +29,7 @@ export function EmptyState() {
   if (
     isViewingRootOfABucket &&
     dataState === 'noneYet' &&
-    autopilotNotConfigured.active
+    autopilotNotEnabled.active
   ) {
     return (
       <div className="flex flex-col gap-10 justify-center items-center h-[400px] cursor-pointer">
@@ -38,9 +38,9 @@ export function EmptyState() {
         </Text>
         <div className="flex flex-col gap-6 justify-center items-center">
           <Text color="subtle" className="text-center max-w-[500px]">
-            Before you can upload files you must configure your settings. Once
-            configured, <Code>renterd</Code> will find contracts with hosts
-            based on the settings you choose. <Code>renterd</Code> will also
+            Before you can upload files you must configure and enable your
+            settings. Once enabled, <Code>renterd</Code> will find contracts
+            with hosts based on the settings. <Code>renterd</Code> will also
             repair your data as hosts come and go.
           </Text>
           <LinkButton variant="accent" href={routes.config.index}>

--- a/apps/renterd/components/OnboardingBar.tsx
+++ b/apps/renterd/components/OnboardingBar.tsx
@@ -19,7 +19,7 @@ import { useSyncStatus } from '../hooks/useSyncStatus'
 import { routes } from '../config/routes'
 import { useDialog } from '../contexts/dialog'
 import { useNotEnoughContracts } from './Files/checks/useNotEnoughContracts'
-import { useAutopilotState, useWallet } from '@siafoundation/renterd-react'
+import { useWallet } from '@siafoundation/renterd-react'
 import BigNumber from 'bignumber.js'
 import { humanSiacoin } from '@siafoundation/units'
 import { useAppSettings } from '@siafoundation/react-core'
@@ -28,7 +28,6 @@ import { useSpendingEstimate } from '../contexts/config/useSpendingEstimate'
 
 export function OnboardingBar() {
   const { isUnlockedAndAuthedRoute } = useAppSettings()
-  const autopilotState = useAutopilotState()
   const { openDialog } = useDialog()
   const wallet = useWallet()
   const [maximized, setMaximized] = useLocalStorageState<boolean>(
@@ -50,7 +49,7 @@ export function OnboardingBar() {
     wallet.data ? wallet.data.confirmed + wallet.data.unconfirmed : 0
   )
 
-  const step1Configured = autopilotState.data?.configured
+  const step1Configured = true
   const step2Synced = syncStatus.isSynced
   const step3Funded = walletBalance.gt(0)
   const step4Contracts = !notEnoughContracts.active
@@ -101,23 +100,12 @@ export function OnboardingBar() {
                   </Link>
                 }
                 description={
-                  'Specify how much data you plan to store and your target price.'
+                  'Specify your estimated usage and maximum pricing values.'
                 }
                 action={
-                  step1Configured ? (
-                    <Text color="green">
-                      <CheckmarkFilled16 />
-                    </Text>
-                  ) : (
-                    <>
-                      <Link href={routes.config.index}>
-                        <Launch16 />
-                      </Link>
-                      <Text color="amber">
-                        <RadioButton16 />
-                      </Text>
-                    </>
-                  )
+                  <Link href={routes.config.index}>
+                    <Launch16 />
+                  </Link>
                 }
               />
               <Section

--- a/apps/renterd/contexts/config/index.tsx
+++ b/apps/renterd/contexts/config/index.tsx
@@ -19,15 +19,8 @@ import {
 } from './useResources'
 
 export function useConfigMain() {
-  const {
-    autopilotState,
-    autopilot,
-    gouging,
-    pinned,
-    upload,
-    averages,
-    resources,
-  } = useResources()
+  const { autopilotState, autopilot, gouging, pinned, upload, resources } =
+    useResources()
 
   const {
     form,
@@ -45,12 +38,10 @@ export function useConfigMain() {
       return undefined
     }
     return transformDown({
-      hasBeenConfigured: !!loaded.autopilotState.data?.configured,
       autopilot: loaded.autopilot.data,
       gouging: loaded.gouging.data,
       pinned: loaded.pinned.data,
       upload: loaded.upload.data,
-      averages: loaded.averages.data,
     })
   }, [resources])
 
@@ -66,21 +57,19 @@ export function useConfigMain() {
     const _gouging = await gouging.mutate()
     const _pinned = await pinned.mutate()
     const _upload = await upload.mutate()
-    if (!_autopilotState || !_gouging || !_upload || !_pinned) {
+    if (!_autopilotState || !_autopilot || !_gouging || !_upload || !_pinned) {
       triggerErrorToast({ title: 'Error fetching settings' })
       return undefined
     }
     form.reset(
       transformDown({
-        hasBeenConfigured: _autopilotState.configured,
         autopilot: _autopilot,
         gouging: _gouging,
         pinned: _pinned,
         upload: _upload,
-        averages: averages.data,
       })
     )
-  }, [form, autopilotState, autopilot, gouging, pinned, upload, averages.data])
+  }, [form, autopilotState, autopilot, gouging, pinned, upload])
 
   useFormInit({
     form,

--- a/apps/renterd/contexts/config/transformDown.ts
+++ b/apps/renterd/contexts/config/transformDown.ts
@@ -79,60 +79,11 @@ export function transformDownAutopilot(
   }
 }
 
-function firstTimeGougingData({
-  gouging,
-  averages,
-  hasBeenConfigured,
-}: {
-  gouging: SettingsGouging
-  averages?: {
-    settings: {
-      download_price: string
-      storage_price: string
-      upload_price: string
-    }
-  }
-  hasBeenConfigured: boolean
-}): SettingsGouging {
-  // Already configured, the user has changed the defaults.
-  if (hasBeenConfigured) {
-    return gouging
-  }
-  // If sia central is disabled, we cant override with averages.
-  if (!averages) {
-    return gouging
-  }
-  return {
-    ...gouging,
-    maxStoragePrice: averages.settings.storage_price,
-    maxDownloadPrice: new BigNumber(
-      averages.settings.download_price
-    ).toString(),
-    maxUploadPrice: new BigNumber(averages.settings.upload_price).toString(),
-  }
-}
-
 export function transformDownGouging({
-  gouging: _gouging,
-  averages,
-  hasBeenConfigured,
+  gouging,
 }: {
   gouging: SettingsGouging
-  averages?: {
-    settings: {
-      download_price: string
-      storage_price: string
-      upload_price: string
-    }
-  }
-  hasBeenConfigured: boolean
 }): ValuesGouging {
-  const gouging = firstTimeGougingData({
-    gouging: _gouging,
-    averages,
-    hasBeenConfigured,
-  })
-
   return {
     maxStoragePriceTBMonth: toSiacoins(
       valuePerBytePerBlockToPerTBPerMonth(
@@ -198,27 +149,17 @@ export function transformDownUpload(u: SettingsUpload): ValuesUpload {
 }
 
 export type RemoteData = {
-  hasBeenConfigured: boolean
-  autopilot: AutopilotConfig | undefined
+  autopilot: AutopilotConfig
   gouging: SettingsGouging
   pinned: SettingsPinned
   upload: SettingsUpload
-  averages?: {
-    settings: {
-      download_price: string
-      storage_price: string
-      upload_price: string
-    }
-  }
 }
 
 export function transformDown({
-  hasBeenConfigured,
   autopilot,
   gouging,
   pinned,
   upload,
-  averages,
 }: RemoteData): InputValues {
   return {
     // autopilot
@@ -226,8 +167,6 @@ export function transformDown({
     // gouging
     ...transformDownGouging({
       gouging,
-      averages,
-      hasBeenConfigured,
     }),
     // pinning
     ...transformDownPinned(pinned),

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -38,8 +38,7 @@ import { objectEntries } from '@siafoundation/design-system'
 export function transformUpAutopilot(
   network: 'mainnet' | 'zen' | 'anagami',
   values: SubmitValuesAutopilot,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  existingValues: AutopilotConfig | undefined
+  existingValues: AutopilotConfig
 ): AutopilotConfig {
   const v = applyDefaultToAnyEmptyValues(
     values,
@@ -48,8 +47,6 @@ export function transformUpAutopilot(
 
   return {
     ...existingValues,
-    enabled:
-      existingValues?.enabled !== undefined ? existingValues.enabled : true,
     contracts: {
       ...existingValues?.contracts,
       amount: Math.round(v.amountHosts.toNumber()),

--- a/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
+++ b/apps/renterd/contexts/config/useAutopilotEvaluations.tsx
@@ -53,9 +53,6 @@ export function useAutopilotEvaluations({
     if (!renterdState.data) {
       return false
     }
-    if (!loaded.autopilotState.data.configured) {
-      return false
-    }
     return true
   }, [form.formState.isValid, resources, renterdState.data])
 
@@ -250,8 +247,6 @@ export function useAutopilotEvaluations({
 
     const recommended = transformDownGouging({
       gouging: recommendedGougingSettings,
-      averages: resources.averages.data,
-      hasBeenConfigured: true,
     })
     const recommendedPinned = pricesToPinnedPrices({
       exchangeRate: rate,
@@ -297,7 +292,6 @@ export function useAutopilotEvaluations({
     return recs
   }, [
     recommendedGougingSettings,
-    resources,
     payloads,
     currentValuesWithPinnedOverridesAndDefaults,
     getIsFieldEnabled,

--- a/apps/renterd/contexts/config/useOnValid.tsx
+++ b/apps/renterd/contexts/config/useOnValid.tsx
@@ -38,7 +38,6 @@ export function useOnValid({
       if (!loaded || !renterdState.data) {
         return
       }
-      const firstTimeSettingConfig = !loaded.autopilotState.data?.configured
 
       const { payloads } = transformUp({
         resources: loaded,
@@ -80,17 +79,11 @@ export function useOnValid({
 
       triggerSuccessToast({ title: 'Configuration has been saved' })
 
-      // If autopilot is being configured for the first time,
-      // revalidate the empty hosts list.
-      if (firstTimeSettingConfig) {
-        const refreshHostsAfterDelay = async () => {
-          await delay(5_000)
-          mutate((key) => key.startsWith(busHostsRoute))
-          await delay(5_000)
-          mutate((key) => key.startsWith(busHostsRoute))
-        }
-        refreshHostsAfterDelay()
+      const refreshHostsAfterDelay = async () => {
+        await delay(5_000)
+        mutate((key) => key.startsWith(busHostsRoute))
       }
+      refreshHostsAfterDelay()
 
       await revalidateAndResetForm()
     },

--- a/apps/renterd/contexts/config/useResources.tsx
+++ b/apps/renterd/contexts/config/useResources.tsx
@@ -13,8 +13,6 @@ import {
   useSettingsPinned,
   useSettingsUpload,
 } from '@siafoundation/renterd-react'
-import { useSiaCentralHostsNetworkAverages } from '@siafoundation/sia-central-react'
-import { SiaCentralHostsNetworkAveragesResponse } from '@siafoundation/sia-central-types'
 import { minutesInMilliseconds } from '@siafoundation/units'
 import { useMemo } from 'react'
 
@@ -26,16 +24,13 @@ export function useResources() {
       },
     },
   })
-  // Settings that 404 when empty.
   const autopilot = useAutopilotConfig({
     config: {
       swr: {
-        errorRetryCount: 0,
         refreshInterval: minutesInMilliseconds(1),
       },
     },
   })
-  // Settings with initial defaults.
   const gouging = useSettingsGouging({
     config: {
       swr: {
@@ -54,13 +49,6 @@ export function useResources() {
     config: {
       swr: {
         refreshInterval: minutesInMilliseconds(1),
-      },
-    },
-  })
-  const averages = useSiaCentralHostsNetworkAverages({
-    config: {
-      swr: {
-        revalidateOnFocus: false,
       },
     },
   })
@@ -90,10 +78,6 @@ export function useResources() {
         data: upload.data,
         error: upload.error,
       },
-      averages: {
-        data: averages.data,
-        error: averages.error,
-      },
       appSettings: {
         settings: {
           siaCentral: appSettings.settings.siaCentral,
@@ -111,8 +95,6 @@ export function useResources() {
       pinned.error,
       upload.data,
       upload.error,
-      averages.data,
-      averages.error,
       appSettings.settings.siaCentral,
     ]
   )
@@ -124,7 +106,6 @@ export function useResources() {
     gouging,
     pinned,
     upload,
-    averages,
     appSettings,
   }
 }
@@ -132,21 +113,16 @@ export function useResources() {
 export function checkIfAllResourcesLoaded(resources: ResourcesMaybeLoaded) {
   const { autopilotState, autopilot, gouging, pinned, upload } = resources
   const loaded = !!(
-    // These settings have initial daemon values.
-    (
-      autopilotState.data &&
-      !autopilotState.error &&
-      gouging.data &&
-      !gouging.error &&
-      pinned.data &&
-      !pinned.error &&
-      upload.data &&
-      !upload.error &&
-      // These settings are undefined and will error until the user sets them.
-      (autopilot.data || autopilot.error)
-    )
-    // We do not wait for exchange rate or averages to load,
-    // in case the third party API is down.
+    autopilotState.data &&
+    !autopilotState.error &&
+    autopilot.data &&
+    !autopilot.error &&
+    gouging.data &&
+    !gouging.error &&
+    pinned.data &&
+    !pinned.error &&
+    upload.data &&
+    !upload.error
   )
   if (loaded) {
     return resources as ResourcesRequiredLoaded
@@ -186,10 +162,6 @@ export type ResourcesMaybeLoaded = {
     data?: SettingsUpload
     error?: SWRError
   }
-  averages: {
-    data?: SiaCentralHostsNetworkAveragesResponse
-    error?: SWRError
-  }
   appSettings: {
     settings: {
       siaCentral: boolean
@@ -203,7 +175,7 @@ export type ResourcesRequiredLoaded = {
     error?: SWRError
   }
   autopilot: {
-    data?: AutopilotConfig
+    data: AutopilotConfig
     error?: SWRError
   }
   gouging: {
@@ -217,10 +189,6 @@ export type ResourcesRequiredLoaded = {
   upload: {
     data: SettingsUpload
     error?: undefined
-  }
-  averages: {
-    data?: SiaCentralHostsNetworkAveragesResponse
-    error?: SWRError
   }
   appSettings: {
     settings: {

--- a/apps/renterd/contexts/hosts/columns.tsx
+++ b/apps/renterd/contexts/hosts/columns.tsx
@@ -120,18 +120,7 @@ export const columns: HostsTableColumn[] = (
       id: 'ap_usable',
       label: 'usable',
       category: 'autopilot',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip side="right" content="Autopilot is not configured">
-              <div className="mt-[5px]">
-                <Text color="subtle">
-                  <UndefinedFilled16 />
-                </Text>
-              </div>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <Tooltip
             side="right"
@@ -166,18 +155,7 @@ export const columns: HostsTableColumn[] = (
       id: 'ap_gouging',
       label: 'gouging',
       category: 'autopilot',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip side="right" content="Autopilot is not configured">
-              <div className="mt-[5px]">
-                <Text color="subtle">
-                  <UndefinedFilled16 />
-                </Text>
-              </div>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <Tooltip
             side="right"
@@ -457,14 +435,7 @@ export const columns: HostsTableColumn[] = (
       label: 'overall score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -480,14 +451,7 @@ export const columns: HostsTableColumn[] = (
       label: 'age score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -503,14 +467,7 @@ export const columns: HostsTableColumn[] = (
       label: 'collateral score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -526,14 +483,7 @@ export const columns: HostsTableColumn[] = (
       label: 'interactions score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -549,14 +499,7 @@ export const columns: HostsTableColumn[] = (
       label: 'prices score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -572,14 +515,7 @@ export const columns: HostsTableColumn[] = (
       label: 'storage remaining score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -595,14 +531,7 @@ export const columns: HostsTableColumn[] = (
       label: 'uptime score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
@@ -618,22 +547,13 @@ export const columns: HostsTableColumn[] = (
       label: 'version score',
       category: 'autopilot',
       contentClassName: 'w-[120px] justify-end',
-      render: ({ data, context }) => {
-        if (!context.isAutopilotConfigured) {
-          return (
-            <Tooltip content="Autopilot is not configured">
-              <Text color="verySubtle">-</Text>
-            </Tooltip>
-          )
-        }
+      render: ({ data }) => {
         return (
           <ValueNum
             size="12"
             value={data.scoreBreakdown.version}
             variant="value"
-            format={(v) =>
-              context.isAutopilotConfigured ? '-' : v.toPrecision(2)
-            }
+            format={(v) => v.toPrecision(2)}
           />
         )
       },

--- a/apps/renterd/contexts/hosts/index.tsx
+++ b/apps/renterd/contexts/hosts/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@siafoundation/design-system'
 import { useAppSettings } from '@siafoundation/react-core'
 import {
-  useAutopilotState,
   useHostsAllowlist,
   useHostsBlocklist,
   useHosts as useHostsSearch,
@@ -53,7 +52,6 @@ function useHostsMain() {
     useServerFilters()
 
   const { dataset: allContracts } = useContracts()
-  const autopilotState = useAutopilotState()
 
   const keyIn = useMemo(() => {
     let keyIn: string[] = []
@@ -213,13 +211,11 @@ function useHostsMain() {
   const dataState = useDatasetEmptyState(dataset, isValidating, error, filters)
 
   const siascanUrl = useSiascanUrl()
-  const isAutopilotConfigured = !!autopilotState.data?.configured
   const tableContext: HostContext = useMemo(
     () => ({
-      isAutopilotConfigured,
       siascanUrl,
     }),
-    [isAutopilotConfigured, siascanUrl]
+    [siascanUrl]
   )
 
   const hostsWithLocation = useMemo(

--- a/apps/renterd/contexts/hosts/types.tsx
+++ b/apps/renterd/contexts/hosts/types.tsx
@@ -2,7 +2,7 @@ import { HostPriceTable, HostSettings } from '@siafoundation/types'
 import BigNumber from 'bignumber.js'
 import { ContractData } from '../contracts/types'
 
-export type HostContext = { isAutopilotConfigured: boolean; siascanUrl: string }
+export type HostContext = { siascanUrl: string }
 
 export type HostData = {
   id: string

--- a/libs/renterd-types/src/autopilot.ts
+++ b/libs/renterd-types/src/autopilot.ts
@@ -6,9 +6,8 @@ export const autopilotConfigEvaluateRoute = '/autopilot/config/evaluate'
 export const autopilotTriggerRoute = '/autopilot/trigger'
 export const busAutopilotRoute = '/bus/autopilot'
 
-type AutopilotStatus = {
-  id: string
-  configured: boolean
+export type AutopilotState = {
+  enabled: boolean
   migrating: boolean
   migratingLastStart: string
   pruning: boolean
@@ -17,9 +16,7 @@ type AutopilotStatus = {
   scanningLastStart: string
   uptimeMS: string
   startTime: number
-}
-
-export type AutopilotState = AutopilotStatus & BuildState
+} & BuildState
 
 export type AutopilotStateParams = void
 export type AutopilotStatePayload = void


### PR DESCRIPTION
- The configured boolean was removed from AutopilotState.
- Uploading files is no longer disabled if the user has not configured their settings.
- The configuration page navbar now has a switch for enabling or disabling autopilot.
- The file explorer warnings now include a warning for when autopilot is disabled, the warning relating to configuration status was removed.
- The onboarding bar no longer shows depending on the status of configuration but the first step still suggests configuring settings and enabling autopilot.
- If the autopilot is disabling a warning will appear on the bottom dock. The widget includes a switch for re-enabling the autopilot.
- The configuration no longer fills Sia Central network averages for max prices during first time configuration.


![Screenshot 2024-11-26 at 2.35.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/aca32100-326e-44f9-8249-863b23a864a6.png)

![Screenshot 2024-11-26 at 2.34.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/83d3370f-44ce-4c37-97f0-5e211a7449fc.png)

![Screenshot 2024-11-26 at 2.17.05 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/0efb57fa-6ed9-4dcf-951e-98b8d4debd6d.png)