### PR TITLE
feat(cluster): v2 transition support

### DIFF
--- a/.changeset/slow-flowers-remain.md
+++ b/.changeset/slow-flowers-remain.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/clusterd': minor
+---
+
+Added transition network mode.

--- a/.changeset/stale-pillows-exist.md
+++ b/.changeset/stale-pillows-exist.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/clusterd': minor
+---
+
+Added mineToHeight and getCurrentHeight APIs.

--- a/internal/cluster/cmd/clusterd/main.go
+++ b/internal/cluster/cmd/clusterd/main.go
@@ -44,7 +44,7 @@ func main() {
 	flag.StringVar(&dir, "dir", "", "directory to store renter data")
 	flag.StringVar(&apiAddr, "api", ":3001", "API address")
 	flag.StringVar(&logLevel, "log", "info", "logging level")
-	flag.StringVar(&network, "network", "v1", "network to use (v1 or v2)")
+	flag.StringVar(&network, "network", "v1", "network to use (v1, v2 or transition)")
 	flag.StringVar(&siafundAddr, "siafund", "", "address to send siafunds to")
 
 	flag.IntVar(&renterdCount, "renterd", 0, "number of renter daemons to run")
@@ -127,6 +127,9 @@ func main() {
 	case "v2":
 		n.HardforkV2.AllowHeight = 2
 		n.HardforkV2.RequireHeight = 3
+	case "transition":
+		n.HardforkV2.AllowHeight = 400
+		n.HardforkV2.RequireHeight = 500
 	default:
 		log.Fatal("invalid network", zap.String("network", network))
 	}


### PR DESCRIPTION
This PR adds cluster support for testing across the v2 fork activation heights.

### Changes
- Added transition network mode.
- Added mineToHeight and getCurrentHeight APIs.