### PR TITLE
fix(hostd): home metrics graph width

### DIFF
--- a/.changeset/green-baboons-sip.md
+++ b/.changeset/green-baboons-sip.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+Fixed an issue where the metrics graphs were much wider than the screen. Closes https://github.com/SiaFoundation/hostd/issues/500

--- a/.changeset/spotty-chefs-hang.md
+++ b/.changeset/spotty-chefs-hang.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fixed a bug with ScrollArea where it would adopt its contents width.

--- a/apps/hostd/components/Home/HomeBandwidth.tsx
+++ b/apps/hostd/components/Home/HomeBandwidth.tsx
@@ -11,9 +11,9 @@ import { useMetrics } from '../../contexts/metrics'
 export function HomeBandwidth() {
   const { bandwidth } = useMetrics()
   return (
-    <div className="flex flex-col gap-3 flex-1 overflow-hidden">
+    <div className="flex flex-col gap-3 flex-1">
       <Heading>Bandwidth</Heading>
-      <DatumScrollArea>
+      <DatumScrollArea bleed>
         <DatumCardConfigurable
           category="bandwidth"
           label="ingress"

--- a/apps/hostd/components/Home/HomeOperations.tsx
+++ b/apps/hostd/components/Home/HomeOperations.tsx
@@ -11,46 +11,44 @@ import { useMetrics } from '../../contexts/metrics'
 export function HomeOperations() {
   const { operations } = useMetrics()
   return (
-    <div className="flex gap-3">
-      <div className="flex flex-col gap-3 flex-1 overflow-hidden">
-        <Heading>Operations</Heading>
-        <DatumScrollArea>
-          <DatumCardConfigurable
-            category="operations"
-            label="storage reads"
-            color={operations.config.data['storageReads'].color}
-            value={operations.stats['storageReads']}
-            defaultMode="total"
-            isLoading={operations.isLoading}
-            enabledModes={['total', 'average', 'latest']}
-            valueFormat={humanNumber}
-          />
-          <DatumCardConfigurable
-            category="operations"
-            label="storage writes"
-            color={operations.config.data['storageWrites'].color}
-            value={operations.stats['storageWrites']}
-            defaultMode="total"
-            isLoading={operations.isLoading}
-            enabledModes={['total', 'average', 'latest']}
-            valueFormat={humanNumber}
-          />
-        </DatumScrollArea>
-        <ChartXY
-          id="hostd/v0/metrics/graphs/operations"
-          height={300}
-          data={operations.data}
-          config={operations.config}
+    <div className="flex flex-col gap-3 flex-1">
+      <Heading>Operations</Heading>
+      <DatumScrollArea bleed>
+        <DatumCardConfigurable
+          category="operations"
+          label="storage reads"
+          color={operations.config.data['storageReads'].color}
+          value={operations.stats['storageReads']}
+          defaultMode="total"
           isLoading={operations.isLoading}
-          actionsLeft={
-            <>
-              <Text font="mono" weight="semibold">
-                Operations
-              </Text>
-            </>
-          }
+          enabledModes={['total', 'average', 'latest']}
+          valueFormat={humanNumber}
         />
-      </div>
+        <DatumCardConfigurable
+          category="operations"
+          label="storage writes"
+          color={operations.config.data['storageWrites'].color}
+          value={operations.stats['storageWrites']}
+          defaultMode="total"
+          isLoading={operations.isLoading}
+          enabledModes={['total', 'average', 'latest']}
+          valueFormat={humanNumber}
+        />
+      </DatumScrollArea>
+      <ChartXY
+        id="hostd/v0/metrics/graphs/operations"
+        height={300}
+        data={operations.data}
+        config={operations.config}
+        isLoading={operations.isLoading}
+        actionsLeft={
+          <>
+            <Text font="mono" weight="semibold">
+              Operations
+            </Text>
+          </>
+        }
+      />
     </div>
   )
 }

--- a/apps/hostd/components/Home/HomeStorage.tsx
+++ b/apps/hostd/components/Home/HomeStorage.tsx
@@ -11,9 +11,9 @@ import { useMetrics } from '../../contexts/metrics'
 export function HomeStorage() {
   const { storage } = useMetrics()
   return (
-    <div className="flex flex-col gap-3 flex-1 overflow-hidden">
+    <div className="flex flex-col gap-3 flex-1">
       <Heading>Storage</Heading>
-      <DatumScrollArea>
+      <DatumScrollArea bleed>
         <DatumCardConfigurable
           category="storage"
           label="storage - physical"

--- a/libs/design-system/src/core/ScrollArea.tsx
+++ b/libs/design-system/src/core/ScrollArea.tsx
@@ -23,8 +23,12 @@ export const ScrollArea = React.forwardRef<
     <ScrollAreaPrimitive.Viewport
       id={id}
       ref={ref}
-      // Temporary fix until removed upstream: https://github.com/radix-ui/primitives/issues/926
-      className="w-full h-full [&>div]:!block [&>div]:!h-full"
+      // Part 1: Temporary fix until removed upstream:
+      // https://github.com/radix-ui/primitives/issues/926
+      // Part 2: After updating radix there was an issues where the scroll area
+      // would adopt its contents width. The following fixed that:
+      // https://github.com/radix-ui/primitives/issues/3129
+      className="w-full h-full [&>div]:!min-w-0 [&>div]:!h-full"
     >
       {children}
     </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
- Fixed an issue where the metrics graphs were much wider than the screen. https://github.com/SiaFoundation/hostd/issues/500
- Fixed a bug with ScrollArea where it would adopt its contents width.

![Screenshot 2024-11-27 at 4.22.24 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/e17e0cd9-ec05-4b1d-a4ba-e1fce10d41b0.png)

