### PR TITLE
fix(hostd): volume delete fixture

### DIFF
--- a/apps/hostd-e2e/src/fixtures/volumes.ts
+++ b/apps/hostd-e2e/src/fixtures/volumes.ts
@@ -45,7 +45,8 @@ export const deleteVolume = step(
     await expect(
       page.getByText('Volume is now being permanently deleted')
     ).toBeVisible()
-    await volumeNotInList(page, fullPath)
+    const row = page.getByRole('row', { name: fullPath })
+    await expect(row.getByText('removing')).toBeVisible()
   }
 )
 

--- a/apps/hostd-e2e/src/specs/volumes.spec.ts
+++ b/apps/hostd-e2e/src/specs/volumes.spec.ts
@@ -117,7 +117,7 @@ test('viewing a page with no data shows the correct empty state', async ({
   await expect(next).toBeDisabled()
   await expect(last).toBeDisabled()
 
-  await deleteVolume(page, 'v2', dirPath)
+  await page.goto(url + '?limit=1&offset=2')
 
   await expect(
     page.getByText('No data on this page, reset pagination to continue.')
@@ -128,8 +128,8 @@ test('viewing a page with no data shows the correct empty state', async ({
   await expectVolumeRowByIndex(page, 0)
   await expect(first).toBeDisabled()
   await expect(previous).toBeDisabled()
-  await expect(next).toBeDisabled()
-  await expect(last).toBeDisabled()
+  await expect(next).toBeEnabled()
+  await expect(last).toBeEnabled()
 })
 
 function getVolumePath(dirPath: string, name: string) {


### PR DESCRIPTION
- Volume removal now takes longer so tests can no rely on the presence of the volume row to verify removal since it can take longer than the test timeout for the row to disappear. Instead we now verify removal by only checking the status has changed to removing.