### PR TITLE
fix(renterd): files name sort is on path

### DIFF
--- a/.changeset/healthy-moles-unite.md
+++ b/.changeset/healthy-moles-unite.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where files were being sorted by name rather than full path in all files mode.

--- a/.changeset/tiny-donkeys-do.md
+++ b/.changeset/tiny-donkeys-do.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The default files sort direction is now asc instead of desc.

--- a/apps/renterd-e2e/src/specs/pagination.spec.ts
+++ b/apps/renterd-e2e/src/specs/pagination.spec.ts
@@ -59,7 +59,7 @@ test('paginating files works as expected in both directory and all files mode', 
 
   const first = page.getByRole('button', { name: 'go to first page' })
   const next = page.getByRole('button', { name: 'go to next page' })
-  await expectFileRowById(page, 'bucket1/file5.txt')
+  await expectFileRowById(page, 'bucket1/file1.txt')
   await expect(first).toBeDisabled()
   await expect(next).toBeEnabled()
   await next.click()
@@ -67,7 +67,7 @@ test('paginating files works as expected in both directory and all files mode', 
   await expect(first).toBeEnabled()
   await expect(next).toBeEnabled()
   await next.click()
-  await expectFileRowById(page, 'bucket1/file1.txt')
+  await expectFileRowById(page, 'bucket1/file5.txt')
   await expect(first).toBeEnabled()
   await expect(next).toBeDisabled()
 
@@ -75,7 +75,7 @@ test('paginating files works as expected in both directory and all files mode', 
   url = page.url()
   await page.goto(url + '?limit=2')
 
-  await expectFileRowById(page, 'bucket1/file5.txt')
+  await expectFileRowById(page, 'bucket1/file1.txt')
   await expect(first).toBeDisabled()
   await expect(next).toBeEnabled()
   await next.click()
@@ -83,7 +83,7 @@ test('paginating files works as expected in both directory and all files mode', 
   await expect(first).toBeEnabled()
   await expect(next).toBeEnabled()
   await next.click()
-  await expectFileRowById(page, 'bucket1/file1.txt')
+  await expectFileRowById(page, 'bucket1/file5.txt')
   await expect(first).toBeEnabled()
   await expect(next).toBeDisabled()
 })

--- a/apps/renterd/contexts/filesManager/dataset.tsx
+++ b/apps/renterd/contexts/filesManager/dataset.tsx
@@ -2,7 +2,7 @@ import { ObjectMetadata } from '@siafoundation/renterd-types'
 import { sortBy, toPairs } from '@technically/lodash'
 import useSWR from 'swr'
 import { useContracts } from '../contracts'
-import { ObjectData } from './types'
+import { ObjectData, sortOptions } from './types'
 import {
   buildDirectoryPath,
   getFilename,
@@ -127,9 +127,11 @@ export function useDataset({ id, objects, tableState }: Props) {
             dataMap[upload.path] = upload
           })
       }
+      // Re-apply sort on the client so that uploads are included.
+      const sortInfo = sortOptions.find((s) => s.id === tableState.sortField)
       const all = sortBy(
         toPairs(dataMap).map((p) => p[1]),
-        tableState.sortField as keyof ObjectData
+        sortInfo?.clientId || 'path'
       )
       if (tableState.sortDirection === 'desc') {
         all.reverse()

--- a/apps/renterd/contexts/filesManager/types.ts
+++ b/apps/renterd/contexts/filesManager/types.ts
@@ -59,24 +59,32 @@ export const columnsDefaultVisible: TableColumnId[] = [
 export type SortField = 'name' | 'health' | 'size'
 
 export const defaultSortField: SortField = 'name'
+export const defaultSortDirection = 'asc'
 
-export const sortOptions: { id: SortField; label: string; category: string }[] =
-  [
-    {
-      id: 'name',
-      label: 'name',
-      category: 'general',
-    },
-    {
-      id: 'health',
-      label: 'health',
-      category: 'general',
-    },
-    {
-      id: 'size',
-      label: 'size',
-      category: 'general',
-    },
-  ]
+export const sortOptions: {
+  id: SortField
+  label: string
+  category: string
+  clientId: keyof ObjectData
+}[] = [
+  {
+    id: 'name',
+    label: 'name',
+    clientId: 'path',
+    category: 'general',
+  },
+  {
+    id: 'health',
+    label: 'health',
+    clientId: 'health',
+    category: 'general',
+  },
+  {
+    id: 'size',
+    label: 'size',
+    clientId: 'size',
+    category: 'general',
+  },
+]
 
 export type ExplorerMode = 'directory' | 'flat'

--- a/apps/renterd/contexts/filesManager/useFilesTableState.tsx
+++ b/apps/renterd/contexts/filesManager/useFilesTableState.tsx
@@ -3,6 +3,7 @@ import {
   FilesTableColumn,
   columnsDefaultVisible,
   defaultSortField,
+  defaultSortDirection,
   sortOptions,
 } from './types'
 
@@ -12,5 +13,6 @@ export function useFilesTableState(columns: FilesTableColumn[]) {
     columnsDefaultVisible,
     sortOptions,
     defaultSortField,
+    defaultSortDirection,
   })
 }


### PR DESCRIPTION
- Fixed an issue where files were being sorted by name rather than full path in all files mode.
  - The sort field is called `name` so it was sorting on the `name` on the client - the server is really sorting on the full path when returning delimiter="" results.
  - The reason we have to re-apply the sorting at all on the client-side because we naturally weave in any active uploads that fit into the current directory or the all files view. This is to achieve a UX where uploads show immediately just in a "syncing" state as seen in iCloud, Dropbox, etc.
- The default files sort direction is now asc instead of desc.


