### PR TITLE
feat(explorer): use explored for search

### DIFF
--- a/.changeset/quiet-maps-attend.md
+++ b/.changeset/quiet-maps-attend.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Replace Sia Central with explored for search.


### PR DESCRIPTION
This PR replaces Sia Central with explored, for the explorer search feature.

Down stack, we add the 'host' SearchResultType return. Before the [connected](https://github.com/SiaFoundation/explored/pull/161) PR hits, if a user searches for a host pubkey with the `ed25519` prefix, we will succeed. If not prefixed, we will hit the error case (and tell the user the request failed) but, after the PR hits, this should just work.