### PR TITLE
refactor(renterd): improve uploads performance

### DIFF
--- a/.changeset/chilled-days-live.md
+++ b/.changeset/chilled-days-live.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The application no longer lags when uploading thousands of files.

--- a/.changeset/itchy-paws-call.md
+++ b/.changeset/itchy-paws-call.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Added useThrottledStateMap.

--- a/.changeset/light-ravens-own.md
+++ b/.changeset/light-ravens-own.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Added `throttle`, often useful for mutation callbacks.

--- a/apps/renterd/contexts/filesManager/types.ts
+++ b/apps/renterd/contexts/filesManager/types.ts
@@ -85,7 +85,8 @@ export type ExplorerMode = 'directory' | 'flat'
 export type UploadStatus = 'queued' | 'uploading' | 'processing'
 
 export type ObjectUploadData = ObjectData & {
-  upload?: MultipartUpload
+  multipartId?: string
+  multipartUpload?: MultipartUpload
   uploadStatus: UploadStatus
   uploadAbort?: () => Promise<void>
   uploadFile?: File

--- a/apps/renterd/contexts/filesManager/useWarnActiveUploadsOnClose.tsx
+++ b/apps/renterd/contexts/filesManager/useWarnActiveUploadsOnClose.tsx
@@ -1,30 +1,26 @@
 import { useEffect } from 'react'
-import { UploadsMap } from './types'
+import { ObjectUploadData } from './types'
 
 export function useWarnActiveUploadsOnClose({
-  uploadsMap,
+  uploadsList,
 }: {
-  uploadsMap: UploadsMap
+  uploadsList: ObjectUploadData[]
 }) {
   useEffect(() => {
-    const activeUploads = Object.values(uploadsMap).filter(
-      (upload) => upload.uploadStatus === 'uploading'
-    )
-
     const warnUserAboutActiveUploads = (event: BeforeUnloadEvent) => {
-      if (activeUploads.length > 0) {
-        const message = `Warning, closing the tab will abort all ${activeUploads.length} active uploads.`
+      if (uploadsList.length > 0) {
+        const message = `Warning, closing the tab will abort all ${uploadsList.length} active uploads.`
         event.returnValue = message // Legacy method for cross browser support
         return message // Chrome requires returnValue to be set
       }
     }
 
-    if (activeUploads.length > 0) {
+    if (uploadsList.length > 0) {
       window.addEventListener('beforeunload', warnUserAboutActiveUploads)
     }
 
     return () => {
       window.removeEventListener('beforeunload', warnUserAboutActiveUploads)
     }
-  }, [uploadsMap])
+  }, [uploadsList])
 }

--- a/apps/renterd/contexts/uploads/index.tsx
+++ b/apps/renterd/contexts/uploads/index.tsx
@@ -17,6 +17,7 @@ import { ObjectUploadData } from '../filesManager/types'
 import { MultipartUploadListUploadsPayload } from '@siafoundation/renterd-types'
 import { maybeFromNullishArrayResponse } from '@siafoundation/react-core'
 import { Maybe, Nullable } from '@siafoundation/types'
+import { getUploadId } from '../filesManager/uploads'
 
 const defaultLimit = 50
 
@@ -84,7 +85,7 @@ function useUploadsMain() {
       const key = upload.key
       const name = getFilename(key)
       const fullPath = join(activeBucket.name, upload.key)
-      const localUpload = uploadsMap[id]
+      const localUpload = uploadsMap[getUploadId(fullPath)]
       if (localUpload) {
         return localUpload
       }

--- a/apps/renterd/lib/multipartUpload.ts
+++ b/apps/renterd/lib/multipartUpload.ts
@@ -136,19 +136,21 @@ export class MultipartUpload {
         this.#activeConnections[id].abort()
       })
 
-    try {
-      await this.#api.busUploadAbort.post({
-        payload: {
-          bucket: this.#bucket,
-          key: this.#key,
-          uploadID: this.#uploadId,
-        } as MultipartUploadAbortPayload,
-      })
-    } catch (e) {
-      triggerErrorToast({
-        title: 'Error aborting upload',
-        body: (e as Error).message,
-      })
+    if (this.#uploadId) {
+      try {
+        await this.#api.busUploadAbort.post({
+          payload: {
+            bucket: this.#bucket,
+            key: this.#key,
+            uploadID: this.#uploadId,
+          } as MultipartUploadAbortPayload,
+        })
+      } catch (e) {
+        triggerErrorToast({
+          title: 'Error aborting upload',
+          body: (e as Error).message,
+        })
+      }
     }
     this.#resolve?.()
   }

--- a/libs/react-core/package.json
+++ b/libs/react-core/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^18.2.0",
-    "@siafoundation/types": "0.7.0"
+    "@siafoundation/types": "0.7.0",
+    "@technically/lodash": "^4.17.0"
   },
   "dependencies": {
     "@siafoundation/next": "^0.1.3",

--- a/libs/react-core/src/index.ts
+++ b/libs/react-core/src/index.ts
@@ -14,6 +14,8 @@ export * from './useTryUntil'
 export * from './userPrefersReducedMotion'
 export * from './mutate'
 export * from './arrayResponse'
+export * from './throttle'
+export * from './useThrottledStateMap'
 
 export * from './workflows'
 export * from './coreProvider'

--- a/libs/react-core/src/throttle.test.ts
+++ b/libs/react-core/src/throttle.test.ts
@@ -1,0 +1,62 @@
+import { throttle } from './throttle'
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+describe('throttle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('both', () => {
+    const fn = jest.fn()
+    throttle('test', 100, fn)
+    throttle('test', 100, fn)
+    throttle('test', 100, fn)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    jest.runAllTimers()
+
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('trailing', () => {
+    const fn = jest.fn()
+    throttle('test', 100, fn, 'trailing')
+    throttle('test', 100, fn, 'trailing')
+    throttle('test', 100, fn, 'trailing')
+
+    expect(fn).toHaveBeenCalledTimes(0)
+
+    jest.runAllTimers()
+
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('leading', () => {
+    const fn = jest.fn()
+    throttle('test', 100, fn, 'leading')
+    throttle('test', 100, fn, 'leading')
+    throttle('test', 100, fn, 'leading')
+
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    jest.runAllTimers()
+
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should use the last cached function', () => {
+    const fn1 = jest.fn()
+    const fn2 = jest.fn()
+    throttle('test2', 100, fn1, 'trailing')
+    throttle('test2', 100, fn2, 'trailing')
+
+    jest.runAllTimers()
+
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+})

--- a/libs/react-core/src/throttle.ts
+++ b/libs/react-core/src/throttle.ts
@@ -1,0 +1,33 @@
+import { throttle as _throttle } from '@technically/lodash'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const wrapperRegistry = new Map<string, (...args: any[]) => any>()
+
+/**
+ * Executes a function with throttling. Creates and caches the throttled version
+ * of the function based on the key and delay.
+ *
+ * @param key - Unique identifier for the throttled function
+ * @param delay - Throttle delay in ms
+ * @param fn - Function to throttle
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function throttle<T extends (...args: any[]) => any>(
+  key: string,
+  delay: number,
+  fn: T,
+  edge: 'leading' | 'trailing' | 'both' = 'both'
+): (...args: Parameters<T>) => ReturnType<T> {
+  const fullKey = key + edge + String(delay)
+  if (!wrapperRegistry.has(fullKey)) {
+    wrapperRegistry.set(
+      fullKey,
+      _throttle((func: T, ...args: Parameters<T>) => func(...args), delay, {
+        leading: edge === 'leading' || edge === 'both',
+        trailing: edge === 'trailing' || edge === 'both',
+      })
+    )
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return wrapperRegistry.get(fullKey)!(fn)
+}

--- a/libs/react-core/src/useThrottledStateMap.ts
+++ b/libs/react-core/src/useThrottledStateMap.ts
@@ -1,0 +1,59 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { throttle } from '@technically/lodash'
+
+/**
+ * A hook that allows you to create a state map that can be updated thousands
+ * of times per second directly with the setter function, but only updates the
+ * render state every `throttleMs` milliseconds.
+ *
+ * @param initialValue - The initial value of the map.
+ * @param throttleMs - The throttle time in milliseconds.
+ * @returns A tuple containing the current value of the map, a setter function,
+ * and the throttled value.
+ */
+export function useThrottledStateMap<T extends Record<string, unknown>>(
+  initialValue: T,
+  throttleMs = 1000
+): [T, (value: T | ((prev: T) => T)) => void, T] {
+  // Real-time value in ref.
+  const valueRef = useRef<T>(initialValue)
+  // Throttled state for renders.
+  const [throttledValue, setThrottledValue] = useState<T>(initialValue)
+
+  // Throttled sync function.
+  const sync = useMemo(
+    () =>
+      throttle(
+        () => {
+          setThrottledValue({ ...valueRef.current })
+        },
+        throttleMs,
+        {
+          trailing: true,
+        }
+      ),
+    [throttleMs]
+  )
+
+  // Cleanup throttle on unmount.
+  useEffect(() => {
+    return () => {
+      sync.cancel()
+    }
+  }, [sync])
+
+  // Setter that updates ref and triggers throttled sync.
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      const nextValue =
+        value instanceof Function ? value(valueRef.current) : value
+      valueRef.current = nextValue
+      sync()
+    },
+    [sync]
+  )
+
+  return [valueRef.current, setValue, throttledValue]
+}

--- a/libs/renterd-react/package.json
+++ b/libs/renterd-react/package.json
@@ -4,7 +4,6 @@
   "version": "4.13.3",
   "license": "MIT",
   "dependencies": {
-    "@technically/lodash": "^4.17.0",
     "@siafoundation/react-core": "^1.6.0",
     "swr": "^2.1.1",
     "@siafoundation/renterd-types": "0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,6 @@
         "use-debounce": "^9.0.3",
         "use-local-storage-state": "^18.3.3",
         "usehooks-ts": "^2.9.1",
-        "uuid": "^9.0.0",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -511,6 +510,7 @@
       },
       "peerDependencies": {
         "@siafoundation/types": "0.7.0",
+        "@technically/lodash": "^4.17.0",
         "react": "^18.2.0"
       }
     },
@@ -591,7 +591,6 @@
         "@siafoundation/react-core": "^1.6.0",
         "@siafoundation/renterd-types": "0.14.1",
         "@siafoundation/units": "3.3.0",
-        "@technically/lodash": "^4.17.0",
         "swr": "^2.1.1"
       }
     },
@@ -30791,14 +30790,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/uvu": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.3.tgz",
@@ -38310,7 +38301,6 @@
         "@siafoundation/react-core": "^1.6.0",
         "@siafoundation/renterd-types": "0.14.1",
         "@siafoundation/units": "3.3.0",
-        "@technically/lodash": "^4.17.0",
         "swr": "^2.1.1"
       }
     },
@@ -52815,11 +52805,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "uvu": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "use-debounce": "^9.0.3",
     "use-local-storage-state": "^18.3.3",
     "usehooks-ts": "^2.9.1",
-    "uuid": "^9.0.0",
     "yup": "^0.32.11"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes
- The application no longer lags when uploading thousands of files.

### Details
- The performance was improved with the following two changes:
  - The uploads state map which can store thousands of records and receive hundreds of progress updates per second was moved to ref-based mutable state.
  - Multipart uploads are now created when they are popped off the queue and start uploading, previously adding a directory with thousands of files would immediately create a multpart upload session for every file.