### PR TITLE
refactor(renterd): min account expiry and min price table validity units

### DIFF
--- a/.changeset/rich-rats-try.md
+++ b/.changeset/rich-rats-try.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The min account expiry and min price table validity configuration settings are now stored in milliseconds.

--- a/.changeset/spicy-dots-wait.md
+++ b/.changeset/spicy-dots-wait.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/units': minor
+---
+
+Add and remove time methods.

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -270,9 +270,9 @@ describe('tansforms', () => {
           maxRPCPrice: '99970619000000000000000000',
           maxStoragePrice: '210531181019',
           maxUploadPrice: '1000232323000000',
-          minAccountExpiry: 86400000000000,
+          minAccountExpiry: 86400000,
           minMaxEphemeralAccountBalance: '1000000000000000000000000',
-          minPriceTableValidity: 300000000000,
+          minPriceTableValidity: 300000,
         })
       })
     })
@@ -503,9 +503,9 @@ function buildAllResponses() {
       maxRPCPrice: '99970619000000000000000000',
       maxStoragePrice: '210531181019',
       maxUploadPrice: '1000232323000000',
-      minAccountExpiry: 86400000000000,
+      minAccountExpiry: 86400000,
       minMaxEphemeralAccountBalance: '1000000000000000000000000',
-      minPriceTableValidity: 300000000000,
+      minPriceTableValidity: 300000,
     } as SettingsGouging,
     pinned: {
       currency: 'usd' as CurrencyId,

--- a/apps/renterd/contexts/config/transformDown.ts
+++ b/apps/renterd/contexts/config/transformDown.ts
@@ -8,8 +8,8 @@ import {
 import {
   blocksToWeeks,
   bytesToTB,
-  nanosecondsInDays,
-  nanosecondsInMinutes,
+  millisecondsInDays,
+  millisecondsInMinutes,
   toSiacoins,
   valuePerBytePerBlockToPerTBPerMonth,
   valuePerByteToPerTB,
@@ -106,10 +106,10 @@ export function transformDownGouging({
     ),
     hostBlockHeightLeeway: new BigNumber(gouging.hostBlockHeightLeeway),
     minPriceTableValidityMinutes: new BigNumber(
-      nanosecondsInMinutes(gouging.minPriceTableValidity)
+      millisecondsInMinutes(gouging.minPriceTableValidity)
     ),
     minAccountExpiryDays: new BigNumber(
-      nanosecondsInDays(gouging.minAccountExpiry)
+      millisecondsInDays(gouging.minAccountExpiry)
     ),
     minMaxEphemeralAccountBalance: toSiacoins(
       gouging.minMaxEphemeralAccountBalance,

--- a/apps/renterd/contexts/config/transformUp.ts
+++ b/apps/renterd/contexts/config/transformUp.ts
@@ -11,9 +11,9 @@ import {
   valuePerTBPerMonthToPerBytePerBlock,
   valuePerMonthToPerPeriod,
   valuePerMillionToPerOne,
-  daysInNanoseconds,
-  minutesInNanoseconds,
   valuePerTBToPerByte,
+  minutesInMilliseconds,
+  daysInMilliseconds,
 } from '@siafoundation/units'
 import {
   getAdvancedDefaultsAutopilot,
@@ -102,10 +102,10 @@ export function transformUpGouging(
     maxContractPrice: toHastings(v.maxContractPrice).toString(),
     hostBlockHeightLeeway: Math.round(v.hostBlockHeightLeeway.toNumber() || 0),
     minPriceTableValidity: Math.round(
-      minutesInNanoseconds(v.minPriceTableValidityMinutes.toNumber() || 0)
+      minutesInMilliseconds(v.minPriceTableValidityMinutes.toNumber() || 0)
     ),
     minAccountExpiry: Math.round(
-      daysInNanoseconds(v.minAccountExpiryDays.toNumber())
+      daysInMilliseconds(v.minAccountExpiryDays.toNumber())
     ),
     minMaxEphemeralAccountBalance: toHastings(
       v.minMaxEphemeralAccountBalance

--- a/libs/units/src/time.ts
+++ b/libs/units/src/time.ts
@@ -30,16 +30,16 @@ export function nowInMilliseconds() {
   return new Date().getTime()
 }
 
-export function nanosecondsInMinutes(ns: number) {
-  return ns / 1000 / 1000 / 1000 / 60
+export function millisecondsInMinutes(ms: number) {
+  return ms / 1000 / 60
 }
 
 export function millisecondsInHours(ms: number) {
-  return ms / 1000 / 1000 / 60 / 60
+  return ms / 1000 / 60 / 60
 }
 
-export function millisecondsInMinutes(ms: number) {
-  return ms / 1000 / 60
+export function millisecondsInDays(ms: number) {
+  return ms / 1000 / 60 / 60 / 24
 }
 
 export function microsecondsInMinutes(us: number) {


### PR DESCRIPTION
- The min account expiry and min price table validity configuration settings are now stored in milliseconds.