### PR TITLE
feat(walletd): seed wallet send siacoin v2 transactions

### DIFF
--- a/.changeset/afraid-deers-train.md
+++ b/.changeset/afraid-deers-train.md
@@ -1,0 +1,5 @@
+---
+'walletd': minor
+---
+
+Seed wallets now support and automatically switch to sending V2 transactions once the consensus height hits the V2 hardfork allow height. Closes https://github.com/SiaFoundation/walletd/issues/216 Closes https://github.com/SiaFoundation/walletd/issues/186

--- a/apps/walletd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/walletd-e2e/src/fixtures/beforeTest.ts
@@ -13,10 +13,18 @@ import {
   mockApiSiaScanExchangeRates,
 } from '@siafoundation/e2e'
 
-export async function beforeTest(page: Page) {
+export async function beforeTest(
+  page: Page,
+  { siafundAddr }: { siafundAddr?: string } = {}
+) {
   await mockApiSiaScanExchangeRates({ page })
   await mockApiSiaCentralHostsNetworkAverages({ page })
-  await setupCluster({ walletdCount: 1, renterdCount: 1 })
+  await setupCluster({
+    walletdCount: 1,
+    renterdCount: 1,
+    networkVersion: 'transition',
+    siafundAddr,
+  })
   const walletdNode = clusterd.nodes.find((n) => n.type === 'walletd')
 
   await login({
@@ -29,6 +37,7 @@ export async function beforeTest(page: Page) {
   await setCurrencyDisplay(page, 'bothPreferSc')
 }
 
+// Helper that assumes a single renterd node is being used to test sending funds.
 export async function sendSiacoinFromRenterd(address: string, amount: string) {
   const renterdNode = clusterd.nodes.find((n) => n.type === 'renterd')
   const bus = Bus({
@@ -49,6 +58,12 @@ export async function sendSiacoinFromRenterd(address: string, amount: string) {
   } catch (e) {
     console.log('error sending siacoin', e)
   }
+}
+
+// Helper that assumes a single renterd node is being used to test sending funds.
+export async function getRenterdAddress() {
+  const renterdNode = clusterd.nodes.find((n) => n.type === 'renterd')
+  return renterdNode.walletAddress
 }
 
 export async function afterTest() {

--- a/apps/walletd-e2e/src/fixtures/seedSendSiacoin.ts
+++ b/apps/walletd-e2e/src/fixtures/seedSendSiacoin.ts
@@ -1,0 +1,100 @@
+import { expect } from '@playwright/test'
+import { unlockOpenWallet } from './wallet'
+import { navigateToWallet } from './navigate'
+import { fillComposeTransactionSiacoin } from './sendSiacoinDialog'
+import { step } from '@siafoundation/e2e'
+
+export const sendSiacoinWithSeedWallet = step(
+  'send siacoin with a seed wallet',
+  async (
+    page,
+    {
+      walletName,
+      mnemonic,
+      changeAddress,
+      receiveAddress,
+      amount,
+      expectedFee,
+      expectedVersion,
+    }: {
+      walletName: string
+      mnemonic: string
+      changeAddress: string
+      receiveAddress: string
+      amount: number
+      expectedFee: number
+      expectedVersion: 'v1' | 'v2'
+    }
+  ) => {
+    const amountWithFeeString = `${(amount + expectedFee).toFixed(3)} SC`
+    const feeString = `${expectedFee.toFixed(3)} SC`
+    await navigateToWallet(page, walletName)
+    await unlockOpenWallet(page, mnemonic)
+    await page.getByLabel('send').click()
+    await fillComposeTransactionSiacoin({
+      page,
+      receiveAddress,
+      changeAddress,
+      amount,
+    })
+    const sendDialog = page.getByRole('dialog', { name: 'Send' })
+    await expect(
+      sendDialog.getByText('The wallet is currently unlocked')
+    ).toBeVisible()
+    await expect(sendDialog.getByLabel('Recipient address')).toContainText(
+      receiveAddress.slice(0, 5)
+    )
+    await expect(sendDialog.getByLabel('Change address')).toContainText(
+      changeAddress.slice(0, 5)
+    )
+    await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
+    await expect(sendDialog.getByText('Total')).toBeVisible()
+    await expect(sendDialog.getByText(amountWithFeeString)).toBeVisible()
+
+    await page
+      .getByRole('button', { name: 'Sign and broadcast transaction' })
+      .click()
+    await expect(
+      page.getByText('Transaction successfully broadcast')
+    ).toBeVisible()
+    await expect(sendDialog.getByLabel('Recipient address')).toContainText(
+      receiveAddress.slice(0, 5)
+    )
+    await expect(sendDialog.getByLabel('Change address')).toContainText(
+      changeAddress.slice(0, 5)
+    )
+    await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
+    await expect(sendDialog.getByLabel('Total')).toContainText(
+      amountWithFeeString
+    )
+    if (expectedVersion === 'v2') {
+      await expect(sendDialog.getByLabel('Transaction ID')).toBeVisible()
+    }
+    await sendDialog.getByRole('button', { name: 'Close' }).click()
+    if (expectedVersion === 'v2') {
+      await expect(sendDialog.getByLabel('Transaction ID')).toBeVisible()
+    }
+    const transactionId: string | undefined =
+      expectedVersion === 'v2'
+        ? ((await sendDialog
+            .getByLabel('Transaction ID')
+            .getAttribute('value')) as string)
+        : undefined
+
+    await page.reload()
+    await expect(page.getByTestId('eventsTable')).toBeVisible()
+    await expect(
+      page.getByTestId('eventsTable').locator('tbody tr').first()
+    ).toBeVisible()
+    await expect(
+      page
+        .getByTestId('eventsTable')
+        .locator('tbody tr')
+        .first()
+        .getByTestId('amount')
+        .getByText(`-${amountWithFeeString}`)
+    ).toBeVisible()
+
+    return transactionId
+  }
+)

--- a/apps/walletd-e2e/src/fixtures/seedSendSiafund.ts
+++ b/apps/walletd-e2e/src/fixtures/seedSendSiafund.ts
@@ -1,0 +1,106 @@
+import { expect } from '@playwright/test'
+import { unlockOpenWallet } from './wallet'
+import { navigateToWallet } from './navigate'
+import { fillComposeTransactionSiafund } from './sendSiafundDialog'
+import { step } from '@siafoundation/e2e'
+
+export const sendSiafundWithSeedWallet = step(
+  'send siafund with a seed wallet',
+  async (
+    page,
+    {
+      walletName,
+      mnemonic,
+      changeAddress,
+      receiveAddress,
+      claimAddress,
+      amount,
+      expectedFee,
+      expectedVersion,
+    }: {
+      walletName: string
+      mnemonic: string
+      changeAddress: string
+      receiveAddress: string
+      claimAddress?: string
+      amount: number
+      expectedFee: number
+      expectedVersion: 'v1' | 'v2'
+    }
+  ) => {
+    const amountString = `${amount} SF`
+    const feeString = `${expectedFee.toFixed(3)} SC`
+
+    await navigateToWallet(page, walletName)
+    await unlockOpenWallet(page, mnemonic)
+    await page.getByLabel('send').click()
+    await fillComposeTransactionSiafund({
+      page,
+      receiveAddress,
+      changeAddress,
+      amount,
+    })
+    const sendDialog = page.getByRole('dialog', { name: 'Send' })
+    await expect(
+      sendDialog.getByText('The wallet is currently unlocked')
+    ).toBeVisible()
+    await expect(sendDialog.getByLabel('Recipient address')).toContainText(
+      receiveAddress.slice(0, 5)
+    )
+    await expect(sendDialog.getByLabel('Change address')).toContainText(
+      changeAddress.slice(0, 5)
+    )
+    if (expectedVersion === 'v1' && claimAddress) {
+      await expect(sendDialog.getByLabel('Claim address')).toContainText(
+        claimAddress.slice(0, 5)
+      )
+    }
+    await expect(sendDialog.getByLabel('Amount')).toContainText(amountString)
+    await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
+
+    await page
+      .getByRole('button', { name: 'Sign and broadcast transaction' })
+      .click()
+    await expect(
+      page.getByText('Transaction successfully broadcast')
+    ).toBeVisible()
+    await expect(sendDialog.getByLabel('Recipient address')).toContainText(
+      receiveAddress.slice(0, 5)
+    )
+    await expect(sendDialog.getByLabel('Change address')).toContainText(
+      changeAddress.slice(0, 5)
+    )
+    if (expectedVersion === 'v1' && claimAddress) {
+      await expect(sendDialog.getByLabel('Claim address')).toContainText(
+        claimAddress.slice(0, 5)
+      )
+    }
+    await expect(sendDialog.getByLabel('Amount')).toContainText(amountString)
+    await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
+    if (expectedVersion === 'v2') {
+      await expect(sendDialog.getByLabel('Transaction ID')).toBeVisible()
+    }
+    const transactionId: string | undefined =
+      expectedVersion === 'v2'
+        ? ((await sendDialog
+            .getByLabel('Transaction ID')
+            .getAttribute('value')) as string)
+        : undefined
+
+    await page.reload()
+    await expect(page.getByTestId('eventsTable')).toBeVisible()
+    await expect(
+      page.getByTestId('eventsTable').locator('tbody tr').first()
+    ).toBeVisible()
+    await expect(
+      page
+        .getByTestId('eventsTable')
+        .locator('tbody tr')
+        .first()
+        .getByTestId('amount')
+        .getByText(`-${amountString}`)
+    ).toBeVisible()
+
+    return transactionId
+  }
+)

--- a/apps/walletd-e2e/src/fixtures/sendSiafundDialog.ts
+++ b/apps/walletd-e2e/src/fixtures/sendSiafundDialog.ts
@@ -1,7 +1,11 @@
 import { Page } from 'playwright'
-import { fillTextInputByName, step } from '@siafoundation/e2e'
+import {
+  fillSelectInputByName,
+  fillTextInputByName,
+  step,
+} from '@siafoundation/e2e'
 
-export const fillComposeTransactionSiacoin = step(
+export const fillComposeTransactionSiafund = step(
   'fill compose transaction siacoin',
   async ({
     page,
@@ -15,9 +19,10 @@ export const fillComposeTransactionSiacoin = step(
     amount: number
   }) => {
     await fillTextInputByName(page, 'receiveAddress', receiveAddress)
+    await fillSelectInputByName(page, 'mode', 'siafund')
     await page.getByLabel('customChangeAddress').click()
     await fillTextInputByName(page, 'changeAddress', changeAddress)
-    await fillTextInputByName(page, 'siacoin', String(amount))
+    await fillTextInputByName(page, 'siafund', String(amount))
     await page.getByRole('button', { name: 'Generate transaction' }).click()
   }
 )

--- a/apps/walletd/components/Wallet/WalletActionsMenu.tsx
+++ b/apps/walletd/components/Wallet/WalletActionsMenu.tsx
@@ -89,6 +89,7 @@ export function WalletActionsMenu() {
           wallet={wallet}
           trigger={
             <Button
+              aria-label="wallet context menu"
               size="small"
               tip="Wallet settings"
               tipAlign="end"

--- a/apps/walletd/components/WalletContextMenu.tsx
+++ b/apps/walletd/components/WalletContextMenu.tsx
@@ -29,7 +29,6 @@ export function WalletContextMenu({
       {metadata.type === 'seed' ? (
         state.status === 'unlocked' ? (
           <DropdownMenuItem
-            aria-label="Wallet context menu"
             onClick={(e) => e.stopPropagation()}
             onSelect={() => actions.lock()}
           >

--- a/apps/walletd/components/WalletsList/WalletsFiltersBar.tsx
+++ b/apps/walletd/components/WalletsList/WalletsFiltersBar.tsx
@@ -8,7 +8,7 @@ export function WalletsFiltersBar() {
     useWallets()
 
   return (
-    <div className="flex gap-2 w-full">
+    <div className="flex items-center gap-2 w-full">
       {!!unlockedCount && (
         <div className="flex gap-1.5">
           <Text>

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/useFundAndSign.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/useFundAndSign.tsx
@@ -1,9 +1,9 @@
 import { ChainIndex, Transaction } from '@siafoundation/types'
 import { useCallback } from 'react'
-import { SendParams } from '../_sharedWalletSend/types'
+import { SendParamsV1 } from '../_sharedWalletSendV1/typesV1'
 
 type Props = {
-  fund: (params: SendParams) => Promise<{
+  fund: (params: SendParamsV1) => Promise<{
     fundedTransaction?: Transaction
     toSign?: string[]
     error?: string
@@ -24,7 +24,7 @@ type Props = {
 
 export function useFundAndSign({ fund, cancel, sign }: Props) {
   const fundAndSign = useCallback(
-    async (params: SendParams) => {
+    async (params: SendParamsV1) => {
       const {
         fundedTransaction,
         toSign,

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/useSendForm.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/useSendForm.tsx
@@ -1,4 +1,4 @@
-import { SendReceipt } from '../_sharedWalletSend/SendReceipt'
+import { SendReceiptV1 } from '../_sharedWalletSendV1/SendReceiptV1'
 import { useForm } from 'react-hook-form'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
@@ -13,11 +13,11 @@ import { useLedger } from '../../contexts/ledger'
 import { Transaction, ChainIndex } from '@siafoundation/types'
 import { LedgerSignTxn } from './LedgerSignTxn'
 import { useSign } from './useSign'
-import { useBroadcast } from '../_sharedWalletSend/useBroadcast'
+import { useBroadcastV1 } from '../_sharedWalletSendV1/useBroadcastV1'
 import { useFundAndSign } from './useFundAndSign'
-import { useCancel } from '../_sharedWalletSend/useCancel'
-import { useFund } from '../_sharedWalletSend/useFund'
-import { SendParams, SendStep } from '../_sharedWalletSend/types'
+import { useCancelV1 } from '../_sharedWalletSendV1/useCancelV1'
+import { useFundV1 } from '../_sharedWalletSendV1/useFundV1'
+import { SendParamsV1, SendStep } from '../_sharedWalletSendV1/typesV1'
 
 const defaultValues = {
   isConnected: false,
@@ -27,7 +27,7 @@ const defaultValues = {
 type Props = {
   walletId: string
   step: SendStep
-  params: SendParams
+  params: SendParamsV1
   onConfirm: (params: { transactionId?: string }) => void
 }
 
@@ -62,10 +62,10 @@ export function useSendForm({ params, step, onConfirm }: Props) {
   const isConnected = form.watch('isConnected')
   const isSigned = form.watch('isSigned')
   const { device, error: ledgerError } = useLedger()
-  const cancel = useCancel()
+  const cancel = useCancelV1()
   const sign = useSign({ cancel })
-  const broadcast = useBroadcast({ cancel })
-  const fund = useFund()
+  const broadcast = useBroadcastV1({ cancel })
+  const fund = useFundV1()
   const fundAndSign = useFundAndSign({ cancel, fund, sign })
   const [waitingForUser, setWaitingForUser] = useState(false)
   const [txn, setTxn] = useState<Transaction>()
@@ -177,7 +177,7 @@ export function useSendForm({ params, step, onConfirm }: Props) {
           />
         </div>
       </div>
-      <SendReceipt params={params} />
+      <SendReceiptV1 params={params} />
     </div>
   )
 

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/index.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/index.tsx
@@ -1,37 +1,34 @@
 import BigNumber from 'bignumber.js'
 import { useMemo, useState } from 'react'
+import { useComposeFormV1 } from '../../_sharedWalletSendV1/useComposeFormV1'
+import { useSendFormV1 } from './useSendFormV1'
 import { useWalletBalance } from '@siafoundation/walletd-react'
-import { useComposeFormV1 } from '../_sharedWalletSendV1/useComposeFormV1'
-import { useSendForm } from './useSendForm'
+import { SendFlowDialogV1 } from '../../_sharedWalletSendV1/SendFlowDialogV1'
 import {
   SendParamsV1,
   SendStep,
   emptySendParamsV1,
-} from '../_sharedWalletSendV1/typesV1'
-import { SendFlowDialogV1 } from '../_sharedWalletSendV1/SendFlowDialogV1'
-import { useWalletAddresses } from '../../hooks/useWalletAddresses'
+} from '../../_sharedWalletSendV1/typesV1'
+import { useWalletAddresses } from '../../../hooks/useWalletAddresses'
 
-export type WalletSendLedgerDialogParams = {
+export type WalletSendSeedDialogParams = {
   walletId: string
 }
 
 type Props = {
-  params?: WalletSendLedgerDialogParams
+  params?: WalletSendSeedDialogParams
   trigger?: React.ReactNode
   open: boolean
   onOpenChange: (val: boolean) => void
 }
 
-export function WalletSendLedgerDialog({
+export function WalletSendSeedDialogV1({
   params: dialogParams,
   trigger,
   open,
   onOpenChange,
 }: Props) {
   const { walletId } = dialogParams || {}
-  const [step, setStep] = useState<SendStep>('compose')
-  const [signedTxnId, setSignedTxnId] = useState<string>()
-  const [sendParams, setSendParams] = useState<SendParamsV1>(emptySendParamsV1)
   const balance = useWalletBalance({
     disabled: !walletId,
     params: {
@@ -39,16 +36,18 @@ export function WalletSendLedgerDialog({
     },
   })
   const { dataset: addresses } = useWalletAddresses({ id: walletId })
-
   const balanceSc = useMemo(
     () => new BigNumber(balance.data?.siacoins || 0),
     [balance.data]
   )
-
   const balanceSf = useMemo(
     () => new BigNumber(balance.data?.siafunds || 0),
     [balance.data]
   )
+
+  const [step, setStep] = useState<SendStep>('compose')
+  const [signedTxnId, setSignedTxnId] = useState<string>()
+  const [sendParams, setSendParams] = useState<SendParamsV1>(emptySendParamsV1)
 
   // Form for each step
   const compose = useComposeFormV1({
@@ -56,17 +55,17 @@ export function WalletSendLedgerDialog({
     balanceSf,
     defaultChangeAddress: addresses?.[0]?.address,
     defaultClaimAddress: addresses?.[0]?.address,
-    onComplete: (data) => {
+    onComplete: (params) => {
       setSendParams((d) => ({
         ...d,
-        ...data,
+        ...params,
       }))
       setStep('send')
     },
   })
-  const send = useSendForm({
+
+  const send = useSendFormV1({
     walletId,
-    step,
     params: sendParams,
     onConfirm: ({ transactionId }) => {
       setSignedTxnId(transactionId)

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/useSendFormV1.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/useSendFormV1.tsx
@@ -1,4 +1,4 @@
-import { SendReceipt } from '../_sharedWalletSend/SendReceipt'
+import { SendReceiptV1 } from '../../_sharedWalletSendV1/SendReceiptV1'
 import { useForm } from 'react-hook-form'
 import { useCallback, useMemo, useState } from 'react'
 import {
@@ -6,16 +6,16 @@ import {
   triggerErrorToast,
   useOnInvalid,
 } from '@siafoundation/design-system'
-import { getFieldMnemonic, MnemonicFieldType } from '../../lib/fieldMnemonic'
-import { FieldMnemonic } from '../FieldMnemonic'
-import { useWalletCachedSeed } from '../../hooks/useWalletCachedSeed'
-import { useSignAndBroadcast } from './useSignAndBroadcast'
-import { useWallets } from '../../contexts/wallets'
-import { SendParams } from '../_sharedWalletSend/types'
+import { getFieldMnemonic, MnemonicFieldType } from '../../../lib/fieldMnemonic'
+import { FieldMnemonic } from '../../FieldMnemonic'
+import { useWalletCachedSeed } from '../../../hooks/useWalletCachedSeed'
+import { useSignAndBroadcastV1 } from './useSignAndBroadcastV1'
+import { useWallets } from '../../../contexts/wallets'
+import { SendParamsV1 } from '../../_sharedWalletSendV1/typesV1'
 
 type Props = {
   walletId: string
-  params: SendParams
+  params: SendParamsV1
   onConfirm: (params: { transactionId?: string }) => void
 }
 
@@ -51,8 +51,8 @@ function getFields({
   }
 }
 
-export function useSendForm({ walletId, params, onConfirm }: Props) {
-  const signAndBroadcast = useSignAndBroadcast()
+export function useSendFormV1({ walletId, params, onConfirm }: Props) {
+  const signAndBroadcast = useSignAndBroadcastV1()
   const { isSeedCached } = useWalletCachedSeed(walletId)
   const { dataset } = useWallets()
   const wallet = dataset?.find((w) => w.id === walletId)
@@ -109,7 +109,7 @@ export function useSendForm({ walletId, params, onConfirm }: Props) {
         fields={fields}
         actionText="complete the transaction"
       />
-      <SendReceipt params={params} />
+      <SendReceiptV1 params={params} />
     </div>
   )
 

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/useSignAndBroadcastV1.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/useSignAndBroadcastV1.tsx
@@ -1,0 +1,102 @@
+import {
+  useConsensusNetwork,
+  useWalletOutputsSiacoin,
+  useConsensusTipState,
+  useWalletOutputsSiafund,
+} from '@siafoundation/walletd-react'
+import { useWallets } from '../../../contexts/wallets'
+import { useCallback } from 'react'
+import { signTransactionSeedV1 } from '../../../lib/signSeedV1'
+import { useWalletAddresses } from '../../../hooks/useWalletAddresses'
+import { SendParamsV1 } from '../../_sharedWalletSendV1/typesV1'
+import { useBroadcastV1 } from '../../_sharedWalletSendV1/useBroadcastV1'
+import { useCancelV1 } from '../../_sharedWalletSendV1/useCancelV1'
+import { useFundV1 } from '../../_sharedWalletSendV1/useFundV1'
+
+export function useSignAndBroadcastV1() {
+  const { wallet, cacheWalletMnemonic } = useWallets()
+  const walletId = wallet?.id
+
+  const siacoinOutputs = useWalletOutputsSiacoin({
+    disabled: !walletId,
+    params: {
+      id: walletId,
+    },
+  })
+  const siafundOutputs = useWalletOutputsSiafund({
+    disabled: !walletId,
+    params: {
+      id: walletId,
+    },
+  })
+  const { dataset: addresses } = useWalletAddresses({ id: walletId })
+  const cs = useConsensusTipState()
+  const cn = useConsensusNetwork()
+  const fund = useFundV1()
+  const cancel = useCancelV1()
+  const broadcast = useBroadcastV1({ cancel })
+
+  return useCallback(
+    async ({
+      mnemonic,
+      params,
+    }: {
+      mnemonic: string
+      params: SendParamsV1
+    }) => {
+      if (!addresses) {
+        return {
+          error: 'No addresses found',
+        }
+      }
+
+      // fund
+      const {
+        fundedTransaction,
+        toSign,
+        error: fundingError,
+        basis,
+      } = await fund(params)
+      if (fundingError) {
+        return {
+          fundedTransaction,
+          error: fundingError,
+        }
+      }
+      const { signedTransaction, error: signingError } = signTransactionSeedV1({
+        mnemonic,
+        transaction: fundedTransaction,
+        toSign,
+        consensusState: cs.data,
+        consensusNetwork: cn.data,
+        addresses,
+        siacoinOutputs: siacoinOutputs.data?.outputs,
+        siafundOutputs: siafundOutputs.data?.outputs,
+      })
+      if (signingError) {
+        cancel(fundedTransaction)
+        return {
+          error: signingError,
+        }
+      }
+
+      // if successfully signed cache the seed
+      cacheWalletMnemonic(walletId, mnemonic)
+
+      // broadcast
+      return broadcast({ signedTransaction, basis })
+    },
+    [
+      cancel,
+      addresses,
+      fund,
+      walletId,
+      cs.data,
+      cn.data,
+      siacoinOutputs.data,
+      siafundOutputs.data,
+      cacheWalletMnemonic,
+      broadcast,
+    ]
+  )
+}

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV2/useSendFormV2.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV2/useSendFormV2.tsx
@@ -1,0 +1,122 @@
+import { useForm } from 'react-hook-form'
+import { useCallback, useMemo, useState } from 'react'
+import {
+  ConfigFields,
+  triggerErrorToast,
+  useOnInvalid,
+} from '@siafoundation/design-system'
+import { getFieldMnemonic, MnemonicFieldType } from '../../../lib/fieldMnemonic'
+import { FieldMnemonic } from '../../FieldMnemonic'
+import { useWalletCachedSeed } from '../../../hooks/useWalletCachedSeed'
+import { useSignAndBroadcastV2 } from './useSignAndBroadcastV2'
+import { useWallets } from '../../../contexts/wallets'
+import { SendParamsV2 } from '../../_sharedWalletSendV2/typesV2'
+import { SendReceiptV2 } from '../../_sharedWalletSendV2/SendReceiptV2'
+
+type Props = {
+  walletId: string
+  params: SendParamsV2
+  onConfirm: (params: { transactionId?: string }) => void
+}
+
+const defaultValues = {
+  mnemonic: '',
+}
+
+type Values = typeof defaultValues
+
+function getFields({
+  mnemonicHash,
+  mnemonicFieldType,
+  setMnemonicFieldType,
+  isSeedCached,
+}: {
+  mnemonicHash?: string
+  mnemonicFieldType: MnemonicFieldType
+  setMnemonicFieldType: (type: MnemonicFieldType) => void
+  isSeedCached: boolean
+}): ConfigFields<Values, never> {
+  return {
+    mnemonic: isSeedCached
+      ? {
+          title: 'Seed',
+          type: 'text',
+          validation: {},
+        }
+      : getFieldMnemonic({
+          mnemonicHash,
+          setMnemonicFieldType,
+          mnemonicFieldType,
+        }),
+  }
+}
+
+export function useSendFormV2({ walletId, params, onConfirm }: Props) {
+  const signAndBroadcastV2 = useSignAndBroadcastV2()
+  const { isSeedCached } = useWalletCachedSeed(walletId)
+  const { dataset } = useWallets()
+  const wallet = dataset?.find((w) => w.id === walletId)
+  const mnemonicHash = wallet?.metadata.mnemonicHash
+
+  const form = useForm({
+    mode: 'all',
+    defaultValues,
+  })
+
+  const [mnemonicFieldType, setMnemonicFieldType] =
+    useState<MnemonicFieldType>('password')
+  const fields = useMemo(
+    () =>
+      getFields({
+        mnemonicFieldType,
+        setMnemonicFieldType,
+        mnemonicHash,
+        isSeedCached,
+      }),
+    [mnemonicFieldType, setMnemonicFieldType, mnemonicHash, isSeedCached]
+  )
+
+  const onValid = useCallback(
+    async (values: Values) => {
+      const result = await signAndBroadcastV2({
+        mnemonic: wallet.state.mnemonic || values.mnemonic,
+        params,
+      })
+
+      if ('error' in result) {
+        triggerErrorToast({ title: result.error })
+        return
+      }
+
+      onConfirm({ transactionId: result.id })
+    },
+    [signAndBroadcastV2, params, onConfirm, wallet]
+  )
+
+  const onInvalid = useOnInvalid(fields)
+
+  const handleSubmit = useMemo(
+    () => form.handleSubmit(onValid, onInvalid),
+    [form, onValid, onInvalid]
+  )
+
+  const el = (
+    <div className="flex flex-col gap-4">
+      <FieldMnemonic
+        walletId={walletId}
+        name="mnemonic"
+        form={form}
+        fields={fields}
+        actionText="complete the transaction"
+      />
+      <SendReceiptV2 params={params} />
+    </div>
+  )
+
+  return {
+    form,
+    el,
+    handleSubmit,
+    reset: () => form.reset(defaultValues),
+  }
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV1/SendDoneV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/SendDoneV1.tsx
@@ -1,0 +1,23 @@
+import { Text } from '@siafoundation/design-system'
+import { CheckmarkFilled32 } from '@siafoundation/react-icons'
+import { SendReceiptV1 } from './SendReceiptV1'
+import { SendParamsV1 } from './typesV1'
+
+type Props = {
+  params: SendParamsV1
+  transactionId?: string
+}
+
+export function SendDoneV1({ params, transactionId }: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <SendReceiptV1 params={params} transactionId={transactionId} />
+      <div className="flex flex-col items-center justify-center gap-2 my-4">
+        <Text>
+          <CheckmarkFilled32 />
+        </Text>
+        <Text>Transaction successfully broadcast.</Text>
+      </div>
+    </div>
+  )
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV1/SendFlowDialogV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/SendFlowDialogV1.tsx
@@ -4,8 +4,8 @@ import {
   ProgressSteps,
   FormSubmitButton,
 } from '@siafoundation/design-system'
-import { SendDone } from './SendDone'
-import { SendParams, SendStep } from './types'
+import { SendDoneV1 } from './SendDoneV1'
+import { SendParamsV1, SendStep } from './typesV1'
 import { UseFormReturn } from 'react-hook-form'
 
 export type SendDialogParams = {
@@ -30,7 +30,7 @@ type Props = {
     handleSubmit: () => void
     reset: () => void
   }
-  sendParams: SendParams
+  sendParams: SendParamsV1
   signedTxnId?: string
   step: SendStep
   setStep: (step: SendStep) => void
@@ -42,7 +42,7 @@ type Props = {
   }
 }
 
-export function SendFlowDialog({
+export function SendFlowDialogV1({
   trigger,
   open,
   onOpenChange,
@@ -106,7 +106,7 @@ export function SendFlowDialog({
         {step === 'compose' && compose.el}
         {step === 'send' && send.el}
         {step === 'done' && (
-          <SendDone params={sendParams} transactionId={signedTxnId} />
+          <SendDoneV1 params={sendParams} transactionId={signedTxnId} />
         )}
       </div>
     </Dialog>

--- a/apps/walletd/dialogs/_sharedWalletSendV1/SendReceiptV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/SendReceiptV1.tsx
@@ -4,14 +4,14 @@ import {
   ValueCopyable,
   ValueSf,
 } from '@siafoundation/design-system'
-import { SendParams } from './types'
+import { SendParamsV1 } from './typesV1'
 
 type Props = {
-  params: SendParams
+  params: SendParamsV1
   transactionId?: string
 }
 
-export function SendReceipt({
+export function SendReceiptV1({
   params: {
     receiveAddress,
     changeAddress,
@@ -27,57 +27,82 @@ export function SendReceipt({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex gap-6 justify-between items-center">
-        <Text color="verySubtle" noWrap>
+        <Text color="verySubtle" noWrap id="recipientAddress">
           Recipient address
         </Text>
-        <ValueCopyable value={receiveAddress} type="address" />
+        <ValueCopyable
+          value={receiveAddress}
+          type="address"
+          labeledBy="recipientAddress"
+        />
       </div>
       <div className="flex gap-6 justify-between items-center">
-        <Text color="verySubtle" noWrap>
+        <Text color="verySubtle" noWrap id="changeAddress">
           Change address
         </Text>
-        <ValueCopyable value={changeAddress} type="address" />
+        <ValueCopyable
+          value={changeAddress}
+          type="address"
+          labeledBy="changeAddress"
+        />
       </div>
       {mode === 'siafund' && (
         <div className="flex gap-6 justify-between items-center">
-          <Text color="verySubtle" noWrap>
+          <Text color="verySubtle" noWrap id="claimAddress">
             Claim address
           </Text>
-          <ValueCopyable value={claimAddress} type="address" />
+          <ValueCopyable
+            value={claimAddress}
+            type="address"
+            labeledBy="claimAddress"
+          />
         </div>
       )}
       <div className="flex gap-2 justify-between items-center">
-        <Text color="verySubtle" noWrap>
+        <Text color="verySubtle" noWrap id="amount">
           Amount
         </Text>
         <div className="flex relative top-[-0.5px]">
           {mode === 'siacoin' ? (
             <ValueSc
+              labeledBy="amount"
               size="14"
               value={siacoin}
               variant="value"
               dynamicUnits={false}
             />
           ) : (
-            <ValueSf size="14" value={siafund} variant="value" />
+            <ValueSf
+              labeledBy="amount"
+              size="14"
+              value={siafund}
+              variant="value"
+            />
           )}
         </div>
       </div>
       <div className="flex gap-2 justify-between items-center">
-        <Text color="verySubtle" noWrap>
+        <Text color="verySubtle" noWrap id="networkFee">
           Network fee
         </Text>
         <div className="flex relative top-[-0.5px]">
-          <ValueSc size="14" value={fee} variant="value" dynamicUnits={false} />
+          <ValueSc
+            labeledBy="networkFee"
+            size="14"
+            value={fee}
+            variant="value"
+            dynamicUnits={false}
+          />
         </div>
       </div>
       {mode === 'siacoin' && (
         <div className="flex items-center gap-2 justify-between">
-          <Text color="verySubtle" noWrap>
+          <Text color="verySubtle" noWrap id="total">
             Total
           </Text>
           <div className="flex relative top-[-0.5px]">
             <ValueSc
+              labeledBy="total"
               size="14"
               value={totalSiacoin}
               variant="value"
@@ -88,10 +113,14 @@ export function SendReceipt({
       )}
       {transactionId && (
         <div className="flex gap-6 items-center justify-between">
-          <Text color="verySubtle" noWrap>
+          <Text color="verySubtle" noWrap id="transactionId">
             Transaction ID
           </Text>
-          <ValueCopyable value={transactionId} type="transaction" />
+          <ValueCopyable
+            value={transactionId}
+            type="transaction"
+            labeledBy="transactionId"
+          />
         </div>
       )}
     </div>

--- a/apps/walletd/dialogs/_sharedWalletSendV1/typesV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/typesV1.tsx
@@ -1,0 +1,23 @@
+import BigNumber from 'bignumber.js'
+
+export type SendStep = 'compose' | 'send' | 'done'
+
+export type SendParamsV1 = {
+  mode: 'siacoin' | 'siafund'
+  receiveAddress: string
+  changeAddress: string
+  claimAddress: string
+  siafund: number
+  siacoin: BigNumber
+  fee: BigNumber
+}
+
+export const emptySendParamsV1: SendParamsV1 = {
+  mode: 'siacoin',
+  receiveAddress: '',
+  changeAddress: '',
+  claimAddress: '',
+  siacoin: new BigNumber(0),
+  siafund: 0,
+  fee: new BigNumber(0),
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV1/useBroadcastV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/useBroadcastV1.tsx
@@ -1,0 +1,49 @@
+import { ChainIndex, Transaction } from '@siafoundation/types'
+import { useTxPoolBroadcast } from '@siafoundation/walletd-react'
+import { useCallback } from 'react'
+
+export function useBroadcastV1({
+  cancel,
+}: {
+  cancel: (t: Transaction) => void
+}) {
+  const txPoolBroadcast = useTxPoolBroadcast()
+
+  const broadcast = useCallback(
+    async ({
+      signedTransaction,
+      basis,
+    }: {
+      signedTransaction: Transaction
+      basis: ChainIndex
+    }) => {
+      if (!signedTransaction) {
+        return {
+          error: 'No signed transaction',
+        }
+      }
+      // broadcast
+      const broadcastResponse = await txPoolBroadcast.post({
+        payload: {
+          basis,
+          transactions: [signedTransaction],
+          v2transactions: [],
+        },
+      })
+      if (broadcastResponse.error) {
+        cancel(signedTransaction)
+        return {
+          error: broadcastResponse.error,
+        }
+      }
+
+      return {
+        // Need transaction ID, but its not part of transaction object
+        // transactionId: signResponse.data.??,
+      }
+    },
+    [cancel, txPoolBroadcast]
+  )
+
+  return broadcast
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV1/useCancelV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/useCancelV1.tsx
@@ -4,7 +4,7 @@ import { useWallets } from '../../contexts/wallets'
 import { useCallback } from 'react'
 import { triggerErrorToast } from '@siafoundation/design-system'
 
-export function useCancel() {
+export function useCancelV1() {
   const { wallet } = useWallets()
   const walletId = wallet?.id
   const walletRelease = useWalletRelease()

--- a/apps/walletd/dialogs/_sharedWalletSendV1/useComposeFormV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/useComposeFormV1.tsx
@@ -15,8 +15,9 @@ import {
 } from '@siafoundation/design-system'
 import { useForm } from 'react-hook-form'
 import { useCallback, useMemo } from 'react'
-import { SendParams } from './types'
+import { SendParamsV1 } from './typesV1'
 import { Information16 } from '@siafoundation/react-icons'
+import { Maybe } from '@siafoundation/types'
 
 const exampleAddr =
   'e3b1050aef388438668b52983cf78f40925af8f0aa8b9de80c18eadcefce8388d168a313e3f2'
@@ -77,13 +78,13 @@ function getFields({
       placeholder: '100',
       validation: {
         validate: {
-          required: (value: BigNumber, values) =>
+          required: (value: Maybe<BigNumber>, values) =>
             values.mode !== 'siacoin' || !!value || 'required',
-          gtz: (value: BigNumber, values) =>
+          gtz: (value: Maybe<BigNumber>, values) =>
             values.mode !== 'siacoin' ||
             !new BigNumber(value || 0).isZero() ||
             'must be greater than zero',
-          balance: (value: BigNumber, values) =>
+          balance: (value: Maybe<BigNumber>, values) =>
             values.mode !== 'siacoin' ||
             balanceSc.gte(toHastings(value || 0).plus(fee)) ||
             'not enough funds in wallet',
@@ -99,11 +100,11 @@ function getFields({
         validate: {
           required: (value, values) =>
             values.mode !== 'siafund' || !!value || 'required',
-          gtz: (value: BigNumber, values) =>
+          gtz: (value: Maybe<BigNumber>, values) =>
             values.mode !== 'siafund' ||
             value?.gt(0) ||
             'must be greater than zero',
-          balance: (value: BigNumber, values) =>
+          balance: (value: Maybe<BigNumber>, values) =>
             values.mode !== 'siafund' ||
             (balanceSc?.gte(fee) && balanceSf?.gte(value)) ||
             'not enough funds in wallet',
@@ -112,12 +113,12 @@ function getFields({
     },
     customChangeAddress: {
       type: 'boolean',
-      title: 'Custom change adress',
+      title: 'Custom change address',
       validation: {},
     },
     customClaimAddress: {
       type: 'boolean',
-      title: 'Custom claim adress',
+      title: 'Custom claim address',
       validation: {},
     },
     changeAddress: {
@@ -209,14 +210,14 @@ function getFields({
 }
 
 type Props = {
-  onComplete: (data: SendParams) => void
+  onComplete: (data: SendParamsV1) => void
   balanceSc?: BigNumber
   balanceSf?: BigNumber
   defaultChangeAddress: string
   defaultClaimAddress: string
 }
 
-export function useComposeForm({
+export function useComposeFormV1({
   balanceSc,
   balanceSf,
   onComplete,

--- a/apps/walletd/dialogs/_sharedWalletSendV1/useFundV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/useFundV1.tsx
@@ -4,9 +4,9 @@ import {
 } from '@siafoundation/walletd-react'
 import { useWallets } from '../../contexts/wallets'
 import { useCallback } from 'react'
-import { SendParams } from './types'
+import { SendParamsV1 } from './typesV1'
 
-export function useFund() {
+export function useFundV1() {
   const { wallet } = useWallets()
   const walletId = wallet?.id
   const walletFundSc = useWalletFundSiacoin()
@@ -21,7 +21,7 @@ export function useFund() {
       siacoin,
       siafund,
       fee,
-    }: SendParams) => {
+    }: SendParamsV1) => {
       if (!receiveAddress || !changeAddress || !claimAddress) {
         return {
           error: 'No addresses',

--- a/apps/walletd/dialogs/_sharedWalletSendV2/SendDoneV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/SendDoneV2.tsx
@@ -1,17 +1,17 @@
 import { Text } from '@siafoundation/design-system'
 import { CheckmarkFilled32 } from '@siafoundation/react-icons'
-import { SendReceipt } from './SendReceipt'
-import { SendParams } from './types'
+import { SendReceiptV2 } from './SendReceiptV2'
+import { SendParamsV2 } from './typesV2'
 
 type Props = {
-  params: SendParams
+  params: SendParamsV2
   transactionId?: string
 }
 
-export function SendDone({ params, transactionId }: Props) {
+export function SendDoneV2({ params, transactionId }: Props) {
   return (
     <div className="flex flex-col gap-4">
-      <SendReceipt params={params} transactionId={transactionId} />
+      <SendReceiptV2 params={params} transactionId={transactionId} />
       <div className="flex flex-col items-center justify-center gap-2 my-4">
         <Text>
           <CheckmarkFilled32 />

--- a/apps/walletd/dialogs/_sharedWalletSendV2/SendFlowDialogV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/SendFlowDialogV2.tsx
@@ -1,0 +1,132 @@
+import {
+  Separator,
+  Dialog,
+  ProgressSteps,
+  FormSubmitButton,
+  Text,
+  Button,
+} from '@siafoundation/design-system'
+import { SendParamsV2, SendStep } from './typesV2'
+import { UseFormReturn } from 'react-hook-form'
+import { SendDoneV2 } from './SendDoneV2'
+
+export type SendDialogParams = {
+  walletId: string
+}
+
+type Props = {
+  trigger?: React.ReactNode
+  open: boolean
+  onOpenChange: (val: boolean) => void
+  compose: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    form: UseFormReturn<any>
+    el: React.ReactNode
+    handleSubmit: () => void
+    reset: () => void
+  }
+  send: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    form: UseFormReturn<any>
+    el: React.ReactNode
+    handleSubmit: () => void
+    reset: () => void
+  }
+  sendParams: SendParamsV2
+  signedTxnId?: string
+  step: SendStep
+  setStep: (step: SendStep) => void
+  controls?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    form: UseFormReturn<any>
+    submitLabel: string
+    handleSubmit: () => void
+  }
+  disabledMessage?: React.ReactNode
+}
+
+export function SendFlowDialogV2({
+  trigger,
+  open,
+  onOpenChange,
+  sendParams,
+  signedTxnId,
+  step,
+  send,
+  compose,
+  setStep,
+  controls,
+  disabledMessage,
+}: Props) {
+  return (
+    <Dialog
+      trigger={trigger}
+      open={open}
+      onOpenChange={(val) => {
+        if (!val) {
+          compose.reset()
+          send.reset()
+          setStep('compose')
+        }
+        onOpenChange(val)
+      }}
+      title="Send"
+      onSubmit={controls ? controls.handleSubmit : undefined}
+      controls={
+        controls?.form && (
+          <div className="flex flex-col gap-1">
+            {disabledMessage ? (
+              <Button size="medium" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            ) : (
+              <FormSubmitButton form={controls.form}>
+                {controls.submitLabel}
+              </FormSubmitButton>
+            )}
+          </div>
+        )
+      }
+      contentVariants={{
+        className: 'w-[450px]',
+      }}
+    >
+      {disabledMessage ? (
+        <div className="z-10 top-0 right-0 bottom-0 left-0 backdrop-blur-sm flex flex-col items-center justify-center gap-4">
+          <Text size="16" className="text-red-500">
+            {disabledMessage}
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <ProgressSteps
+            onChange={(step: SendStep) => {
+              setStep(step)
+            }}
+            activeStep={step}
+            steps={[
+              {
+                id: 'compose',
+                label: 'Compose',
+              },
+              {
+                id: 'send',
+                label: 'Sign & Send',
+              },
+              {
+                id: 'done',
+                label: 'Complete',
+              },
+            ]}
+          />
+          <Separator className="w-full mt-4" />
+          {step === 'compose' && compose.el}
+          {step === 'send' && send.el}
+          {step === 'done' && (
+            <SendDoneV2 params={sendParams} transactionId={signedTxnId} />
+          )}
+        </div>
+      )}
+    </Dialog>
+  )
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV2/SendReceiptV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/SendReceiptV2.tsx
@@ -1,0 +1,117 @@
+import {
+  Text,
+  ValueSc,
+  ValueCopyable,
+  ValueSf,
+} from '@siafoundation/design-system'
+import { SendParamsV2 } from './typesV2'
+
+type Props = {
+  params: SendParamsV2
+  transactionId?: string
+}
+
+export function SendReceiptV2({
+  params: { receiveAddress, changeAddress, siacoin, siafund, fee },
+  transactionId,
+}: Props) {
+  const totalSiacoin = siacoin.plus(fee)
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-6 justify-between items-center">
+        <Text color="verySubtle" noWrap id="recipientAddress">
+          Recipient address
+        </Text>
+        <ValueCopyable
+          value={receiveAddress}
+          type="address"
+          labeledBy="recipientAddress"
+        />
+      </div>
+      <div className="flex gap-6 justify-between items-center">
+        <Text color="verySubtle" noWrap id="changeAddress">
+          Change address
+        </Text>
+        <ValueCopyable
+          value={changeAddress}
+          type="address"
+          labeledBy="changeAddress"
+        />
+      </div>
+      <div className="flex gap-2 justify-between items-center">
+        <Text color="verySubtle" noWrap id="amount">
+          Amount
+        </Text>
+        <div className="flex relative gap-1 top-[-0.5px]">
+          {siacoin.gt(0) && (
+            <ValueSc
+              size="14"
+              value={siacoin}
+              variant="value"
+              dynamicUnits={false}
+              labeledBy="amount"
+            />
+          )}
+          {siafund > 0 && (
+            <ValueSf
+              size="14"
+              value={siafund}
+              variant="value"
+              labeledBy="amount"
+            />
+          )}
+        </div>
+      </div>
+      <div className="flex gap-2 justify-between items-center">
+        <Text color="verySubtle" noWrap id="networkFee">
+          Network fee
+        </Text>
+        <div className="flex relative top-[-0.5px]">
+          <ValueSc
+            size="14"
+            value={fee}
+            variant="value"
+            dynamicUnits={false}
+            labeledBy="networkFee"
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2 justify-between">
+        <Text color="verySubtle" noWrap id="total">
+          Total
+        </Text>
+        <div className="flex relative gap-1 top-[-0.5px]">
+          {siacoin.gt(0) && (
+            <ValueSc
+              size="14"
+              value={totalSiacoin}
+              variant="value"
+              dynamicUnits={false}
+              labeledBy="total"
+            />
+          )}
+          {siafund > 0 && (
+            <ValueSf
+              size="14"
+              value={siafund}
+              variant="value"
+              labeledBy="total"
+            />
+          )}
+        </div>
+      </div>
+      {transactionId && (
+        <div className="flex gap-6 items-center justify-between">
+          <Text color="verySubtle" noWrap id="transactionId">
+            Transaction ID
+          </Text>
+          <ValueCopyable
+            value={transactionId}
+            type="transaction"
+            labeledBy="transactionId"
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV2/hardforkV2.ts
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/hardforkV2.ts
@@ -1,0 +1,37 @@
+// mainnet: https://github.com/SiaFoundation/coreutils/blob/master/chain/network.go#L50-L51
+// n.HardforkV2.AllowHeight = 526000   // June 6th, 2025 @ 6:00am UTC
+// n.HardforkV2.RequireHeight = 530000 // July 4th, 2025 @ 2:00am UTC
+
+// zen: https://github.com/SiaFoundation/coreutils/blob/master/chain/network.go#L144-L145
+// n.HardforkV2.AllowHeight = 112000   // March 1, 2025 @ 7:00:00 UTC
+// n.HardforkV2.RequireHeight = 114000 // ~ 2 weeks later
+
+// anagami: https://github.com/SiaFoundation/coreutils/blob/master/chain/network.go#L172-L173
+// n.HardforkV2.AllowHeight = 2016         // ~2 weeks in
+// n.HardforkV2.RequireHeight = 2016 + 288 // ~2 days later
+
+// test cluster: internal/cluster/cmd/clusterd/main.go#L131-L132
+// n.HardforkV2.AllowHeight = 400
+// n.HardforkV2.RequireHeight = 500
+
+const hardforkV2AllowHeights = {
+  mainnet: 526_000,
+  zen: 112_000,
+  anagami: 2_016,
+  testCluster: 400,
+}
+
+export function getCurrentVersion({
+  network,
+  height,
+}: {
+  network: string
+  height: number
+}) {
+  const hardforkV2AllowHeight =
+    process.env.NEXT_PUBLIC_TEST_CLUSTER === 'true'
+      ? hardforkV2AllowHeights.testCluster
+      : hardforkV2AllowHeights[network || 'mainnet']
+
+  return height > hardforkV2AllowHeight ? 'v2' : 'v1'
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV2/typesV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/typesV2.tsx
@@ -2,21 +2,19 @@ import BigNumber from 'bignumber.js'
 
 export type SendStep = 'compose' | 'send' | 'done'
 
-export type SendParams = {
+export type SendParamsV2 = {
+  mode: 'siacoin' | 'siafund'
   receiveAddress: string
   changeAddress: string
-  claimAddress: string
-  mode: 'siacoin' | 'siafund'
   siafund: number
   siacoin: BigNumber
   fee: BigNumber
 }
 
-export const emptySendParams: SendParams = {
+export const emptySendParamsV2: SendParamsV2 = {
+  mode: 'siacoin',
   receiveAddress: '',
   changeAddress: '',
-  claimAddress: '',
-  mode: 'siacoin',
   siacoin: new BigNumber(0),
   siafund: 0,
   fee: new BigNumber(0),

--- a/apps/walletd/dialogs/_sharedWalletSendV2/useBroadcastV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/useBroadcastV2.tsx
@@ -1,18 +1,23 @@
-import { Transaction, ChainIndex } from '@siafoundation/types'
+import { Result, V2Transaction } from '@siafoundation/types'
 import { useTxPoolBroadcast } from '@siafoundation/walletd-react'
 import { useCallback } from 'react'
+import { ChainIndex } from '@siafoundation/types'
+import { useCancelV2 } from './useCancelV2'
 
-export function useBroadcast({ cancel }: { cancel: (t: Transaction) => void }) {
+export function useBroadcastV2() {
+  const cancel = useCancelV2()
   const txPoolBroadcast = useTxPoolBroadcast()
 
   const broadcast = useCallback(
     async ({
-      signedTransaction,
+      id,
       basis,
+      signedTransaction,
     }: {
-      signedTransaction: Transaction
+      id: string
       basis: ChainIndex
-    }) => {
+      signedTransaction: V2Transaction
+    }): Promise<Result<{ id: string }>> => {
       if (!signedTransaction) {
         return {
           error: 'No signed transaction',
@@ -22,8 +27,8 @@ export function useBroadcast({ cancel }: { cancel: (t: Transaction) => void }) {
       const broadcastResponse = await txPoolBroadcast.post({
         payload: {
           basis,
-          transactions: [signedTransaction],
-          v2transactions: [],
+          transactions: [],
+          v2transactions: [signedTransaction],
         },
       })
       if (broadcastResponse.error) {
@@ -34,8 +39,7 @@ export function useBroadcast({ cancel }: { cancel: (t: Transaction) => void }) {
       }
 
       return {
-        // Need transaction ID, but its not part of transaction object
-        // transactionId: signResponse.data.??,
+        id,
       }
     },
     [cancel, txPoolBroadcast]

--- a/apps/walletd/dialogs/_sharedWalletSendV2/useCancelV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/useCancelV2.tsx
@@ -1,0 +1,38 @@
+import { V2Transaction } from '@siafoundation/types'
+import { useWalletRelease } from '@siafoundation/walletd-react'
+import { useWallets } from '../../contexts/wallets'
+import { useCallback } from 'react'
+import { triggerErrorToast } from '@siafoundation/design-system'
+
+export function useCancelV2() {
+  const { wallet } = useWallets()
+  const walletId = wallet?.id
+  const walletRelease = useWalletRelease()
+
+  const cancel = useCallback(
+    async (transaction: V2Transaction) => {
+      const siacoinOutputs =
+        transaction.siacoinInputs?.map((i) => i.parent.id) || []
+      const siafundOutputs =
+        transaction.siafundInputs?.map((i) => i.parent.id) || []
+      const response = await walletRelease.post({
+        params: {
+          id: walletId,
+        },
+        payload: {
+          siacoinOutputs,
+          siafundOutputs,
+        },
+      })
+      if (response.error) {
+        triggerErrorToast({
+          title: 'Error canceling transaction',
+          body: response.error,
+        })
+      }
+    },
+    [walletId, walletRelease]
+  )
+
+  return cancel
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV2/useComposeFormV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/useComposeFormV2.tsx
@@ -1,0 +1,320 @@
+/* eslint-disable react/no-unescaped-entities */
+import BigNumber from 'bignumber.js'
+import { isValidAddress, toHastings } from '@siafoundation/units'
+import {
+  Text,
+  InfoTip,
+  ValueSc,
+  FieldSwitch,
+  ConfigFields,
+  FieldSiacoin,
+  FieldText,
+  FieldNumber,
+  FieldSelect,
+  Tooltip,
+} from '@siafoundation/design-system'
+import { useForm } from 'react-hook-form'
+import { useCallback, useMemo } from 'react'
+import { SendParamsV2 } from './typesV2'
+import { Information16 } from '@siafoundation/react-icons'
+import { Maybe } from '@siafoundation/types'
+
+const exampleAddr =
+  'e3b1050aef388438668b52983cf78f40925af8f0aa8b9de80c18eadcefce8388d168a313e3f2'
+
+const defaultValues = {
+  receiveAddress: '',
+  changeAddress: '',
+  customChangeAddress: false,
+  mode: 'siacoin' as 'siacoin' | 'siafund',
+  siacoin: undefined as BigNumber,
+  siafund: undefined as BigNumber,
+  includeFee: false,
+}
+
+function getFields({
+  balanceSc,
+  balanceSf,
+  fee,
+}: {
+  balanceSc: BigNumber
+  balanceSf: BigNumber
+  fee: BigNumber
+}): ConfigFields<typeof defaultValues, never> {
+  return {
+    receiveAddress: {
+      type: 'text',
+      title: 'Recipient address',
+      placeholder: exampleAddr,
+      validation: {
+        validate: {
+          required: (value: string) => {
+            return !!value || 'required'
+          },
+          valid: (value: string) => {
+            return isValidAddress(value) || 'invalid address'
+          },
+        },
+      },
+    },
+    mode: {
+      type: 'select',
+      title: 'Action',
+      options: [
+        { value: 'siacoin', label: 'Send siacoins' },
+        { value: 'siafund', label: 'Send siafunds' },
+      ],
+      validation: {
+        required: 'required',
+      },
+    },
+    siacoin: {
+      type: 'siacoin',
+      title: 'Siacoin',
+      placeholder: '100',
+      validation: {
+        validate: {
+          required: (value: Maybe<BigNumber>, values) =>
+            values.mode !== 'siacoin' || !!value || 'required',
+          gtz: (value: Maybe<BigNumber>, values) =>
+            values.mode !== 'siacoin' ||
+            !new BigNumber(value || 0).isZero() ||
+            'must be greater than zero',
+          balance: (value: Maybe<BigNumber>, values) =>
+            values.mode !== 'siacoin' ||
+            balanceSc.gte(toHastings(value || 0).plus(fee)) ||
+            'not enough funds in wallet',
+        },
+      },
+    },
+    siafund: {
+      type: 'number',
+      title: 'Siafunds',
+      decimalsLimit: 0,
+      placeholder: '100',
+      validation: {
+        validate: {
+          required: (value, values) =>
+            values.mode !== 'siafund' || !!value || 'required',
+          gtz: (value: Maybe<BigNumber>, values) =>
+            values.mode !== 'siafund' ||
+            value?.gt(0) ||
+            'must be greater than zero',
+          balance: (value: Maybe<BigNumber>, values) =>
+            values.mode !== 'siafund' ||
+            (balanceSc?.gte(fee) && balanceSf?.gte(value)) ||
+            'not enough funds in wallet',
+        },
+      },
+    },
+    customChangeAddress: {
+      type: 'boolean',
+      title: 'Custom change address',
+      validation: {},
+    },
+    changeAddress: {
+      type: 'text',
+      title: 'Change address',
+      placeholder: exampleAddr,
+      actions: (
+        <Tooltip
+          content={
+            <>
+              The address where any change or claims from the transaction will
+              be sent. If a custom change address is not specified it is
+              automatically set to the wallet's address 0.
+            </>
+          }
+        >
+          <Text color="subtle" className="cursor-pointer">
+            <Information16 className="scale-75" />
+          </Text>
+        </Tooltip>
+      ),
+      validation: {
+        validate: {
+          required: (value: string, values) => {
+            const customChangeAddressNotEnabled = !values.customChangeAddress
+            return customChangeAddressNotEnabled || !!value || 'required'
+          },
+          valid: (value: string, values) => {
+            const customChangeAddressNotEnabled = !values.customChangeAddress
+            return (
+              customChangeAddressNotEnabled ||
+              isValidAddress(value) ||
+              'invalid address'
+            )
+          },
+        },
+      },
+    },
+    includeFee: {
+      type: 'boolean',
+      title: '',
+      validation: {},
+    },
+  }
+}
+
+type Props = {
+  onComplete: (data: SendParamsV2) => void
+  balanceSc: BigNumber | undefined
+  balanceSf: BigNumber | undefined
+  fee: BigNumber | undefined
+  defaultChangeAddress: string
+}
+
+export function useComposeFormV2({
+  balanceSc,
+  balanceSf,
+  fee,
+  onComplete,
+  defaultChangeAddress,
+}: Props) {
+  const form = useForm({
+    mode: 'all',
+    defaultValues,
+  })
+
+  const fields = getFields({
+    balanceSc,
+    balanceSf,
+    fee,
+  })
+
+  const onValid = useCallback(
+    async (values: typeof defaultValues) => {
+      const sc = new BigNumber(values.siacoin || 0)
+      const sf = new BigNumber(values.siafund || 0)
+
+      const siacoin = values.includeFee
+        ? toHastings(sc).minus(fee)
+        : toHastings(sc)
+
+      const siafund = sf.toNumber()
+
+      onComplete({
+        receiveAddress: values.receiveAddress,
+        changeAddress: values.customChangeAddress
+          ? values.changeAddress
+          : defaultChangeAddress,
+        siacoin,
+        siafund,
+        mode: values.mode,
+        fee,
+      })
+    },
+    [onComplete, defaultChangeAddress, fee]
+  )
+
+  const handleSubmit = useMemo(
+    () => form.handleSubmit(onValid),
+    [form, onValid]
+  )
+
+  const siacoin = form.watch('siacoin')
+  const mode = form.watch('mode')
+  const customChangeAddress = form.watch('customChangeAddress')
+  const includeFee = form.watch('includeFee')
+  const sc = toHastings(siacoin || 0)
+
+  const el = (
+    <div className="flex flex-col gap-4">
+      {balanceSf.gt(0) && (
+        <FieldSelect size="medium" form={form} fields={fields} name="mode" />
+      )}
+      <FieldText
+        size="medium"
+        form={form}
+        fields={fields}
+        name="receiveAddress"
+        autoComplete="off"
+      />
+      <div className="flex gap-2">
+        <FieldSwitch
+          size="small"
+          form={form}
+          fields={fields}
+          name="customChangeAddress"
+          group={false}
+        >
+          <div className="flex items-center gap-px">
+            <Text color="verySubtle" weight="medium" size="14" ellipsis>
+              custom change address
+            </Text>
+            {fields.changeAddress.actions}
+          </div>
+        </FieldSwitch>
+      </div>
+      {customChangeAddress && (
+        <FieldText
+          size="medium"
+          form={form}
+          fields={fields}
+          name="changeAddress"
+          autoComplete="off"
+        />
+      )}
+      {mode === 'siacoin' ? (
+        <>
+          <FieldSiacoin
+            size="medium"
+            form={form}
+            fields={fields}
+            name="siacoin"
+          />
+          <div className="flex items-center">
+            <FieldSwitch
+              size="small"
+              form={form}
+              fields={fields}
+              name="includeFee"
+            >
+              <Text>Include fee</Text>
+              <InfoTip>
+                Include or exclude the network fee from the above transaction
+                value.
+              </InfoTip>
+            </FieldSwitch>
+            <div className="flex flex-1" />
+          </div>
+        </>
+      ) : (
+        <FieldNumber size="medium" form={form} fields={fields} name="siafund" />
+      )}
+      <div className="flex flex-col gap-2 my-1">
+        <div className="flex gap-2 justify-between items-center">
+          <Text color="verySubtle">Network fee</Text>
+          <div className="flex relative top-[-0.5px]">
+            <ValueSc
+              size="14"
+              value={fee || new BigNumber(0)}
+              variant="value"
+              dynamicUnits={false}
+            />
+          </div>
+        </div>
+        {mode === 'siacoin' && fee && (
+          <div className="flex justify-between gap-2 items-center">
+            <Text color="verySubtle">Total</Text>
+            <div className="flex relative top-[-0.5px]">
+              <ValueSc
+                size="14"
+                value={includeFee ? sc : sc.plus(fee)}
+                variant="value"
+                dynamicUnits={false}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  return {
+    form,
+    el,
+    handleSubmit,
+    reset: () => form.reset(defaultValues),
+  }
+}

--- a/apps/walletd/dialogs/_sharedWalletSendV2/useConstructV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/useConstructV2.tsx
@@ -1,0 +1,72 @@
+import { useWalletConstructV2Transaction } from '@siafoundation/walletd-react'
+import { useWallets } from '../../contexts/wallets'
+import { useCallback } from 'react'
+import { SendParamsV2 } from './typesV2'
+import { WalletConstructV2TransactionPayload } from '@siafoundation/walletd-types'
+import { SiacoinOutput, SiafundOutput } from '@siafoundation/types'
+
+export function useConstructV2() {
+  const { wallet } = useWallets()
+  const walletId = wallet?.id
+  const construct = useWalletConstructV2Transaction()
+
+  const fund = useCallback(
+    async ({
+      receiveAddress,
+      changeAddress,
+      siacoin,
+      siafund,
+    }: SendParamsV2) => {
+      if (!receiveAddress || !changeAddress) {
+        return {
+          error: 'No addresses',
+        }
+      }
+
+      const siacoins: SiacoinOutput[] = []
+      const siafunds: SiafundOutput[] = []
+
+      if (siacoin.gt(0)) {
+        siacoins.push({
+          value: siacoin.toString(),
+          address: receiveAddress,
+        })
+      }
+
+      if (siafund > 0) {
+        siafunds.push({
+          value: siafund,
+          address: receiveAddress,
+        })
+      }
+
+      const payload: WalletConstructV2TransactionPayload = {
+        changeAddress,
+        siacoins,
+        siafunds,
+      }
+
+      // construct: funds txn, calculates and adds miner fees, determines utxo change.
+      const response = await construct.post({
+        params: {
+          id: walletId,
+        },
+        payload,
+      })
+      if (response.error) {
+        return {
+          error: response.error,
+        }
+      }
+      return {
+        id: response.data.id,
+        fundedTransaction: response.data.transaction,
+        estimatedFee: response.data.estimatedFee,
+        basis: response.data.basis,
+      }
+    },
+    [walletId, construct]
+  )
+
+  return fund
+}

--- a/apps/walletd/next.config.js
+++ b/apps/walletd/next.config.js
@@ -1,4 +1,4 @@
-const { composePlugins, withNx } = require('@nx/next');
+const { composePlugins, withNx } = require('@nx/next')
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -32,10 +32,10 @@ const nextConfigExport = {
   output: 'export',
 }
 
-const nextConfig = process.env.NEXT_OUTPUT_EXPORT ? nextConfigExport : nextConfigServe
+const nextConfig = process.env.NEXT_OUTPUT_EXPORT
+  ? nextConfigExport
+  : nextConfigServe
 
-const plugins = [
-  withNx,
-];
+const plugins = [withNx]
 
-module.exports = composePlugins(...plugins)(nextConfig);
+module.exports = composePlugins(...plugins)(nextConfig)

--- a/libs/e2e/src/fixtures/click.ts
+++ b/libs/e2e/src/fixtures/click.ts
@@ -81,3 +81,11 @@ export const clickTwice = step('click twice', async (locator: Locator) => {
   await locator.click()
   await locator.click()
 })
+
+export const expectThenClick = step(
+  'expect then click',
+  async (locator: Locator) => {
+    await expect(locator).toBeVisible()
+    await locator.click()
+  }
+)


### PR DESCRIPTION
- Seed wallets now support and automatically switch to sending V2 transactions once the consensus height hits the V2 hardfork allow height.
- V2 transactions use the construct API and the new V2 signing methods added in the previous PR.
- This PR renames all send related files with V1-specific naming and creates a separate duplicate set of files with V2-specific naming and changes. This is to be very clear about what code is used in V1 vs V2, and to make it easier to remove all V1 code after the hardfork.

