### PR TITLE
fix(hostd): net address and wallet address view on siascan changes

### DIFF
--- a/.changeset/funny-icons-grab.md
+++ b/.changeset/funny-icons-grab.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The host net address context menu no longer has a view on siascan option. Closes https://github.com/SiaFoundation/hostd/issues/554

--- a/.changeset/silly-vans-film.md
+++ b/.changeset/silly-vans-film.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The host wallet address context menu now has a view on siascan option.

--- a/apps/hostd/components/Profile/index.tsx
+++ b/apps/hostd/components/Profile/index.tsx
@@ -112,6 +112,7 @@ export function Profile() {
             maxLength={24}
             value={wallet.data?.address}
             type="address"
+            siascanUrl={siascanUrl}
           />
         </div>
       </div>

--- a/libs/units/src/entityTypes.ts
+++ b/libs/units/src/entityTypes.ts
@@ -47,7 +47,6 @@ export function getEntityDisplayLength(type?: EntityType): number {
 
 export function doesEntityHaveSiascanUrl(type?: EntityType) {
   const includeList: EntityType[] = [
-    'hostIp',
     'hostPublicKey',
     'contract',
     'address',


### PR DESCRIPTION
- The host net address context menu no longer has a view on siascan option. https://github.com/SiaFoundation/hostd/issues/554
- The host wallet address context menu now has a view on siascan option.
