### PR TITLE
feat(explorer): remove host benchmarks

### DIFF
--- a/.changeset/rich-suits-bake.md
+++ b/.changeset/rich-suits-bake.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Removed Host benchmarks, due to lack of explored support.

--- a/apps/explorer/app/host/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/host/[id]/opengraph-image.tsx
@@ -2,11 +2,8 @@ import { getOGImage } from '../../../components/OGImageEntity'
 import { siaCentral } from '../../../config/siaCentral'
 import {
   getDownloadCost,
-  getDownloadSpeed,
   getStorageCost,
   getUploadCost,
-  getUploadSpeed,
-  humanBytes,
 } from '@siafoundation/units'
 import { truncate } from '@siafoundation/design-system'
 import { CurrencyOption, currencyOptions } from '@siafoundation/react-core'
@@ -78,7 +75,6 @@ export default async function Image({ params }) {
           rate: r.rates.sc.usd,
         },
       }),
-      subvalue: humanBytes(h.host.settings.remaining_storage),
     },
     {
       label: 'download',
@@ -89,7 +85,6 @@ export default async function Image({ params }) {
           rate: r.rates.sc.usd,
         },
       }),
-      subvalue: h.host.benchmark && getDownloadSpeed(h.host),
     },
     {
       label: 'upload',
@@ -100,7 +95,6 @@ export default async function Image({ params }) {
           rate: r.rates.sc.usd,
         },
       }),
-      subvalue: h.host.benchmark && getUploadSpeed(h.host),
     },
   ]
 

--- a/apps/explorer/components/Home/HostListItem.tsx
+++ b/apps/explorer/components/Home/HostListItem.tsx
@@ -11,16 +11,15 @@ import {
 import {
   CloudDownload16,
   CloudUpload16,
+  OpenPanelFilledBottom16,
   VmdkDisk16,
 } from '@siafoundation/react-icons'
 import { SiaCentralExchangeRates } from '@siafoundation/sia-central-types'
 import {
   getDownloadCost,
-  getDownloadSpeed,
   getRemainingStorage,
   getStorageCost,
   getUploadCost,
-  getUploadSpeed,
 } from '@siafoundation/units'
 import { useMemo } from 'react'
 import { routes } from '../../config/routes'
@@ -50,10 +49,6 @@ export function HostListItem({ host, rates, entity }: Props) {
     [exchange, host]
   )
 
-  const downloadSpeed = useMemo(() => getDownloadSpeed(host), [host])
-
-  const uploadSpeed = useMemo(() => getUploadSpeed(host), [host])
-
   const remainingStorage = useMemo(() => getRemainingStorage(host), [host])
 
   return (
@@ -62,7 +57,7 @@ export function HostListItem({ host, rates, entity }: Props) {
         className="flex flex-col items-center gap-1 w-full"
         data-testid="explorer-topHosts-item"
       >
-        <div className="flex gap-2 items-center w-full">
+        <div className="flex gap-2 items-center w-full @container">
           <div className="flex gap-2 items-center">
             <Link
               href={routes.host.view.replace(':id', host.public_key)}
@@ -73,14 +68,14 @@ export function HostListItem({ host, rates, entity }: Props) {
             </Link>
           </div>
           <div className="flex-1" />
-          <Text color="subtle" className="hidden lg:flex">
+          <Text color="subtle" className="hidden @sm:flex">
             {formatDistance(new Date(host.first_seen_timestamp), new Date(), {
               addSuffix: false,
             })}{' '}
             old
           </Text>
         </div>
-        <div className="flex gap-2 justify-between w-full pt-1 pb-1">
+        <div className="flex gap-2 w-full pt-1 pb-1 @container">
           <div className="flex gap-1 items-center">
             <Text size="10" color="subtle" ellipsis className="scale-75">
               <VmdkDisk16 />
@@ -90,13 +85,8 @@ export function HostListItem({ host, rates, entity }: Props) {
                 {storageCost}
               </Text>
             </Tooltip>
-            <Tooltip content="Remaining storage">
-              <Text size="10" color="subtle" ellipsis>
-                {remainingStorage}
-              </Text>
-            </Tooltip>
           </div>
-          <div className="hidden lg:flex gap-1 items-center">
+          <div className="flex gap-1 items-center">
             <Text size="10" color="subtle" ellipsis className="scale-75">
               <CloudDownload16 />
             </Text>
@@ -105,13 +95,8 @@ export function HostListItem({ host, rates, entity }: Props) {
                 {downloadCost}
               </Text>
             </Tooltip>
-            <Tooltip content="Download speed">
-              <Text size="10" color="subtle" ellipsis>
-                {downloadSpeed || '-'}
-              </Text>
-            </Tooltip>
           </div>
-          <div className="hidden lg:flex gap-1 items-center">
+          <div className="flex gap-1 items-center">
             <Text size="10" color="subtle" ellipsis className="scale-75">
               <CloudUpload16 />
             </Text>
@@ -120,9 +105,14 @@ export function HostListItem({ host, rates, entity }: Props) {
                 {uploadCost}
               </Text>
             </Tooltip>
-            <Tooltip content="Upload speed">
-              <Text size="10" color="subtle" ellipsis>
-                {uploadSpeed || '-'}
+          </div>
+          <div className="hidden @xs:flex gap-1 items-center">
+            <Text size="10" color="subtle" ellipsis className="scale-75">
+              <OpenPanelFilledBottom16 />
+            </Text>
+            <Tooltip content="Remaining storage">
+              <Text size="10" color="contrast" ellipsis>
+                {remainingStorage}
               </Text>
             </Tooltip>
           </div>

--- a/apps/explorer/components/Host/HostPricing.tsx
+++ b/apps/explorer/components/Host/HostPricing.tsx
@@ -11,12 +11,8 @@ import { SiaCentralExchangeRates } from '@siafoundation/sia-central-types'
 import { useMemo } from 'react'
 import {
   getDownloadCost,
-  // getDownloadSpeed,
-  // getRemainingOverTotalStorage,
-  // getRemainingStorage,
   getStorageCost,
   getUploadCost,
-  // getUploadSpeed,
 } from '@siafoundation/units'
 import { useExchangeRate } from '../../hooks/useExchangeRate'
 
@@ -46,17 +42,6 @@ export function HostPricing({ host, rates }: Props) {
       getUploadCost({ price: host.settings.uploadbandwidthprice, exchange }),
     [exchange, host]
   )
-
-  // const downloadSpeed = useMemo(() => getDownloadSpeed(host), [host])
-
-  // const uploadSpeed = useMemo(() => getUploadSpeed(host), [host])
-
-  // const remainingOverTotalStorage = useMemo(
-  //   () => getRemainingOverTotalStorage(host),
-  //   [host]
-  // )
-
-  // const remainingStorage = useMemo(() => getRemainingStorage(host), [host])
 
   return (
     <div className="flex flex-col" data-testid="explorer-hostPricing">
@@ -92,23 +77,6 @@ export function HostPricing({ host, rates }: Props) {
           </div>
         </Tooltip>
       </div>
-      {/* <div className="grid grid-cols-3 gap-4">
-        <Tooltip content={remainingOverTotalStorage}>
-          <div className="flex justify-end">
-            <Text color="subtle">{remainingStorage}</Text>
-          </div>
-        </Tooltip>
-        <Tooltip content={`Download speed benchmarked at ${downloadSpeed}`}>
-          <div className="flex justify-end">
-            <Text color="subtle">{downloadSpeed}</Text>
-          </div>
-        </Tooltip>
-        <Tooltip content={`Upload speed benchmarked at ${uploadSpeed}`}>
-          <div className="flex justify-end">
-            <Text color="subtle">{uploadSpeed}</Text>
-          </div>
-        </Tooltip>
-      </div> */}
     </div>
   )
 }


### PR DESCRIPTION
Slight visual changes on this one for the hosts list on the home page to fix some consequences of removing the two benchmark subvalues:

* Remaining storage moves to a "primary" value with its own icon
* Removed justify-between for these now four items - this felt too spaced out with the smaller amount of text. Runner up visually for me was justify-around, but I like unset better.
* ~~At the lower width breakpoint, now storage cost and download cost stay visible.~~ Downstack, we've introduced 2xs and 3xs container breakpoints to `theme` and used container queries to makes this more responsive.