### PR TITLE
fix(renterd): first file download no bucket error

### DIFF
--- a/.changeset/late-points-learn.md
+++ b/.changeset/late-points-learn.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the first attempt to download a file would show a bucket not found error.

--- a/apps/renterd-e2e/src/specs/files.spec.ts
+++ b/apps/renterd-e2e/src/specs/files.spec.ts
@@ -111,6 +111,29 @@ test('can upload, rename, and delete files', async ({ page }) => {
   await deleteBucket(page, bucketName)
 })
 
+test('can upload and download a file', async ({ page }) => {
+  const bucketName = 'files-test'
+  const fileName = 'sample.txt'
+  const filePath = `${bucketName}/${fileName}`
+
+  // Create bucket.
+  await navigateToBuckets({ page })
+  await createBucket(page, bucketName)
+  await openBucket(page, bucketName)
+
+  // Upload.
+  await dragAndDropFileFromSystem(page, fileName)
+  await expect(page.getByText('100%')).toBeVisible()
+  await fileInList(page, filePath)
+
+  // Download.
+  await openFileContextMenu(page, filePath)
+  await page.getByRole('menuitem', { name: 'Download file' }).click()
+  await expect(
+    page.getByRole('button', { name: 'Active downloads' })
+  ).toBeVisible()
+})
+
 test('can rename and delete a directory with contents', async ({ page }) => {
   test.setTimeout(120_000)
   const bucketName = 'files-test'

--- a/apps/renterd/contexts/config/transform.spec.ts
+++ b/apps/renterd/contexts/config/transform.spec.ts
@@ -464,6 +464,7 @@ describe('tansforms', () => {
 function buildAllResponses() {
   return {
     autopilotState: {
+      enabled: true,
       migrating: true,
       migratingLastStart: new Date().toISOString(),
       scanning: true,


### PR DESCRIPTION
- Fixed an issue where the first attempt to download a file would show a bucket not found error.

### Notes
- Strange issue where buckets.data is still undefined in the closure even though the data has been fetched. Adding useCallback does the trick, oddly even just console logging buckets.data above downloadFiles fixes the issue.