### PR TITLE
fix(renterd): files directory mode page select ignores parent dir

### DIFF
--- a/.changeset/polite-doors-do.md
+++ b/.changeset/polite-doors-do.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where selecting the entire page of files would select the parent navigation row.

--- a/apps/renterd-e2e/src/specs/files.spec.ts
+++ b/apps/renterd-e2e/src/specs/files.spec.ts
@@ -338,3 +338,24 @@ test('bulk delete using the all files explorer mode', async ({ page }) => {
     },
   })
 })
+
+test('bulk selecting the entire page ignores the .. parent directory nav row', async ({
+  page,
+}) => {
+  const bucketName = 'bucket1'
+  await navigateToBuckets({ page })
+  await createBucket(page, bucketName)
+  await createFilesMap(page, bucketName, {
+    'file1.txt': null,
+    'file2.txt': null,
+    'file3.txt': null,
+    'file4.txt': null,
+    'file5.txt': null,
+  })
+  await navigateToBuckets({ page })
+  await openBucket(page, bucketName)
+
+  await page.getByRole('checkbox', { name: 'select all files' }).check()
+  const menu = page.getByLabel('file multi-select menu')
+  await expect(menu.getByText('5 files selected')).toBeVisible()
+})

--- a/apps/renterd/contexts/filesDirectory/columns.tsx
+++ b/apps/renterd/contexts/filesDirectory/columns.tsx
@@ -36,6 +36,7 @@ export const columns: FilesTableColumn[] = [
       return (
         <ControlGroup className="flex h-4">
           <Checkbox
+            aria-label="select all files"
             onClick={multiSelect.onSelectPage}
             checked={multiSelect.isPageAllSelected}
           />

--- a/apps/renterd/contexts/filesDirectory/index.tsx
+++ b/apps/renterd/contexts/filesDirectory/index.tsx
@@ -27,6 +27,16 @@ function useFilesDirectoryMain() {
 
   const { limit, marker, isMore, response, refresh, dataset } = useDataset()
 
+  const multiSelect = useMultiSelect(dataset)
+
+  // If the active bucket changes, clear the multi-select.
+  useEffect(() => {
+    if (activeBucket) {
+      multiSelect.deselectAll()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeBucket])
+
   // Add parent directory to the dataset.
   const _datasetPage = useMemo(() => {
     if (!dataset) {
@@ -54,16 +64,6 @@ function useFilesDirectoryMain() {
     // when new data fetching is complete.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataset])
-
-  const multiSelect = useMultiSelect(_datasetPage)
-
-  // If the active bucket changes, clear the multi-select.
-  useEffect(() => {
-    if (activeBucket) {
-      multiSelect.deselectAll()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeBucket])
 
   const {
     onDragEnd,


### PR DESCRIPTION
- Fixed an issue where selecting the entire page of files would select the parent navigation row.

