### PR TITLE
fix: update supported fiat exchange currencies

### DIFF
--- a/.changeset/heavy-ducks-work.md
+++ b/.changeset/heavy-ducks-work.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Updated the list of currencies to those supported by explored.

--- a/.changeset/slimy-coats-sneeze.md
+++ b/.changeset/slimy-coats-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@siafoundation/sia-central-mock': minor
+'@siafoundation/sia-central-types': minor
+---
+
+Removed unsupported currencies from Sia Central SDKs.

--- a/libs/react-core/src/appSettings/useExternalData/currency.ts
+++ b/libs/react-core/src/appSettings/useExternalData/currency.ts
@@ -6,7 +6,6 @@ export type CurrencyId =
   | 'jpy'
   | 'aud'
   | 'cny'
-  | 'rub'
   | 'btc'
   | 'eth'
 
@@ -52,12 +51,6 @@ export const currencyOptions: CurrencyOption[] = [
     id: 'aud',
     label: 'AUD',
     prefix: '$',
-    fixed: 2,
-  },
-  {
-    id: 'rub',
-    label: 'RUB',
-    prefix: '₽',
     fixed: 2,
   },
   {

--- a/libs/sia-central-mock/src/siaCentralExchangeRates.ts
+++ b/libs/sia-central-mock/src/siaCentralExchangeRates.ts
@@ -18,8 +18,6 @@ export function getMockSiaCentralExchangeRatesResponse(): SiaCentralExchangeRate
         jpy: '1.600530478116',
         ltc: '0.000116295710314',
         rub: '0.978819669836',
-        scp: '0.0623627615062762',
-        sf: '0.000000745235',
         usd: '0.010571307522',
       },
     },

--- a/libs/sia-central-types/src/exchangeRates.ts
+++ b/libs/sia-central-types/src/exchangeRates.ts
@@ -11,8 +11,6 @@ export type SiaCentralExchangeRates = {
     jpy: string
     ltc: string
     rub: string
-    scp: string
-    sf: string
     usd: string
   }
 }


### PR DESCRIPTION
- Updated the list of currencies to those supported by explored.
- Removed unsupported currencies from Sia Central SDKs.