### PR TITLE
refactor(explorer): move faucet form from formik to react-hook-form

### DIFF
--- a/.changeset/brave-rules-beam.md
+++ b/.changeset/brave-rules-beam.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Refactored faucet form from formik to react-hook-form.


### PR DESCRIPTION
This replaces formik in the explorer faucet fund form. This doesn't remove the `formik` dependency, yet, because we still have these files using formik:

```
ContractsFilterContractIdDialog
ContractsFilterAddressDialog
ContractsFilterPublicKeyDialog
HostsFilterAddressDialog
HostsFilterPublicKeyDialog
AllowlistForm
BlocklistForm
FileCreateDirectoryDialog
WalletAddAddressDialog
```

I have one concern that I really haven't found the right solution for. I think a blue sky implementation of react-hook-form looks something like this:

```react
const { handleSubmit, register } = useForm<(<foo: string, bar: number)>()
const onSubmit = (data) => { data.foo... }

return <form onSubmit={handleSubmit(onSubmit)}>
         <input type="text" {...register('foo')} />
       </form>
```

In theory, this should extend react-hook-form's `FieldValues` to be properly typed and, for example, prevent trying to register a property that doesn't exist in the type or use a value of the wrong type. The problem? I can't figure out how to receive that type in the ReactHookForm component. I've tried pretty much everything I can think of, including a `T Extends FieldValues` approach, but it hasn't worked. In lieu of that panning out, this implementation does work-setting the type in the data of the `onSubmit`. But you won't be properly checked around registering and setting values the way you might be if we could receive the type correctly in the ReactHookFormField component's `FieldValues`. Open to ideas here, for sure.

Otherwise, this does remove `formik` for `react-hook-form` in the faucet form. There just may be a better way to type it on the component side which would somewhat affect this implementation.