### PR TITLE
feat(explorer): add previous and next block navigation to block page

### DIFF
--- a/.changeset/slow-roses-hide.md
+++ b/.changeset/slow-roses-hide.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added previous and next block navigation to blocks page.

--- a/apps/explorer-e2e/src/specs/block.spec.ts
+++ b/apps/explorer-e2e/src/specs/block.spec.ts
@@ -28,10 +28,22 @@ test('block can be directly navigated to by height', async ({ page }) => {
   await expect(page.getByText(TEST_BLOCK_1.display.title).nth(0)).toBeVisible()
 })
 
-test('block can be directly navigated to by id', async ({ page }) => {
+test('block can navigate to previous block', async ({ page }) => {
   await explorerApp.goTo('/block/' + TEST_BLOCK_1.id)
+  await page.getByTestId('explorer-block-prevBlock').click()
 
-  await expect(page.getByText(TEST_BLOCK_1.display.title).nth(0)).toBeVisible()
+  await expect(
+    page.getByText((Number(TEST_BLOCK_1.height) - 1).toLocaleString())
+  ).toBeVisible()
+})
+
+test('block can navigate to nextblock', async ({ page }) => {
+  await explorerApp.goTo('/block/' + TEST_BLOCK_1.id)
+  await page.getByTestId('explorer-block-nextBlock').click()
+
+  await expect(
+    page.getByText((Number(TEST_BLOCK_1.height) + 1).toLocaleString())
+  ).toBeVisible()
 })
 
 test('block can click through to a transaction', async ({ page }) => {

--- a/apps/explorer/components/Block/index.tsx
+++ b/apps/explorer/components/Block/index.tsx
@@ -3,6 +3,7 @@ import {
   Tooltip,
   EntityList,
   stripPrefix,
+  LinkButton,
 } from '@siafoundation/design-system'
 import { humanNumber } from '@siafoundation/units'
 import { ExplorerDatum, DatumProps } from '../ExplorerDatum'
@@ -11,13 +12,15 @@ import { routes } from '../../config/routes'
 import { EntityHeading } from '../EntityHeading'
 import { ContentLayout } from '../ContentLayout'
 import { ExplorerBlock } from '@siafoundation/explored-types'
+import { ArrowLeft16, ArrowRight16 } from '@siafoundation/react-icons'
 
 type Props = {
   block: ExplorerBlock
   blockID: string
+  currentHeight: number
 }
 
-export function Block({ block, blockID }: Props) {
+export function Block({ block, blockID, currentHeight }: Props) {
   const blockDatums: DatumProps[] = useMemo(() => {
     // Grab the miner payout address
     const minerPayoutAddress = block.minerPayouts.find(
@@ -40,6 +43,9 @@ export function Block({ block, blockID }: Props) {
     ]
   }, [block, blockID])
 
+  const previousBlockExists = block.height > 1
+  const nextBlockExists = block.height < currentHeight
+
   return (
     <ContentLayout
       panel={
@@ -52,6 +58,32 @@ export function Block({ block, blockID }: Props) {
               href={routes.block.view.replace(':id', String(block.height))}
             />
             <div className="flex gap-2 items-center">
+              <Tooltip content="previous block" delayDuration={800}>
+                <LinkButton
+                  variant={previousBlockExists ? 'gray' : 'inactive'}
+                  href={routes.block.view.replace(
+                    ':id',
+                    String(block.height - 1)
+                  )}
+                  disabled={!previousBlockExists}
+                  data-testid="explorer-block-prevBlock"
+                >
+                  <ArrowLeft16 />
+                </LinkButton>
+              </Tooltip>
+              <Tooltip content="next block" delayDuration={800}>
+                <LinkButton
+                  variant={nextBlockExists ? 'gray' : 'inactive'}
+                  href={routes.block.view.replace(
+                    ':id',
+                    String(block.height + 1)
+                  )}
+                  disabled={!nextBlockExists}
+                  data-testid="explorer-block-nextBlock"
+                >
+                  <ArrowRight16 />
+                </LinkButton>
+              </Tooltip>
               <Tooltip
                 content={`${humanNumber(
                   block.transactions?.length || 0


### PR DESCRIPTION
![Screenshot 2024-12-17 at 1.36.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/a27abfcc-a2e8-4770-87b9-b1a64dd84f8b.png)

I played with the positioning of these two buttons (next to block height, center, etc) and whether to write out "previous block" and "next block" or not. I settled with this and a tooltip. Included catching the < 1 and > current block height cases.