### PR TITLE
fix(hostd): address configuration hostname no port

### DIFF
--- a/.changeset/sharp-ears-tell.md
+++ b/.changeset/sharp-ears-tell.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The address configuration setting now expects only the hostname without a port. Closes https://github.com/SiaFoundation/hostd/issues/536

--- a/apps/hostd-e2e/src/fixtures/configResetAllSettings.ts
+++ b/apps/hostd-e2e/src/fixtures/configResetAllSettings.ts
@@ -18,7 +18,7 @@ export const configResetAllSettings = step(
 
     // host
     await setSwitchByLabel(page, 'acceptingContracts', false)
-    await fillTextInputByName(page, 'netAddress', 'foobar.com:9880')
+    await fillTextInputByName(page, 'netAddress', 'foobar.com')
     await fillTextInputByName(page, 'maxContractDuration', '6')
 
     // pricing

--- a/apps/hostd-e2e/src/specs/config.spec.ts
+++ b/apps/hostd-e2e/src/specs/config.spec.ts
@@ -28,7 +28,7 @@ test('basic field change and save behaviour', async ({ page }) => {
 
   // Test that values can be updated.
   await setSwitchByLabel(page, 'acceptingContracts', true)
-  await fillTextInputByName(page, 'netAddress', 'foobar.com:7777')
+  await fillTextInputByName(page, 'netAddress', 'foobar1.com')
   await fillTextInputByName(page, 'maxContractDuration', '7')
   await fillSelectInputByName(page, 'pinnedCurrency', 'AUD')
   await fillTextInputByName(page, 'pinnedThreshold', '7')
@@ -48,7 +48,7 @@ test('basic field change and save behaviour', async ({ page }) => {
   // await expect(
   //   page.getByText('Address has changed, make sure to re-announce the host.')
   // ).toBeVisible()
-  await expectTextInputByName(page, 'netAddress', 'foobar.com:7777')
+  await expectTextInputByName(page, 'netAddress', 'foobar1.com')
   await expectTextInputByName(page, 'maxContractDuration', '7')
   await fillSelectInputByName(page, 'pinnedCurrency', 'USD')
   await expectTextInputByName(page, 'pinnedThreshold', '7')

--- a/apps/hostd/contexts/config/fields.tsx
+++ b/apps/hostd/contexts/config/fields.tsx
@@ -10,6 +10,7 @@ import {
 } from './types'
 import { calculateMaxCollateral } from './transform'
 import { currencyOptions } from '@siafoundation/react-core'
+import { Maybe } from '@siafoundation/types'
 
 type Categories = 'host' | 'pricing' | 'DNS' | 'bandwidth' | 'RHP3'
 
@@ -46,9 +47,16 @@ export function getFields({
       category: 'host',
       title: 'Address',
       description: <>The network address of the host.</>,
-      placeholder: 'my.host.com:9982',
+      placeholder: 'my.host.com',
       validation: {
         required: 'required',
+        validate: {
+          noProtocol: (value: Maybe<string>) =>
+            !/^https?:\/\//.test(value || '') ||
+            'must not start with http:// or https://',
+          noPort: (value: Maybe<string>) =>
+            !/:\d+$/.test(value || '') || 'must not include port',
+        },
       },
     },
     maxContractDuration: {


### PR DESCRIPTION
- Address configuration setting now expects only the hostname without a port. https://github.com/SiaFoundation/hostd/issues/536

