### PR TITLE
refactor: visible columns

### DIFF
--- a/.changeset/cyan-lamps-hang.md
+++ b/.changeset/cyan-lamps-hang.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+useTableState now handles column filtering.

--- a/.changeset/silly-zebras-collect.md
+++ b/.changeset/silly-zebras-collect.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Renamed enabledColumns to visibleColumns and removed disabled categories from useTableState.

--- a/apps/hostd/components/Contracts/ContractsViewDropdownMenu.tsx
+++ b/apps/hostd/components/Contracts/ContractsViewDropdownMenu.tsx
@@ -30,7 +30,7 @@ export function ContractsViewDropdownMenu() {
     setSortField,
     sortDirection,
     setSortDirection,
-    enabledColumns,
+    visibleColumnIds,
   } = useContracts()
 
   const generalColumns = configurableColumns
@@ -128,42 +128,42 @@ export function ContractsViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>
       <MenuSectionLabelToggleAll
         label="Time"
         columns={timeColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={timeColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>
       <MenuSectionLabelToggleAll
         label="Usage"
         columns={financialColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={financialColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/hostd/components/Contracts/index.tsx
+++ b/apps/hostd/components/Contracts/index.tsx
@@ -6,7 +6,7 @@ import { StateError } from './StateError'
 
 export function Contracts() {
   const {
-    columns,
+    visibleColumns,
     datasetPage,
     sortField,
     sortDirection,
@@ -33,7 +33,7 @@ export function Contracts() {
         }
         pageSize={limit}
         data={datasetPage}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortDirection={sortDirection}
         sortField={sortField}

--- a/apps/hostd/components/Volumes/VolumesViewDropdownMenu.tsx
+++ b/apps/hostd/components/Volumes/VolumesViewDropdownMenu.tsx
@@ -21,7 +21,7 @@ export function VolumesViewDropdownMenu() {
     resetDefaultColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,
-    enabledColumns,
+    visibleColumnIds,
   } = useVolumes()
 
   const generalColumns = configurableColumns
@@ -68,28 +68,28 @@ export function VolumesViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>
       <MenuSectionLabelToggleAll
         label="Operations"
         columns={opsColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={opsColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/hostd/components/Volumes/index.tsx
+++ b/apps/hostd/components/Volumes/index.tsx
@@ -3,7 +3,7 @@ import { useVolumes } from '../../contexts/volumes'
 import { StateNoneYet } from './StateNoneYet'
 
 export function Volumes() {
-  const { dataset, datasetState, isLoading, columns } = useVolumes()
+  const { dataset, datasetState, isLoading, visibleColumns } = useVolumes()
   return (
     <div className="p-6 min-w-fit">
       <Table
@@ -11,7 +11,7 @@ export function Volumes() {
         isLoading={isLoading}
         pageSize={20}
         data={dataset}
-        columns={columns}
+        columns={visibleColumns}
         emptyState={
           <EmptyState datasetState={datasetState} noneYet={<StateNoneYet />} />
         }

--- a/apps/hostd/components/Wallet/index.tsx
+++ b/apps/hostd/components/Wallet/index.tsx
@@ -14,7 +14,7 @@ export function Wallet() {
     metrics,
     datasetPage,
     datasetState,
-    columns,
+    visibleColumns,
     cellContext,
     sortableColumns,
     sortDirection,
@@ -45,7 +45,7 @@ export function Wallet() {
         pageSize={defaultPageSize}
         data={datasetPage}
         context={cellContext}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortDirection={sortDirection}
         sortField={sortField}

--- a/apps/hostd/contexts/contracts/index.tsx
+++ b/apps/hostd/contexts/contracts/index.tsx
@@ -14,9 +14,7 @@ import {
   columnsDefaultVisible,
   ContractData,
   defaultSortField,
-  SortField,
   sortOptions,
-  TableColumnId,
 } from './types'
 import { columns } from './columns'
 import { useDataset } from './dataset'
@@ -33,7 +31,8 @@ function useContractsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -44,7 +43,7 @@ function useContractsMain() {
     sortField,
     sortDirection,
     resetDefaultColumnVisibility,
-  } = useTableState<TableColumnId, SortField>('hostd/v0/contracts', {
+  } = useTableState('hostd/v0/contracts', {
     columns,
     columnsDefaultVisible,
     sortOptions,
@@ -74,11 +73,6 @@ function useContractsMain() {
   const _datasetPage = useDataset({
     response,
   })
-
-  const filteredTableColumns = useMemo(
-    () => columns.filter((column) => enabledColumns.includes(column.id)),
-    [enabledColumns]
-  )
 
   const { estimatedBlockHeight, isSynced, nodeBlockHeight } = useSyncStatus()
   const currentHeight = isSynced ? nodeBlockHeight : estimatedBlockHeight
@@ -133,10 +127,10 @@ function useContractsMain() {
     cellContext,
     datasetPageTotal: datasetPage?.length || 0,
     datasetFilteredTotal: response.data?.count,
-    columns: filteredTableColumns,
+    visibleColumns,
     datasetPage,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/hostd/contexts/transactions/index.tsx
+++ b/apps/hostd/contexts/transactions/index.tsx
@@ -107,7 +107,8 @@ function useTransactionsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -124,14 +125,6 @@ function useTransactionsMain() {
     sortOptions,
     defaultSortField,
   })
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const siascanUrl = useSiascanUrl()
   const cellContext = useMemo<CellContext>(
@@ -190,7 +183,7 @@ function useTransactionsMain() {
     defaultPageSize,
     cellContext,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -206,8 +199,7 @@ function useTransactionsMain() {
     removeFilter,
     removeLastFilter,
     resetFilters,
-    filteredTableColumns,
-    columns,
+    visibleColumns,
   }
 }
 

--- a/apps/hostd/contexts/volumes/index.tsx
+++ b/apps/hostd/contexts/volumes/index.tsx
@@ -7,8 +7,8 @@ import {
 } from '@siafoundation/design-system'
 import { VolumeMeta } from '@siafoundation/hostd-types'
 import { useVolumes as useVolumesData } from '@siafoundation/hostd-react'
-import { createContext, useContext, useMemo } from 'react'
-import { columnsDefaultVisible, TableColumnId, VolumeData } from './types'
+import { createContext, useContext } from 'react'
+import { columnsDefaultVisible, VolumeData } from './types'
 import { columns } from './columns'
 import { useDataset } from './dataset'
 import { defaultDatasetRefreshInterval } from '../../config/swr'
@@ -22,7 +22,8 @@ function useVolumesMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     toggleColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,
@@ -32,7 +33,7 @@ function useVolumesMain() {
     sortField,
     sortDirection,
     resetDefaultColumnVisibility,
-  } = useTableState<TableColumnId, never>('hostd/v0/volumes', {
+  } = useTableState('hostd/v0/volumes', {
     columns,
     columnsDefaultVisible,
   })
@@ -61,11 +62,6 @@ function useVolumesMain() {
     limit,
   })
 
-  const filteredTableColumns = useMemo(
-    () => columns.filter((column) => enabledColumns.includes(column.id)),
-    [enabledColumns]
-  )
-
   const isValidating = response.isValidating
   const error = response.error
   const datasetState = useDatasetState({
@@ -80,13 +76,13 @@ function useVolumesMain() {
     datasetFilteredTotal: datasetFiltered?.length || 0,
     datasetPageTotal: datasetPage?.length || 0,
     isLoading: response.isValidating,
-    columns: filteredTableColumns,
+    visibleColumns,
     dataset,
     datasetPage,
     offset,
     limit,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     toggleColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,

--- a/apps/renterd/components/Alerts/AlertsViewDropdownMenu.tsx
+++ b/apps/renterd/components/Alerts/AlertsViewDropdownMenu.tsx
@@ -21,7 +21,7 @@ export function AlertsViewDropdownMenu() {
     resetDefaultColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,
-    enabledColumns,
+    visibleColumnIds,
   } = useAlerts()
 
   const generalColumns = configurableColumns
@@ -62,14 +62,14 @@ export function AlertsViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/renterd/components/Alerts/index.tsx
+++ b/apps/renterd/components/Alerts/index.tsx
@@ -6,7 +6,7 @@ import { useAlerts } from '../../contexts/alerts'
 
 export function Alerts() {
   const {
-    columns,
+    visibleColumns,
     datasetPage,
     sortField,
     sortDirection,
@@ -32,7 +32,7 @@ export function Alerts() {
         sortableColumns={sortableColumns}
         pageSize={limit}
         data={datasetPage}
-        columns={columns}
+        columns={visibleColumns}
         sortDirection={sortDirection}
         sortField={sortField}
         toggleSort={toggleSort}

--- a/apps/renterd/components/Contracts/ContractsViewDropdownMenu.tsx
+++ b/apps/renterd/components/Contracts/ContractsViewDropdownMenu.tsx
@@ -30,7 +30,7 @@ export function ContractsViewDropdownMenu() {
     setSortField,
     sortDirection,
     setSortDirection,
-    enabledColumns,
+    visibleColumnIds,
   } = useContracts()
 
   const generalColumns = configurableColumns
@@ -133,42 +133,42 @@ export function ContractsViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>
       <MenuSectionLabelToggleAll
         label="Time"
         columns={timeColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={timeColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>
       <MenuSectionLabelToggleAll
         label="Financial"
         columns={spendingColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={spendingColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/renterd/components/Contracts/index.tsx
+++ b/apps/renterd/components/Contracts/index.tsx
@@ -8,7 +8,7 @@ import { ContractMetrics } from './ContractMetrics'
 
 export function Contracts() {
   const {
-    columns,
+    visibleColumns,
     datasetPage,
     sortField,
     sortDirection,
@@ -76,7 +76,7 @@ export function Contracts() {
               sortableColumns={sortableColumns}
               pageSize={limit}
               data={datasetPage}
-              columns={columns}
+              columns={visibleColumns}
               sortDirection={sortDirection}
               sortField={sortField}
               toggleSort={toggleSort}

--- a/apps/renterd/components/Files/FilesViewDropdownMenu.tsx
+++ b/apps/renterd/components/Files/FilesViewDropdownMenu.tsx
@@ -23,7 +23,7 @@ export function FilesViewDropdownMenu() {
     setSortField,
     sortDirection,
     setSortDirection,
-    enabledColumns,
+    visibleColumnIds,
   } = useFilesManager()
   return (
     <Popover
@@ -103,7 +103,7 @@ export function FilesViewDropdownMenu() {
             label: column.label,
             value: column.id,
           }))}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/renterd/components/FilesDirectory/FilesExplorer.tsx
+++ b/apps/renterd/components/FilesDirectory/FilesExplorer.tsx
@@ -3,7 +3,6 @@ import { useFilesDirectory } from '../../contexts/filesDirectory'
 import { EmptyState } from './EmptyState'
 import { useCanUpload } from '../Files/useCanUpload'
 import { useFilesManager } from '../../contexts/filesManager'
-import { columns } from '../../contexts/filesDirectory/columns'
 import { pluralize } from '@siafoundation/units'
 
 export function FilesExplorer() {
@@ -14,6 +13,7 @@ export function FilesExplorer() {
     sortableColumns,
     toggleSort,
     isViewingBuckets,
+    visibleColumns,
   } = useFilesManager()
   const {
     datasetPage,
@@ -43,7 +43,7 @@ export function FilesExplorer() {
           pageSize={10}
           data={datasetPage}
           context={cellContext}
-          columns={columns}
+          columns={visibleColumns}
           sortableColumns={sortableColumns}
           sortField={sortField}
           sortDirection={sortDirection}

--- a/apps/renterd/components/FilesFlat/FilesExplorer.tsx
+++ b/apps/renterd/components/FilesFlat/FilesExplorer.tsx
@@ -2,10 +2,9 @@ import { Table } from '@siafoundation/design-system'
 import { EmptyState } from './EmptyState'
 import { useFilesFlat } from '../../contexts/filesFlat'
 import { useFilesManager } from '../../contexts/filesManager'
-import { columns } from '../../contexts/filesFlat/columns'
 
 export function FilesExplorer() {
-  const { sortableColumns, toggleSort } = useFilesManager()
+  const { sortableColumns, visibleColumns, toggleSort } = useFilesManager()
   const { datasetPage, datasetState, cellContext, sortField, sortDirection } =
     useFilesFlat()
   return (
@@ -17,7 +16,7 @@ export function FilesExplorer() {
         pageSize={10}
         data={datasetPage}
         context={cellContext}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortField={sortField}
         sortDirection={sortDirection}

--- a/apps/renterd/components/Hosts/HostsViewDropdownMenu.tsx
+++ b/apps/renterd/components/Hosts/HostsViewDropdownMenu.tsx
@@ -21,7 +21,7 @@ export function HostsViewDropdownMenu() {
     setColumnsVisible,
     setColumnsHidden,
     resetDefaultColumnVisibility,
-    enabledColumns,
+    visibleColumnIds,
   } = useHosts()
 
   const generalColumns = configurableColumns
@@ -80,14 +80,14 @@ export function HostsViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>
@@ -96,14 +96,14 @@ export function HostsViewDropdownMenu() {
           <MenuSectionLabelToggleAll
             label="Autopilot"
             columns={autopilotColumns.map((c) => c.value)}
-            enabled={enabledColumns}
+            enabled={visibleColumnIds}
             setColumnsVisible={setColumnsVisible}
             setColumnsHidden={setColumnsHidden}
           />
           <BaseMenuItem>
             <PoolCombo
               options={autopilotColumns}
-              values={enabledColumns}
+              values={visibleColumnIds}
               onChange={(value) => toggleColumnVisibility(value)}
             />
           </BaseMenuItem>
@@ -114,14 +114,14 @@ export function HostsViewDropdownMenu() {
           <MenuSectionLabelToggleAll
             label="Price table (RHPv3)"
             columns={priceTableColumns.map((c) => c.value)}
-            enabled={enabledColumns}
+            enabled={visibleColumnIds}
             setColumnsVisible={setColumnsVisible}
             setColumnsHidden={setColumnsHidden}
           />
           <BaseMenuItem>
             <PoolCombo
               options={priceTableColumns}
-              values={enabledColumns}
+              values={visibleColumnIds}
               onChange={(value) => toggleColumnVisibility(value)}
             />
           </BaseMenuItem>
@@ -132,14 +132,14 @@ export function HostsViewDropdownMenu() {
           <MenuSectionLabelToggleAll
             label="Host settings (RHPv2)"
             columns={settingsColumns.map((c) => c.value)}
-            enabled={enabledColumns}
+            enabled={visibleColumnIds}
             setColumnsVisible={setColumnsVisible}
             setColumnsHidden={setColumnsHidden}
           />
           <BaseMenuItem>
             <PoolCombo
               options={settingsColumns}
-              values={enabledColumns}
+              values={visibleColumnIds}
               onChange={(value) => toggleColumnVisibility(value)}
             />
           </BaseMenuItem>

--- a/apps/renterd/components/Hosts/index.tsx
+++ b/apps/renterd/components/Hosts/index.tsx
@@ -9,7 +9,7 @@ export function Hosts() {
   const {
     datasetPage,
     activeHost,
-    columns,
+    visibleColumns,
     limit,
     datasetState,
     tableContext,
@@ -61,7 +61,7 @@ export function Hosts() {
               context={tableContext}
               pageSize={limit}
               data={datasetPage}
-              columns={columns}
+              columns={visibleColumns}
               rowSize="default"
             />
           </div>

--- a/apps/renterd/components/Keys/KeysViewDropdownMenu.tsx
+++ b/apps/renterd/components/Keys/KeysViewDropdownMenu.tsx
@@ -30,7 +30,7 @@ export function KeysViewDropdownMenu() {
     setSortField,
     sortDirection,
     setSortDirection,
-    enabledColumns,
+    visibleColumnIds,
   } = useKeys()
 
   const generalColumns = configurableColumns
@@ -116,14 +116,14 @@ export function KeysViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/renterd/components/Keys/index.tsx
+++ b/apps/renterd/components/Keys/index.tsx
@@ -6,7 +6,7 @@ import { useKeys } from '../../contexts/keys'
 
 export function Keys() {
   const {
-    columns,
+    visibleColumns,
     datasetPage,
     sortField,
     sortDirection,
@@ -34,7 +34,7 @@ export function Keys() {
         pageSize={limit}
         data={datasetPage}
         context={cellContext}
-        columns={columns}
+        columns={visibleColumns}
         sortDirection={sortDirection}
         sortField={sortField}
         toggleSort={toggleSort}

--- a/apps/renterd/components/Uploads/UploadsTable.tsx
+++ b/apps/renterd/components/Uploads/UploadsTable.tsx
@@ -1,10 +1,10 @@
 import { Table } from '@siafoundation/design-system'
 import { EmptyState } from './EmptyState'
-import { columns } from '../../contexts/uploads/columns'
 import { useUploads } from '../../contexts/uploads'
 
 export function UploadsTable() {
   const {
+    visibleColumns,
     sortableColumns,
     toggleSort,
     datasetPage,
@@ -19,7 +19,7 @@ export function UploadsTable() {
         emptyState={<EmptyState />}
         pageSize={10}
         data={datasetPage}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortField={sortField}
         sortDirection={sortDirection}

--- a/apps/renterd/components/Uploads/UploadsViewDropdownMenu.tsx
+++ b/apps/renterd/components/Uploads/UploadsViewDropdownMenu.tsx
@@ -14,7 +14,7 @@ export function UploadsViewDropdownMenu() {
     configurableColumns,
     toggleColumnVisibility,
     resetDefaultColumnVisibility,
-    enabledColumns,
+    visibleColumnIds,
   } = useUploads()
   return (
     <Popover
@@ -49,7 +49,7 @@ export function UploadsViewDropdownMenu() {
             label: column.label,
             value: column.id,
           }))}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/renterd/components/Wallet/index.tsx
+++ b/apps/renterd/components/Wallet/index.tsx
@@ -14,7 +14,7 @@ export function Wallet() {
     metrics,
     datasetPage,
     datasetState,
-    columns,
+    visibleColumns,
     cellContext,
     sortableColumns,
     sortDirection,
@@ -47,7 +47,7 @@ export function Wallet() {
         pageSize={defaultPageSize}
         data={datasetPage}
         context={cellContext}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortDirection={sortDirection}
         sortField={sortField}

--- a/apps/renterd/contexts/alerts/index.tsx
+++ b/apps/renterd/contexts/alerts/index.tsx
@@ -123,7 +123,8 @@ function useAlertsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -140,14 +141,6 @@ function useAlertsMain() {
     sortOptions,
     defaultSortField,
   })
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const datasetState = useDatasetState({
     datasetPage,
@@ -178,10 +171,10 @@ function useAlertsMain() {
     error: response.error,
     datasetPageTotal: datasetPage?.length || 0,
     totals,
-    columns: filteredTableColumns,
     datasetPage,
     configurableColumns,
-    enabledColumns,
+    visibleColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/renterd/contexts/contracts/index.tsx
+++ b/apps/renterd/contexts/contracts/index.tsx
@@ -61,7 +61,8 @@ function useContractsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -92,14 +93,6 @@ function useContractsMain() {
   const { range: contractsTimeRange } = useMemo(
     () => getContractsTimeRangeBlockHeight(currentHeight, _datasetPage || []),
     [currentHeight, _datasetPage]
-  )
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
   )
 
   const siascanUrl = useSiascanUrl()
@@ -180,12 +173,12 @@ function useContractsMain() {
     datasetTotal: dataset?.length || 0,
     datasetFilteredTotal: datasetFiltered?.length || 0,
     datasetPageTotal: datasetPage?.length || 0,
-    columns: filteredTableColumns,
+    visibleColumns,
     dataset,
     cellContext,
     datasetPage,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/renterd/contexts/filesDirectory/index.tsx
+++ b/apps/renterd/contexts/filesDirectory/index.tsx
@@ -10,7 +10,6 @@ import { CellContext, ObjectData } from '../filesManager/types'
 import { useDataset } from './dataset'
 import { useMove } from './move'
 import { useFilesManager } from '../filesManager'
-import { columns } from './columns'
 
 function useFilesDirectoryMain() {
   const {
@@ -18,7 +17,7 @@ function useFilesDirectoryMain() {
     activeBucket,
     setActiveDirectory,
     filters,
-    enabledColumns,
+    visibleColumns,
     isViewingBuckets,
   } = useFilesManager()
 
@@ -131,14 +130,6 @@ function useFilesDirectoryMain() {
     filters,
   })
 
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
-
   const cellContext = useMemo(
     () =>
       ({
@@ -150,7 +141,7 @@ function useFilesDirectoryMain() {
 
   return {
     datasetState,
-    columns: filteredTableColumns,
+    visibleColumns,
     multiSelect,
     cellContext,
     refresh,

--- a/apps/renterd/contexts/filesFlat/index.tsx
+++ b/apps/renterd/contexts/filesFlat/index.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react'
 import { useDataset } from './dataset'
 import { useFilesManager } from '../filesManager'
-import { columns } from './columns'
 import { CellContext } from '../filesManager/types'
 
 function useFilesFlatMain() {
@@ -17,7 +16,7 @@ function useFilesFlatMain() {
     sortDirection,
     sortField,
     filters,
-    enabledColumns,
+    visibleColumns,
     isViewingBuckets,
   } = useFilesManager()
   const { limit, marker, nextMarker, response, isMore, refresh, dataset } =
@@ -29,14 +28,6 @@ function useFilesFlatMain() {
   const _datasetPage = useMemo(() => {
     return dataset
   }, [dataset])
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const multiSelect = useMultiSelect(dataset)
 
@@ -86,7 +77,7 @@ function useFilesFlatMain() {
     refresh,
     limit,
     datasetPage,
-    columns: filteredTableColumns,
+    visibleColumns,
     marker,
     nextMarker,
     isMore,

--- a/apps/renterd/contexts/filesManager/index.tsx
+++ b/apps/renterd/contexts/filesManager/index.tsx
@@ -27,7 +27,8 @@ import useLocalStorageState from 'use-local-storage-state'
 function useFilesManagerMain() {
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -229,7 +230,8 @@ function useFilesManagerMain() {
     downloadsList,
     downloadCancel,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/renterd/contexts/hosts/index.tsx
+++ b/apps/renterd/contexts/hosts/index.tsx
@@ -37,7 +37,6 @@ import { useDataset } from './dataset'
 import {
   HostContext,
   HostDataWithLocation,
-  TableColumnId,
   ViewMode,
   columnsDefaultVisible,
 } from './types'
@@ -142,7 +141,8 @@ function useHostsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     toggleColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,
@@ -152,15 +152,10 @@ function useHostsMain() {
     sortField,
     sortDirection,
     resetDefaultColumnVisibility,
-  } = useTableState<TableColumnId, never>('renterd/v0/hosts', {
+  } = useTableState('renterd/v0/hosts', {
     columns,
     columnsDefaultVisible,
   })
-
-  const filteredTableColumns = useMemo(
-    () => columns.filter((column) => enabledColumns.includes(column.id)),
-    [enabledColumns]
-  )
 
   const hostsWithLocation = useMemo(
     () => dataset?.filter((h) => h.location) as HostDataWithLocation[],
@@ -255,11 +250,11 @@ function useHostsMain() {
     offset,
     limit,
     datasetPageTotal: datasetPage?.length || 0,
-    columns: filteredTableColumns,
+    visibleColumns,
     datasetPage,
     tableContext,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     toggleColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,

--- a/apps/renterd/contexts/keys/index.tsx
+++ b/apps/renterd/contexts/keys/index.tsx
@@ -52,7 +52,8 @@ function useKeysMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -96,14 +97,6 @@ function useKeysMain() {
     })
   }, [_datasetPage, multiSelect])
 
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
-
   const datasetState = useDatasetState({
     datasetPage,
     isValidating: response.isValidating,
@@ -129,13 +122,13 @@ function useKeysMain() {
     datasetTotal: dataset?.length || 0,
     datasetFilteredTotal: datasetFiltered?.length || 0,
     datasetPageTotal: datasetPage?.length || 0,
-    columns: filteredTableColumns,
+    visibleColumns,
     multiSelect,
     cellContext,
     dataset,
     datasetPage,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/renterd/contexts/transactions/index.tsx
+++ b/apps/renterd/contexts/transactions/index.tsx
@@ -102,7 +102,8 @@ function useTransactionsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -119,14 +120,6 @@ function useTransactionsMain() {
     sortOptions,
     defaultSortField,
   })
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const isValidating = events.isValidating || pending.isValidating
   const error = events.error || pending.error
@@ -194,7 +187,7 @@ function useTransactionsMain() {
     defaultPageSize,
     cellContext,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -206,8 +199,7 @@ function useTransactionsMain() {
     sortDirection,
     resetDefaultColumnVisibility,
     filters,
-    filteredTableColumns,
-    columns,
+    visibleColumns,
   }
 }
 

--- a/apps/renterd/contexts/uploads/index.tsx
+++ b/apps/renterd/contexts/uploads/index.tsx
@@ -118,7 +118,8 @@ function useUploadsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -135,14 +136,6 @@ function useUploadsMain() {
     sortOptions,
     defaultSortField,
   })
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const datasetState = useDatasetState({
     datasetPage,
@@ -167,10 +160,10 @@ function useUploadsMain() {
     isLoading: response.isLoading,
     error: response.error,
     datasetPageTotal: datasetPage?.length || 0,
-    columns: filteredTableColumns,
+    visibleColumns,
     datasetPage,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/walletd/components/Wallet/EventsViewDropdownMenu.tsx
+++ b/apps/walletd/components/Wallet/EventsViewDropdownMenu.tsx
@@ -21,7 +21,7 @@ export function EventsViewDropdownMenu() {
     resetDefaultColumnVisibility,
     setColumnsVisible,
     setColumnsHidden,
-    enabledColumns,
+    visibleColumnIds,
   } = useEvents()
 
   const generalColumns = configurableColumns
@@ -67,14 +67,14 @@ export function EventsViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/walletd/components/Wallet/index.tsx
+++ b/apps/walletd/components/Wallet/index.tsx
@@ -8,7 +8,7 @@ export function Wallet() {
   const {
     datasetPage,
     datasetState,
-    columns,
+    visibleColumns,
     cellContext,
     sortableColumns,
     sortDirection,
@@ -32,7 +32,7 @@ export function Wallet() {
         pageSize={6}
         data={datasetPage}
         context={cellContext}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortDirection={sortDirection}
         sortField={sortField}

--- a/apps/walletd/components/WalletAddresses/AddressesViewDropdownMenu.tsx
+++ b/apps/walletd/components/WalletAddresses/AddressesViewDropdownMenu.tsx
@@ -30,7 +30,7 @@ export function AddressesViewDropdownMenu() {
     setSortField,
     sortDirection,
     setSortDirection,
-    enabledColumns,
+    visibleColumnIds,
   } = useAddresses()
 
   const generalColumns = configurableColumns
@@ -121,14 +121,14 @@ export function AddressesViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/walletd/components/WalletAddresses/index.tsx
+++ b/apps/walletd/components/WalletAddresses/index.tsx
@@ -8,7 +8,7 @@ export function WalletAddresses() {
   const {
     datasetPage,
     datasetState,
-    columns,
+    visibleColumns,
     cellContext,
     sortableColumns,
     sortDirection,
@@ -31,7 +31,7 @@ export function WalletAddresses() {
         pageSize={6}
         data={datasetPage}
         context={cellContext}
-        columns={columns}
+        columns={visibleColumns}
         sortableColumns={sortableColumns}
         sortDirection={sortDirection}
         sortField={sortField}

--- a/apps/walletd/components/WalletsList/WalletsViewDropdownMenu.tsx
+++ b/apps/walletd/components/WalletsList/WalletsViewDropdownMenu.tsx
@@ -30,7 +30,7 @@ export function WalletsViewDropdownMenu() {
     setSortField,
     sortDirection,
     setSortDirection,
-    enabledColumns,
+    visibleColumnIds,
   } = useWallets()
 
   const generalColumns = configurableColumns
@@ -121,14 +121,14 @@ export function WalletsViewDropdownMenu() {
       <MenuSectionLabelToggleAll
         label="General"
         columns={generalColumns.map((c) => c.value)}
-        enabled={enabledColumns}
+        enabled={visibleColumnIds}
         setColumnsVisible={setColumnsVisible}
         setColumnsHidden={setColumnsHidden}
       />
       <BaseMenuItem>
         <PoolCombo
           options={generalColumns}
-          values={enabledColumns}
+          values={visibleColumnIds}
           onChange={(value) => toggleColumnVisibility(value)}
         />
       </BaseMenuItem>

--- a/apps/walletd/components/WalletsList/index.tsx
+++ b/apps/walletd/components/WalletsList/index.tsx
@@ -9,7 +9,7 @@ export function WalletsList() {
     datasetPage,
     datasetState,
     context,
-    columns,
+    visibleColumns,
     sortableColumns,
     sortDirection,
     sortField,
@@ -33,7 +33,7 @@ export function WalletsList() {
           pageSize={6}
           data={datasetPage}
           context={context}
-          columns={columns}
+          columns={visibleColumns}
           sortableColumns={sortableColumns}
           sortDirection={sortDirection}
           sortField={sortField}

--- a/apps/walletd/contexts/addresses/index.tsx
+++ b/apps/walletd/contexts/addresses/index.tsx
@@ -49,7 +49,8 @@ export function useAddressesMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -72,17 +73,9 @@ export function useAddressesMain() {
     filters,
     sortField,
     sortDirection,
-    limit,
     offset,
+    limit,
   })
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const siascanUrl = useSiascanUrl()
   const cellContext = useMemo<CellContext>(
@@ -98,7 +91,7 @@ export function useAddressesMain() {
     datasetTotal: dataset?.length || 0,
     datasetFilteredTotal: datasetFiltered?.length || 0,
     datasetPageTotal: datasetPage?.length || 0,
-    columns: filteredTableColumns,
+    visibleColumns,
     dataset,
     datasetPage,
     offset,
@@ -106,7 +99,7 @@ export function useAddressesMain() {
     cellContext,
     lastIndex,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/walletd/contexts/events/index.tsx
+++ b/apps/walletd/contexts/events/index.tsx
@@ -121,7 +121,8 @@ export function useEventsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -138,14 +139,6 @@ export function useEventsMain() {
     sortOptions,
     defaultSortField,
   })
-
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
 
   const isValidating =
     responseEvents.isValidating || responseTxPool.isValidating
@@ -171,11 +164,11 @@ export function useEventsMain() {
     datasetState,
     error: responseEvents.error,
     datasetPageTotal: datasetPage?.length || 0,
-    columns: filteredTableColumns,
+    visibleColumns,
     datasetPage,
     cellContext,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/apps/walletd/contexts/wallets/index.tsx
+++ b/apps/walletd/contexts/wallets/index.tsx
@@ -113,7 +113,8 @@ function useWalletsMain() {
 
   const {
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
+    visibleColumns,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,
@@ -140,14 +141,6 @@ function useWalletsMain() {
     limit,
   })
 
-  const filteredTableColumns = useMemo(
-    () =>
-      columns.filter(
-        (column) => column.fixed || enabledColumns.includes(column.id)
-      ),
-    [enabledColumns]
-  )
-
   const datasetState = useDatasetState({
     datasetPage: datasetFiltered,
     isValidating: response.isValidating,
@@ -170,7 +163,7 @@ function useWalletsMain() {
     datasetFilteredTotal: datasetFiltered?.length || 0,
     datasetPageTotal: datasetFiltered?.length || 0,
     unlockedCount: cachedMnemonicCount,
-    columns: filteredTableColumns,
+    visibleColumns,
     datasetPage,
     dataset,
     context,
@@ -178,7 +171,7 @@ function useWalletsMain() {
     limit,
     offset,
     configurableColumns,
-    enabledColumns,
+    visibleColumnIds,
     sortableColumns,
     toggleColumnVisibility,
     setColumnsVisible,

--- a/libs/design-system/src/hooks/useSorting.ts
+++ b/libs/design-system/src/hooks/useSorting.ts
@@ -5,7 +5,7 @@ import { useCallback, useMemo } from 'react'
 import useLocalStorageState from 'use-local-storage-state'
 
 type Params<ColumnId extends string, SortField extends string> = {
-  enabledColumns: ColumnId[]
+  visibleColumnIds: ColumnId[]
   defaultSortField?: SortField
   sortOptions?: { id: SortField }[]
 }
@@ -14,7 +14,7 @@ export function useSorting<ColumnId extends string, SortField extends string>(
   scope: string,
   params: Params<ColumnId, SortField>
 ) {
-  const { defaultSortField, sortOptions, enabledColumns } = params
+  const { defaultSortField, sortOptions, visibleColumnIds } = params
 
   const [sortField, setSortField] = useLocalStorageState<SortField>(
     `${scope}/sortField`,
@@ -46,8 +46,11 @@ export function useSorting<ColumnId extends string, SortField extends string>(
       return []
     }
     const sortFieldIds = sortOptions.map((o) => o.id)
-    return intersection(sortFieldIds, enabledColumns as string[]) as SortField[]
-  }, [sortOptions, enabledColumns])
+    return intersection(
+      sortFieldIds,
+      visibleColumnIds as string[]
+    ) as SortField[]
+  }, [sortOptions, visibleColumnIds])
 
   return {
     toggleSort,


### PR DESCRIPTION
- Refactors duplicated column filtering code into the `useTableState` hook.
- Refines naming to make the purpose more clear.