### PR TITLE
feat(explorer): use explored for the address route

### DIFF
--- a/.changeset/good-shirts-behave.md
+++ b/.changeset/good-shirts-behave.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Replaced Sia Central with explored for the address route.

--- a/apps/explorer-e2e/src/fixtures/constants.ts
+++ b/apps/explorer-e2e/src/fixtures/constants.ts
@@ -60,7 +60,7 @@ export const TEST_ADDRESS_1 = {
   id: '68bf48e81536f2221f3809aa9d1c89c1c869a17c6f186a088e49fd2605e4bfaaa24f26e4c42c',
   display: {
     title: 'Address 68bf48e81536f22...',
-    transactionNumber: '500 transactions',
+    transactionNumber: '500 events',
     transactionID: 'c0b92135ca06...',
   },
 }

--- a/apps/explorer/app/address/[id]/page.tsx
+++ b/apps/explorer/app/address/[id]/page.tsx
@@ -2,10 +2,10 @@ import { Address } from '../../../components/Address'
 import { Metadata } from 'next'
 import { routes } from '../../../config/routes'
 import { buildMetadata } from '../../../lib/utils'
-import { siaCentral } from '../../../config/siaCentral'
 import { notFound } from 'next/navigation'
 import { truncate } from '@siafoundation/design-system'
 import { to } from '@siafoundation/request'
+import { explored } from '../../../config/explored'
 
 export function generateMetadata({ params }): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
@@ -22,22 +22,31 @@ export function generateMetadata({ params }): Metadata {
 export const revalidate = 0
 
 export default async function Page({ params }) {
-  const id = params?.id as string
-  const [a, error] = await to(
-    siaCentral.address({
-      params: {
-        id,
-      },
-    })
+  const address = params?.id as string
+
+  const [
+    [balance, balanceError],
+    [events, eventsError],
+    [unspentOutputs, unspentOutputsError],
+  ] = await Promise.all([
+    to(explored.addressBalance({ params: { address } })),
+    to(explored.addressEvents({ params: { address, limit: 500 } })),
+    to(explored.addressSiacoinUTXOs({ params: { address } })),
+  ])
+
+  if (balanceError) throw balanceError
+  if (eventsError) throw eventsError
+  if (unspentOutputsError) throw unspentOutputsError
+  if (!balance || !events || !unspentOutputs) return notFound()
+
+  return (
+    <Address
+      id={address}
+      addressInfo={{
+        balance,
+        events,
+        unspentOutputs,
+      }}
+    />
   )
-
-  if (error) {
-    throw error
-  }
-
-  if (a?.unspent_siacoins == undefined) {
-    return notFound()
-  }
-
-  return <Address id={id} address={a} />
 }

--- a/apps/explorer/components/Address/index.tsx
+++ b/apps/explorer/components/Address/index.tsx
@@ -17,99 +17,87 @@ import { routes } from '../../config/routes'
 import { EntityHeading } from '../EntityHeading'
 import BigNumber from 'bignumber.js'
 import { ContentLayout } from '../ContentLayout'
-import { SiaCentralAddressResponse } from '@siafoundation/sia-central-types'
+import {
+  AddressBalance,
+  ExplorerEvent,
+  EventPayout,
+  EventV1ContractResolution,
+  EventV1Transaction,
+  ExplorerSiacoinOutput,
+} from '@siafoundation/explored-types'
 
-type Tab = 'transactions' | 'evolution' | 'utxos'
+type Tab = 'events' | 'evolution' | 'utxos'
 
 type Props = {
   id: string
-  address: SiaCentralAddressResponse
+  addressInfo: {
+    balance: AddressBalance
+    events: ExplorerEvent[]
+    unspentOutputs: ExplorerSiacoinOutput[]
+  }
 }
 
-export function Address({ id, address }: Props) {
-  const [tab, setTab] = useState<Tab>('transactions')
+export function Address({
+  id,
+  addressInfo: {
+    balance: { unspentSiacoins, unspentSiafunds },
+    events,
+    unspentOutputs,
+  },
+}: Props) {
+  const [tab, setTab] = useState<Tab>('events')
 
   const values = useMemo(() => {
     const list: DatumProps[] = [
       {
         label: 'SC',
-        sc: new BigNumber(address.unspent_siacoins),
+        sc: new BigNumber(unspentSiacoins),
       },
     ]
-    if (address.unspent_siafunds !== '0') {
+    if (unspentSiafunds !== 0) {
       list.push({
         label: 'SF',
-        sf: Number(address.unspent_siafunds),
+        sf: Number(unspentSiafunds),
       })
     }
     return list
-  }, [address])
+  }, [unspentSiacoins, unspentSiafunds])
 
-  const transactions = useMemo(() => {
+  const eventEntities = useMemo(() => {
     const list: EntityListItemProps[] = []
-    if (address.unconfirmed_transactions?.length) {
-      list.push(
-        ...address.unconfirmed_transactions.map((tx) => ({
-          hash: tx.id,
-          sc: getTotal({
-            address: id,
-            inputs: tx.siacoin_inputs,
-            outputs: tx.siacoin_outputs,
-          }),
-          sf: getTotal({
-            address: id,
-            inputs: tx.siafund_inputs,
-            outputs: tx.siafund_outputs,
-          }).toNumber(),
-          label: 'Transaction',
-          initials: 'T',
-          href: routes.transaction.view.replace(':id', tx.id),
-          height: tx.block_height,
-          timestamp: new Date(tx.timestamp).getTime(),
-        }))
-      )
+
+    if (events.length) {
+      events.forEach((event) => {
+        switch (event.type) {
+          case 'v1Transaction':
+            list.push(formatV1TransactionEntity(id, event))
+            break
+          case 'v1ContractResolution':
+            list.push(formatV1ContractResolutionEntity(event))
+            break
+          case 'miner':
+            list.push(formatMinerPayoutEntity(event))
+            break
+        }
+      })
     }
-    if (address.transactions?.length) {
-      list.push(
-        ...address.transactions.map((tx) => ({
-          hash: tx.id,
-          sc: getTotal({
-            address: id,
-            inputs: tx.siacoin_inputs,
-            outputs: tx.siacoin_outputs,
-          }),
-          sf: getTotal({
-            address: id,
-            inputs: tx.siafund_inputs,
-            outputs: tx.siafund_outputs,
-          }).toNumber(),
-          label: 'Transaction',
-          initials: 'T',
-          href: routes.transaction.view.replace(':id', tx.id),
-          height: tx.block_height,
-          timestamp: new Date(tx.timestamp).getTime(),
-        }))
-      )
-    }
-    return list
-  }, [id, address])
+
+    return list.sort(
+      (a, b) =>
+        new Date(b.timestamp || 0).getTime() -
+        new Date(a.timestamp || 0).getTime()
+    )
+  }, [id, events])
 
   const utxos = useMemo(() => {
     const list: EntityListItemProps[] = []
-    if (address.unspent_siacoin_outputs?.length) {
-      list.push(
-        ...address.unspent_siacoin_outputs.map((o) => ({
-          hash: o.output_id,
-          sc: new BigNumber(o.value),
-          label: 'siacoin output',
-          initials: 'SO',
-          scVariant: 'value' as const,
-          height: o.block_height,
-        }))
+    if (unspentOutputs.length) {
+      unspentOutputs.forEach((output) =>
+        list.push(formatUnspentSiacoinOutputEntity(output))
       )
     }
     return list
-  }, [address])
+  }, [unspentOutputs])
 
   return (
     <ContentLayout
@@ -123,13 +111,9 @@ export function Address({ id, address }: Props) {
               href={routes.address.view.replace(':id', id)}
             />
             <div className="flex gap-2 items-center">
-              <Tooltip
-                content={`${humanNumber(
-                  address.transactions?.length
-                )} total transactions`}
-              >
+              <Tooltip content={`${humanNumber(events.length)} total events`}>
                 <Badge variant="accent">
-                  {`${humanNumber(address.transactions?.length)}`} transactions
+                  {`${humanNumber(events.length)}`} events
                 </Badge>
               </Tooltip>
             </div>
@@ -148,11 +132,11 @@ export function Address({ id, address }: Props) {
         onValueChange={(val) => setTab(val as Tab)}
       >
         <TabsList aria-label="Address tabs">
-          <TabsTrigger value="transactions">Transactions</TabsTrigger>
+          <TabsTrigger value="events">Events</TabsTrigger>
           <TabsTrigger value="utxos">Unspent outputs</TabsTrigger>
         </TabsList>
-        <TabsContent value="transactions">
-          <EntityList dataset={transactions} />
+        <TabsContent value="events">
+          <EntityList dataset={eventEntities} />
         </TabsContent>
         <TabsContent value="utxos">
           <EntityList dataset={utxos} />
@@ -168,18 +152,78 @@ function getTotal({
   outputs,
 }: {
   address: string
-  inputs?: { value: string; unlock_hash: string }[]
-  outputs?: { value: string; unlock_hash: string }[]
+  inputs?: { value: string; address: string }[]
+  outputs?: { value: string | number; address: string }[]
 }) {
   return (outputs || [])
     .reduce(
-      (acc, o) => (o.unlock_hash === address ? acc.plus(o.value) : acc),
+      (acc, o) => (o.address === address ? acc.plus(o.value) : acc),
       new BigNumber(0)
     )
     .minus(
       (inputs || []).reduce(
-        (acc, i) => (i.unlock_hash === address ? acc.plus(i.value) : acc),
+        (acc, i) => (i.address === address ? acc.plus(i.value) : acc),
         new BigNumber(0)
       )
     )
+}
+
+function formatV1TransactionEntity(id: string, v1Transaction: ExplorerEvent) {
+  const { transaction } = v1Transaction.data as EventV1Transaction
+  return {
+    hash: v1Transaction.id,
+    sc: getTotal({
+      address: id,
+      inputs: transaction.siacoinInputs,
+      outputs: transaction.siacoinOutputs?.map((o) => o.siacoinOutput),
+    }),
+    sf: getTotal({
+      address: id,
+      inputs: transaction.siafundInputs,
+      outputs: transaction.siafundOutputs?.map((o) => o.siafundOutput),
+    }).toNumber(),
+    label: 'Transaction',
+    initials: 'TX',
+    href: routes.transaction.view.replace(':id', transaction.id),
+    height: v1Transaction.index.height,
+    timestamp: new Date(v1Transaction.timestamp).getTime(),
+  }
+}
+
+function formatV1ContractResolutionEntity(v1ContractResolution: ExplorerEvent) {
+  const { parent, siacoinElement } =
+    v1ContractResolution.data as EventV1ContractResolution
+  return {
+    hash: v1ContractResolution.id,
+    label: 'Contract Resolution',
+    initials: 'CR',
+    href: routes.contract.view.replace(':id', parent.id),
+    sc: new BigNumber(siacoinElement.siacoinOutput.value),
+    timestamp: new Date(v1ContractResolution.timestamp).getTime(),
+  }
+}
+
+function formatMinerPayoutEntity(minerPayout: ExplorerEvent) {
+  const { siacoinElement } = minerPayout.data as EventPayout
+  return {
+    hash: minerPayout.id,
+    label: 'Miner Payout',
+    initials: 'MP',
+    href: routes.address.view.replace(':id', siacoinElement.source),
+    height: minerPayout.index.height,
+    sc: new BigNumber(siacoinElement.siacoinOutput.value),
+    timestamp: new Date(minerPayout.timestamp).getTime(),
+  }
+}
+
+function formatUnspentSiacoinOutputEntity(
+  siacoinOutput: ExplorerSiacoinOutput
+) {
+  return {
+    hash: siacoinOutput.id,
+    sc: new BigNumber(siacoinOutput.siacoinOutput.value),
+    label: 'siacoin output',
+    initials: 'SO',
+    scVariant: 'value' as const,
+  }
 }

--- a/apps/explorer/components/AddressSkeleton/index.tsx
+++ b/apps/explorer/components/AddressSkeleton/index.tsx
@@ -24,12 +24,12 @@ export function AddressSkeleton() {
         </div>
       }
     >
-      <Tabs value="transactions">
+      <Tabs value="events">
         <TabsList aria-label="Address tabs">
-          <TabsTrigger value="transactions">Transactions</TabsTrigger>
+          <TabsTrigger value="events">Events</TabsTrigger>
           <TabsTrigger value="utxos">Unspent outputs</TabsTrigger>
         </TabsList>
-        <TabsContent value="transactions">
+        <TabsContent value="events">
           <EntityList isLoading />
         </TabsContent>
         <TabsContent value="utxos">


### PR DESCRIPTION
Replacing the API here forced a decision around event display, so this has some small UI changes:

* References to transactions in the upper right corner and the tab are now "events". Changed the skeleton to match.
* Items in the event list are now labeled more granularly with the type of event and hopefully all the relevant linking. (Need a check on this for sure)