### PR TITLE
fix(renterd): files copy metadata

### DIFF
--- a/.changeset/silver-pants-deliver.md
+++ b/.changeset/silver-pants-deliver.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue with the copy file metadata action in the file context menu.

--- a/.changeset/thick-geckos-laugh.md
+++ b/.changeset/thick-geckos-laugh.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/renterd-types': minor
+---
+
+The object response has been updated in v2.

--- a/apps/renterd/components/Files/Columns/FilesHealthColumn/FilesHealthColumnContents.tsx
+++ b/apps/renterd/components/Files/Columns/FilesHealthColumn/FilesHealthColumnContents.tsx
@@ -47,7 +47,7 @@ export function FilesHealthColumnContents({
     )
   }
 
-  if (!obj.data?.object) {
+  if (!obj.data) {
     return (
       <Layout displayHealth={displayHealth} label={label}>
         <Text size="12">Error fetching slab metadata.</Text>
@@ -56,7 +56,7 @@ export function FilesHealthColumnContents({
   }
 
   const slabs = sortBy(
-    obj.data.object.slabs?.map((s) => ({
+    obj.data.slabs?.map((s) => ({
       ...s.slab,
       // id is for use as a unique React key.
       // slab key is not necessarily unique. e.g. an object uploaded with tiny

--- a/apps/renterd/components/Files/FileContextMenu/CopyMetadataMenuItem.tsx
+++ b/apps/renterd/components/Files/FileContextMenu/CopyMetadataMenuItem.tsx
@@ -28,10 +28,7 @@ export function CopyMetadataMenuItem({ path }: Props) {
       disabled={!obj.data}
       onSelect={() => {
         if (obj.data) {
-          copyToClipboard(
-            JSON.stringify(obj.data.object, null, 2),
-            'object metadata'
-          )
+          copyToClipboard(JSON.stringify(obj.data, null, 2), 'object metadata')
         }
       }}
     >

--- a/libs/renterd-types/src/bus.ts
+++ b/libs/renterd-types/src/bus.ts
@@ -417,7 +417,7 @@ export type ObjectsResponse = {
 
 export type ObjectParams = { key: string; bucket: string }
 export type ObjectPayload = void
-export type ObjectResponse = { object: Obj }
+export type ObjectResponse = Obj
 
 export type ObjectAddParams = { key: string; bucket: string }
 export type ObjectAddPayload = {


### PR DESCRIPTION
- Fixed an issue with the copy file metadata action in the file context menu.
- The object response has been updated in v2.
