### PR TITLE
feat(walletd): v2 seed signing

### DIFF
--- a/.changeset/healthy-pears-listen.md
+++ b/.changeset/healthy-pears-listen.md
@@ -1,0 +1,5 @@
+---
+'walletd': minor
+---
+
+V1 signing now uses the address spendPolicy.

--- a/.changeset/poor-foxes-poke.md
+++ b/.changeset/poor-foxes-poke.md
@@ -1,0 +1,5 @@
+---
+'walletd': minor
+---
+
+Added V2 signing method.

--- a/.changeset/wise-candles-swim.md
+++ b/.changeset/wise-candles-swim.md
@@ -1,0 +1,5 @@
+---
+'walletd': minor
+---
+
+Generating addresses now stores the spendPolicy in the dedicated field rather than unlockConditions in the metadata.

--- a/apps/walletd/dialogs/WalletAddLedgerDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletAddLedgerDialog/index.tsx
@@ -137,7 +137,6 @@ export function WalletAddLedgerDialog({ trigger, open, onOpenChange }: Props) {
     ) => {
       const metadata: WalletAddressMetadata = {
         index: 0,
-        unlockConditions,
       }
       const response = await addressAdd.put({
         params: {
@@ -146,7 +145,10 @@ export function WalletAddLedgerDialog({ trigger, open, onOpenChange }: Props) {
         payload: {
           address,
           description: '',
-          // TODO: add spendPolicy?
+          spendPolicy: {
+            type: 'uc',
+            policy: unlockConditions,
+          },
           metadata,
         },
       })

--- a/apps/walletd/dialogs/WalletAddressesGenerateLedgerDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletAddressesGenerateLedgerDialog/index.tsx
@@ -245,8 +245,7 @@ export function WalletAddressesGenerateLedgerDialog({
         isNew: !existing,
         index: Number(index),
         address: existing?.address || address,
-        publicKey:
-          existing?.metadata.unlockConditions.publicKeys[0] || publicKey,
+        publicKey: existing?.spendPolicy?.policy.publicKeys[0] || publicKey,
       }
     }
     return indiciesWithAddresses
@@ -284,7 +283,6 @@ export function WalletAddressesGenerateLedgerDialog({
       }
       const metadata: WalletAddressMetadata = {
         index,
-        unlockConditions: uc.unlockConditions,
       }
       const response = await addressAdd.put({
         params: {
@@ -293,7 +291,10 @@ export function WalletAddressesGenerateLedgerDialog({
         payload: {
           address,
           description: '',
-          // TODO: add spendPolicy?
+          spendPolicy: {
+            type: 'uc',
+            policy: uc.unlockConditions,
+          },
           metadata,
         },
       })

--- a/apps/walletd/dialogs/WalletAddressesGenerateSeedDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletAddressesGenerateSeedDialog/index.tsx
@@ -173,7 +173,6 @@ export function WalletAddressesGenerateSeedDialog({
         }
         const metadata: WalletAddressMetadata = {
           index: i,
-          unlockConditions: uc.unlockConditions,
         }
         const response = await addressAdd.put({
           params: {
@@ -182,7 +181,10 @@ export function WalletAddressesGenerateSeedDialog({
           payload: {
             address: stripPrefix(suh.address),
             description: '',
-            // TODO: add spendPolicy?
+            spendPolicy: {
+              type: 'uc',
+              policy: uc.unlockConditions,
+            },
             metadata,
           },
         })

--- a/apps/walletd/dialogs/WalletSendSeedDialog/useSignAndBroadcast.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/useSignAndBroadcast.tsx
@@ -6,7 +6,7 @@ import {
 } from '@siafoundation/walletd-react'
 import { useWallets } from '../../contexts/wallets'
 import { useCallback } from 'react'
-import { signTransactionSeed } from '../../lib/signSeed'
+import { signTransactionSeedV1 } from '../../lib/signSeedV1'
 import { useWalletAddresses } from '../../hooks/useWalletAddresses'
 import { SendParams } from '../_sharedWalletSend/types'
 import { useBroadcast } from '../_sharedWalletSend/useBroadcast'
@@ -57,7 +57,7 @@ export function useSignAndBroadcast() {
           error: fundingError,
         }
       }
-      const { signedTransaction, error: signingError } = signTransactionSeed({
+      const { signedTransaction, error: signingError } = signTransactionSeedV1({
         mnemonic,
         transaction: fundedTransaction,
         toSign,

--- a/apps/walletd/lib/__snapshots__/signSeedV1.spec.ts.snap
+++ b/apps/walletd/lib/__snapshots__/signSeedV1.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`signSeed builds and signs valid transaction 1`] = `
+exports[`signSeedV1 builds and signs valid transaction 1`] = `
 Object {
   "signedTransaction": Object {
     "minerFees": Array [

--- a/apps/walletd/lib/__snapshots__/signSeedV2.spec.ts.snap
+++ b/apps/walletd/lib/__snapshots__/signSeedV2.spec.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`signSeedV2 builds and signs valid transaction 1`] = `
+Object {
+  "signedTransaction": Object {
+    "minerFee": "3930000000000000000000",
+    "siacoinInputs": Array [
+      Object {
+        "parent": Object {
+          "id": "aa3e781330c9b3991e0141807df1327fadf114ca6c37acb9e58004f942d91dfb",
+          "leafIndex": 304248,
+          "maturityHeight": 0,
+          "merkleProof": Array [
+            "0a7a4c392f78899e3c38c5cd9e6a673b2c7afec97930af539af9c8e20209aa78",
+            "a1e074dc48634a234b7366a0d7ab19cd05e3e698e1d44bf07e24d75ae0c65b3c",
+          ],
+          "siacoinOutput": Object {
+            "address": "90c6057cdd2463eca61f83796e83152dbba28b6cb9a74831a043833051ec9f422726bfff2ee8",
+            "value": "1000000000000000000000000",
+          },
+        },
+        "satisfiedPolicy": Object {
+          "policy": Object {
+            "policy": Object {
+              "publicKeys": Array [
+                "ed25519:ee122b2169bdae5776b55609e384e0c58372cd5c529d4edc9b9918b26f8e5535",
+              ],
+              "signaturesRequired": 1,
+              "timelock": 0,
+            },
+            "type": "uc",
+          },
+          "signatures": Array [
+            "32104521d75f2155c893eb352beee47c42f25c1d28bd5648076f3873f0b30188271ccf903df206c47167be4bf331ab927930bda32413d2078bda29f34ee1dc01",
+          ],
+        },
+      },
+      Object {
+        "parent": Object {
+          "id": "32e430158591b4073a6834e9f4c4b67162e348844f569f4e472896bb72efb724",
+          "leafIndex": 305723,
+          "maturityHeight": 0,
+          "merkleProof": Array [
+            "8c02aeec48de589ce497ebe72fb8b527cfe022ef513fcfdc56745c84832f00ec",
+            "1bf63b9959e60272fd7a48a8cecd4120a852c0e14557ea27ccad6ea2071e70b3",
+          ],
+          "siacoinOutput": Object {
+            "address": "f2dbf56b5b0c698d7fbf43f646c76169d84e597e8b37fada97348beeecaa812d400ac4ce7981",
+            "value": "97984280000000000000000000",
+          },
+        },
+        "satisfiedPolicy": Object {
+          "policy": Object {
+            "policy": Object {
+              "publicKeys": Array [
+                "ed25519:ee122b2169bdae5776b55609e384e0c58372cd5c529d4edc9b9918b26f8e5535",
+              ],
+              "signaturesRequired": 1,
+              "timelock": 0,
+            },
+            "type": "uc",
+          },
+          "signatures": Array [
+            "32104521d75f2155c893eb352beee47c42f25c1d28bd5648076f3873f0b30188271ccf903df206c47167be4bf331ab927930bda32413d2078bda29f34ee1dc01",
+          ],
+        },
+      },
+    ],
+    "siacoinOutputs": Array [
+      Object {
+        "address": "90c6057cdd2463eca61f83796e83152dbba28b6cb9a74831a043833051ec9f422726bfff2ee8",
+        "value": "1000000000000000000000000",
+      },
+      Object {
+        "address": "f2dbf56b5b0c698d7fbf43f646c76169d84e597e8b37fada97348beeecaa812d400ac4ce7981",
+        "value": "97984280000000000000000000",
+      },
+    ],
+  },
+}
+`;

--- a/apps/walletd/lib/signLedger.spec.ts
+++ b/apps/walletd/lib/signLedger.spec.ts
@@ -97,7 +97,7 @@ describe('signLedger', () => {
       const device = getMockDevice()
       const mocks = getMockScenarioSeedWallet()
       const addresses = getMockAddresses(mocks)
-      addresses[0].metadata.unlockConditions.publicKeys[0] = undefined
+      addresses[0].spendPolicy.policy.publicKeys[0] = undefined
       expect(
         await signTransactionLedger({
           device,

--- a/apps/walletd/lib/signLedger.ts
+++ b/apps/walletd/lib/signLedger.ts
@@ -5,7 +5,10 @@ import {
 } from '@siafoundation/types'
 import { AddressData } from '../contexts/addresses/types'
 import { LedgerDevice } from '../contexts/ledger/types'
-import { addUnlockConditionsAndSignatures, getToSignMetadata } from './sign'
+import {
+  addUnlockConditionsAndSignaturesV1,
+  getToSignMetadataV1,
+} from './signV1'
 import { getSDK } from '@siafoundation/sdk'
 
 export async function signTransactionLedger({
@@ -30,7 +33,7 @@ export async function signTransactionLedger({
     return { error: 'No outputs' }
   }
 
-  const { error } = addUnlockConditionsAndSignatures({
+  const { error } = addUnlockConditionsAndSignaturesV1({
     transaction,
     toSign,
     addresses,
@@ -44,7 +47,7 @@ export async function signTransactionLedger({
 
   // for each toSign
   for (const [i, toSignId] of toSign.entries()) {
-    const addressInfo = getToSignMetadata({
+    const addressInfo = getToSignMetadataV1({
       toSignId,
       addresses,
       siacoinOutputs,

--- a/apps/walletd/lib/signSeedV1.spec.ts
+++ b/apps/walletd/lib/signSeedV1.spec.ts
@@ -1,4 +1,4 @@
-import { signTransactionSeed } from './signSeed'
+import { signTransactionSeedV1 } from './signSeedV1'
 import { initSDK } from '@siafoundation/sdk'
 import { getMockScenarioSeedWallet } from '@siafoundation/walletd-mock'
 import { getMockAddresses } from './testMocks'
@@ -7,11 +7,11 @@ beforeEach(async () => {
   await initSDK()
 })
 
-describe('signSeed', () => {
+describe('signSeedV1', () => {
   it('builds and signs valid transaction', async () => {
     const mocks = getMockScenarioSeedWallet()
     expect(
-      signTransactionSeed({
+      signTransactionSeedV1({
         mnemonic: mocks.mnemonic,
         transaction: mocks.walletFundResponse.transaction,
         toSign: mocks.walletFundResponse.toSign,
@@ -27,7 +27,7 @@ describe('signSeed', () => {
   it('errors when a toSign utxo is missing', async () => {
     const mocks = getMockScenarioSeedWallet()
     expect(
-      signTransactionSeed({
+      signTransactionSeedV1({
         mnemonic: mocks.mnemonic,
         transaction: mocks.walletFundResponse.transaction,
         consensusState: mocks.consensusState,
@@ -45,7 +45,7 @@ describe('signSeed', () => {
   it('errors when a public keys address is missing', async () => {
     const mocks = getMockScenarioSeedWallet()
     expect(
-      signTransactionSeed({
+      signTransactionSeedV1({
         mnemonic: mocks.mnemonic,
         transaction: mocks.walletFundResponse.transaction,
         toSign: mocks.walletFundResponse.toSign,
@@ -72,7 +72,7 @@ describe('signSeed', () => {
   it('errors when an address is missing its index', async () => {
     const mocks = getMockScenarioSeedWallet()
     expect(
-      signTransactionSeed({
+      signTransactionSeedV1({
         mnemonic: mocks.mnemonic,
         transaction: mocks.walletFundResponse.transaction,
         toSign: mocks.walletFundResponse.toSign,
@@ -99,9 +99,9 @@ describe('signSeed', () => {
   it('errors when an address is missing its public key', async () => {
     const mocks = getMockScenarioSeedWallet()
     const addresses = getMockAddresses(mocks)
-    addresses[0].metadata.unlockConditions.publicKeys[0] = undefined
+    addresses[0].spendPolicy.policy.publicKeys[0] = undefined
     expect(
-      signTransactionSeed({
+      signTransactionSeedV1({
         mnemonic: mocks.mnemonic,
         transaction: mocks.walletFundResponse.transaction,
         toSign: mocks.walletFundResponse.toSign,

--- a/apps/walletd/lib/signSeedV1.ts
+++ b/apps/walletd/lib/signSeedV1.ts
@@ -6,10 +6,13 @@ import {
   ConsensusNetwork,
 } from '@siafoundation/types'
 import { AddressData } from '../contexts/addresses/types'
-import { addUnlockConditionsAndSignatures, getToSignMetadata } from './sign'
+import {
+  addUnlockConditionsAndSignaturesV1,
+  getToSignMetadataV1,
+} from './signV1'
 import { getSDK } from '@siafoundation/sdk'
 
-export function signTransactionSeed({
+export function signTransactionSeedV1({
   mnemonic,
   transaction,
   toSign,
@@ -38,7 +41,7 @@ export function signTransactionSeed({
     return { error: 'No outputs' }
   }
 
-  const { error } = addUnlockConditionsAndSignatures({
+  const { error } = addUnlockConditionsAndSignaturesV1({
     toSign,
     transaction,
     addresses,
@@ -53,7 +56,7 @@ export function signTransactionSeed({
   // for each toSign
   for (const [i, toSignId] of toSign.entries()) {
     // find the utxo and corresponding address
-    const { address, error: utxoAddressError } = getToSignMetadata({
+    const { address, error: utxoAddressError } = getToSignMetadataV1({
       toSignId,
       transaction,
       addresses,

--- a/apps/walletd/lib/signSeedV2.spec.ts
+++ b/apps/walletd/lib/signSeedV2.spec.ts
@@ -1,0 +1,113 @@
+import { signTransactionSeedV2 } from './signSeedV2'
+import { initSDK } from '@siafoundation/sdk'
+import { getMockScenarioSeedWallet } from '@siafoundation/walletd-mock'
+import { getMockAddresses } from './testMocks'
+
+beforeEach(async () => {
+  await initSDK()
+})
+
+describe('signSeedV2', () => {
+  it('builds and signs valid transaction', async () => {
+    const mocks = getMockScenarioSeedWallet()
+    expect(
+      signTransactionSeedV2({
+        mnemonic: mocks.mnemonic,
+        transaction: mocks.walletConstructV2Response.transaction,
+        consensusState: mocks.consensusState,
+        consensusNetwork: mocks.consensusNetwork,
+        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
+        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
+        addresses: getMockAddresses(mocks),
+      })
+    ).toMatchSnapshot()
+  })
+
+  it('errors when an utxo is missing', async () => {
+    const mocks = getMockScenarioSeedWallet()
+    expect(
+      signTransactionSeedV2({
+        mnemonic: mocks.mnemonic,
+        transaction: mocks.walletConstructV2Response.transaction,
+        consensusState: mocks.consensusState,
+        consensusNetwork: mocks.consensusNetwork,
+        siacoinOutputs: [],
+        siafundOutputs: [],
+        addresses: getMockAddresses(mocks),
+      })
+    ).toEqual({
+      error: 'Missing utxo',
+    })
+  })
+
+  it('errors when a public keys address is missing', async () => {
+    const mocks = getMockScenarioSeedWallet()
+    expect(
+      signTransactionSeedV2({
+        mnemonic: mocks.mnemonic,
+        transaction: mocks.walletConstructV2Response.transaction,
+        consensusState: mocks.consensusState,
+        consensusNetwork: mocks.consensusNetwork,
+        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
+        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
+        addresses: [
+          {
+            id: 'id',
+            walletId: 'id',
+            address: 'address not in addresses',
+            metadata: {
+              index: 5,
+            },
+          },
+        ],
+      })
+    ).toEqual({
+      error: 'Missing address',
+    })
+  })
+
+  it('errors when an address is missing its index', async () => {
+    const mocks = getMockScenarioSeedWallet()
+    expect(
+      signTransactionSeedV2({
+        mnemonic: mocks.mnemonic,
+        transaction: mocks.walletConstructV2Response.transaction,
+        consensusState: mocks.consensusState,
+        consensusNetwork: mocks.consensusNetwork,
+        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
+        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
+        addresses: [
+          {
+            id: 'id',
+            walletId: 'id',
+            address:
+              mocks.walletOutputsSiacoinResponse.outputs[1].siacoinOutput
+                .address,
+            metadata: {},
+          },
+        ],
+      })
+    ).toEqual({
+      error: 'Missing address index',
+    })
+  })
+
+  it('errors when an address is missing its public key', async () => {
+    const mocks = getMockScenarioSeedWallet()
+    const addresses = getMockAddresses(mocks)
+    addresses[0].spendPolicy.policy.publicKeys[0] = undefined
+    expect(
+      signTransactionSeedV2({
+        mnemonic: mocks.mnemonic,
+        transaction: mocks.walletConstructV2Response.transaction,
+        consensusState: mocks.consensusState,
+        consensusNetwork: mocks.consensusNetwork,
+        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
+        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
+        addresses,
+      })
+    ).toEqual({
+      error: 'Missing address public key',
+    })
+  })
+})

--- a/apps/walletd/lib/signSeedV2.ts
+++ b/apps/walletd/lib/signSeedV2.ts
@@ -1,0 +1,79 @@
+import {
+  SiacoinElement,
+  SiafundElement,
+  ConsensusState,
+  ConsensusNetwork,
+  V2Transaction,
+  Result,
+} from '@siafoundation/types'
+import { AddressData } from '../contexts/addresses/types'
+import { getSDK } from '@siafoundation/sdk'
+import { addSignaturesSiacoinV2, addSignaturesSiafundV2 } from './signV2'
+
+export function signTransactionSeedV2({
+  mnemonic,
+  transaction,
+  consensusState,
+  consensusNetwork,
+  addresses,
+  siacoinOutputs,
+  siafundOutputs,
+}: {
+  mnemonic: string
+  consensusState: ConsensusState
+  consensusNetwork: ConsensusNetwork
+  transaction: V2Transaction
+  addresses: AddressData[]
+  siacoinOutputs: SiacoinElement[]
+  siafundOutputs: SiafundElement[]
+}): Result<{ signedTransaction: V2Transaction }> {
+  if (!consensusState) {
+    return { error: 'No consensus state' }
+  }
+  if (!addresses) {
+    return { error: 'No addresses' }
+  }
+  if (!siacoinOutputs) {
+    return { error: 'No outputs' }
+  }
+
+  const sigHashResult = getSDK().wallet.v2TransactionInputSigHash(
+    consensusState,
+    consensusNetwork,
+    transaction
+  )
+
+  if ('error' in sigHashResult) {
+    return { error: sigHashResult.error }
+  }
+
+  const { sigHash } = sigHashResult
+
+  const addSigScResult = addSignaturesSiacoinV2({
+    mnemonic,
+    transaction,
+    addresses,
+    siacoinOutputs,
+    sigHash,
+  })
+
+  if ('error' in addSigScResult) {
+    return { error: addSigScResult.error }
+  }
+
+  const addSigSfResult = addSignaturesSiafundV2({
+    mnemonic,
+    transaction,
+    addresses,
+    siafundOutputs,
+    sigHash,
+  })
+
+  if ('error' in addSigSfResult) {
+    return { error: addSigSfResult.error }
+  }
+
+  return {
+    signedTransaction: transaction,
+  }
+}

--- a/apps/walletd/lib/signV1.ts
+++ b/apps/walletd/lib/signV1.ts
@@ -8,7 +8,7 @@ import {
 import { stripPrefix } from '@siafoundation/design-system'
 import { AddressData } from '../contexts/addresses/types'
 
-export function addUnlockConditionsAndSignatures({
+export function addUnlockConditionsAndSignaturesV1({
   transaction,
   toSign,
   addresses,
@@ -40,7 +40,7 @@ export function addUnlockConditionsAndSignatures({
       siacoinInput,
       siafundInput,
       error,
-    } = getToSignMetadata({
+    } = getToSignMetadataV1({
       toSignId,
       addresses,
       siacoinOutputs,
@@ -53,11 +53,11 @@ export function addUnlockConditionsAndSignatures({
     }
 
     if (siacoinUtxo) {
-      siacoinInput.unlockConditions = address.metadata.unlockConditions
+      siacoinInput.unlockConditions = address.spendPolicy.policy
     }
 
     if (siafundUtxo) {
-      siafundInput.unlockConditions = address.metadata.unlockConditions
+      siafundInput.unlockConditions = address.spendPolicy.policy
     }
 
     if (!transaction.signatures) {
@@ -78,7 +78,7 @@ export function addUnlockConditionsAndSignatures({
   return {}
 }
 
-export function getSiacoinUtxoAndAddress({
+function getSiacoinUtxoAndAddressV1({
   id: idPrefixed,
   addresses,
   siacoinOutputs,
@@ -110,7 +110,10 @@ export function getSiacoinUtxoAndAddress({
   if (addressData.metadata.index === undefined) {
     return { error: 'Missing address index' }
   }
-  if (!addressData.metadata.unlockConditions.publicKeys[0]) {
+  if (!addressData.spendPolicy) {
+    return { error: 'Missing address spend policy' }
+  }
+  if (!addressData.spendPolicy.policy.publicKeys[0]) {
     return { error: 'Missing address public key' }
   }
 
@@ -120,7 +123,7 @@ export function getSiacoinUtxoAndAddress({
   }
 }
 
-export function getSiafundUtxoAndAddress({
+function getSiafundUtxoAndAddressV1({
   id: idPrefixed,
   addresses,
   siafundOutputs,
@@ -152,7 +155,10 @@ export function getSiafundUtxoAndAddress({
   if (addressData.metadata.index === undefined) {
     return { error: 'Missing address index' }
   }
-  if (!addressData.metadata.unlockConditions.publicKeys[0]) {
+  if (!addressData.spendPolicy) {
+    return { error: 'Missing address spend policy' }
+  }
+  if (!addressData.spendPolicy.policy.publicKeys[0]) {
     return { error: 'Missing address public key' }
   }
 
@@ -162,7 +168,7 @@ export function getSiafundUtxoAndAddress({
   }
 }
 
-export function getToSignMetadata({
+export function getToSignMetadataV1({
   toSignId: idPrefixed,
   transaction,
   addresses,
@@ -184,7 +190,7 @@ export function getToSignMetadata({
 } {
   const id = stripPrefix(idPrefixed)
   // find the parent utxo funding element for each input
-  const scUtxoAddr = getSiacoinUtxoAndAddress({
+  const scUtxoAddr = getSiacoinUtxoAndAddressV1({
     id,
     addresses,
     siacoinOutputs,
@@ -208,7 +214,7 @@ export function getToSignMetadata({
   }
 
   // find the parent utxo funding element for each input
-  const sfUtxoAddr = getSiafundUtxoAndAddress({
+  const sfUtxoAddr = getSiafundUtxoAndAddressV1({
     id,
     addresses,
     siafundOutputs,

--- a/apps/walletd/lib/signV2.ts
+++ b/apps/walletd/lib/signV2.ts
@@ -1,0 +1,308 @@
+import {
+  Result,
+  SiacoinElement,
+  SiafundElement,
+  V2SiacoinInput,
+  V2SiafundInput,
+  V2Transaction,
+} from '@siafoundation/types'
+import { AddressData } from '../contexts/addresses/types'
+import { getSDK } from '@siafoundation/sdk'
+
+export function addSignaturesSiacoinV2({
+  mnemonic,
+  transaction,
+  addresses,
+  siacoinOutputs,
+  sigHash,
+}: {
+  mnemonic: string
+  transaction: V2Transaction
+  addresses: AddressData[]
+  siacoinOutputs: SiacoinElement[]
+  sigHash: string
+}): { error?: string } {
+  if (!addresses) {
+    return { error: 'No addresses' }
+  }
+  if (!siacoinOutputs) {
+    return { error: 'No outputs' }
+  }
+
+  const scoIdsToSign =
+    transaction.siacoinInputs?.map((sci) => sci.parent.id) ?? []
+
+  // For each toSign ID, find the parent utxo funding element.
+  for (const outputId of scoIdsToSign) {
+    const meta = getToSignSiacoinMetadataV2({
+      outputId,
+      addresses,
+      siacoinOutputs,
+      transaction,
+    })
+
+    if ('error' in meta) {
+      return { error: meta.error }
+    }
+
+    if (
+      meta.siacoinUtxo &&
+      meta.address.metadata.index !== undefined &&
+      meta.address.spendPolicy
+    ) {
+      const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
+        mnemonic,
+        meta.address.metadata.index
+      )
+      if ('error' in pkResponse) {
+        return { error: pkResponse.error }
+      }
+      const signHashResponse = getSDK().wallet.signHash(
+        pkResponse.privateKey,
+        sigHash
+      )
+      if ('error' in signHashResponse) {
+        return { error: signHashResponse.error }
+      }
+      meta.siacoinInput.satisfiedPolicy.signatures = [
+        signHashResponse.signature,
+      ]
+    }
+  }
+
+  return {}
+}
+
+export function addSignaturesSiafundV2({
+  mnemonic,
+  transaction,
+  addresses,
+  siafundOutputs,
+  sigHash,
+}: {
+  mnemonic: string
+  transaction: V2Transaction
+  addresses: AddressData[]
+  siafundOutputs: SiafundElement[]
+  sigHash: string
+}): { error?: string } {
+  if (!addresses) {
+    return { error: 'No addresses' }
+  }
+  if (!siafundOutputs) {
+    return { error: 'No outputs' }
+  }
+
+  const sfoIdsToSign =
+    transaction.siafundInputs?.map((sfi) => sfi.parent.id) ?? []
+
+  // For each toSign ID, find the parent utxo funding element.
+  for (const outputId of sfoIdsToSign) {
+    const meta = getToSignSiafundMetadataV2({
+      outputId,
+      addresses,
+      siafundOutputs,
+      transaction,
+    })
+
+    if ('error' in meta) {
+      return { error: meta.error }
+    }
+
+    if (
+      meta.siafundUtxo &&
+      meta.address.metadata.index !== undefined &&
+      meta.address.spendPolicy
+    ) {
+      const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
+        mnemonic,
+        meta.address.metadata.index
+      )
+      if ('error' in pkResponse) {
+        return { error: pkResponse.error }
+      }
+      const signHashResponse = getSDK().wallet.signHash(
+        pkResponse.privateKey,
+        sigHash
+      )
+      if ('error' in signHashResponse) {
+        return { error: signHashResponse.error }
+      }
+      meta.siafundInput.satisfiedPolicy.signatures = [
+        signHashResponse.signature,
+      ]
+    }
+  }
+
+  return {}
+}
+
+function getSiacoinUtxoAndAddressV2({
+  scoId,
+  addresses,
+  siacoinOutputs,
+}: {
+  scoId: string
+  addresses: AddressData[]
+  siacoinOutputs: SiacoinElement[]
+}): Result<{ utxo: SiacoinElement; address: AddressData }> {
+  // find the utxo by toSign ID
+  const utxo = siacoinOutputs?.find((sco) => sco.id === scoId)
+  if (!utxo) {
+    return { error: 'Missing utxo' }
+  }
+
+  // Find the utxo's address metadata which has the index and public key saved.
+  // The public key was computed and saved when the address was generated.
+  const addressData = addresses?.find(
+    (a) => a.address === utxo.siacoinOutput.address
+  )
+
+  if (!addressData) {
+    return { error: 'Missing address' }
+  }
+  if (!addressData.metadata) {
+    return { error: 'Missing address metadata' }
+  }
+  if (addressData.metadata.index === undefined) {
+    return { error: 'Missing address index' }
+  }
+  if (!addressData.spendPolicy) {
+    return { error: 'Missing address spend policy' }
+  }
+  if (!addressData.spendPolicy.policy.publicKeys[0]) {
+    return { error: 'Missing address public key' }
+  }
+
+  return {
+    utxo,
+    address: addressData,
+  }
+}
+
+function getSiafundUtxoAndAddressV2({
+  sfoId,
+  addresses,
+  siafundOutputs,
+}: {
+  sfoId: string
+  addresses: AddressData[]
+  siafundOutputs: SiafundElement[]
+}): Result<{ utxo: SiafundElement; address: AddressData }> {
+  // find the utxo by toSign ID
+  const utxo = siafundOutputs?.find((sfo) => sfo.id === sfoId)
+  if (!utxo) {
+    return { error: 'Missing utxo' }
+  }
+
+  // find the utxo's address metadata which has the index and public key saved
+  // the public key was computed and saved when the address was generated
+  const addressData = addresses?.find(
+    (a) => a.address === utxo.siafundOutput.address
+  )
+
+  if (!addressData) {
+    return { error: 'Missing address' }
+  }
+  if (!addressData.metadata) {
+    return { error: 'Missing address metadata' }
+  }
+  if (addressData.metadata.index === undefined) {
+    return { error: 'Missing address index' }
+  }
+  if (!addressData.spendPolicy) {
+    return { error: 'Missing address spend policy' }
+  }
+  if (!addressData.spendPolicy.policy.publicKeys[0]) {
+    return { error: 'Missing address public key' }
+  }
+
+  return {
+    utxo,
+    address: addressData,
+  }
+}
+
+function getToSignSiacoinMetadataV2({
+  outputId,
+  transaction,
+  addresses,
+  siacoinOutputs,
+}: {
+  outputId: string
+  transaction: V2Transaction
+  addresses: AddressData[]
+  siacoinOutputs: SiacoinElement[]
+}): Result<{
+  address: AddressData
+  siacoinUtxo: SiacoinElement
+  siacoinInput: V2SiacoinInput
+}> {
+  // Find the parent utxo funding element for each input.
+  const scUtxoAddr = getSiacoinUtxoAndAddressV2({
+    scoId: outputId,
+    addresses,
+    siacoinOutputs,
+  })
+
+  if ('error' in scUtxoAddr) {
+    return { error: scUtxoAddr.error }
+  }
+
+  // Find the siacoin input by matching the toSign ID to the siacoin input's parent ID.
+  const sci = transaction.siacoinInputs?.find(
+    (sci) => sci.parent.id === scUtxoAddr.utxo.id
+  )
+
+  if (!sci) {
+    return { error: 'Missing input' }
+  }
+
+  return {
+    address: scUtxoAddr.address,
+    siacoinUtxo: scUtxoAddr.utxo,
+    siacoinInput: sci,
+  }
+}
+
+function getToSignSiafundMetadataV2({
+  outputId,
+  transaction,
+  addresses,
+  siafundOutputs,
+}: {
+  outputId: string
+  transaction: V2Transaction
+  addresses: AddressData[]
+  siafundOutputs: SiafundElement[]
+}): Result<{
+  address: AddressData
+  siafundUtxo: SiafundElement
+  siafundInput: V2SiafundInput
+}> {
+  // Find the parent utxo funding element for each input.
+  const sfUtxoAddr = getSiafundUtxoAndAddressV2({
+    sfoId: outputId,
+    addresses,
+    siafundOutputs,
+  })
+
+  if ('error' in sfUtxoAddr) {
+    return { error: sfUtxoAddr.error }
+  }
+
+  // Find the siafund input by matching the toSign ID to the siafund input's parent ID.
+  const sfi = transaction.siafundInputs?.find(
+    (sfi) => sfi.parent.id === sfUtxoAddr.utxo.id
+  )
+
+  if (!sfi) {
+    return { error: 'Missing input' }
+  }
+
+  return {
+    address: sfUtxoAddr.address,
+    siafundUtxo: sfUtxoAddr.utxo,
+    siafundInput: sfi,
+  }
+}

--- a/libs/walletd-mock/src/mocks/walletAddresses.ts
+++ b/libs/walletd-mock/src/mocks/walletAddresses.ts
@@ -10,9 +10,9 @@ export function getMockWalletAddressesResponse(): WalletAddressesResponse {
       address:
         'f2dbf56b5b0c698d7fbf43f646c76169d84e597e8b37fada97348beeecaa812d400ac4ce7981',
       description: '',
-      metadata: {
-        index: 0,
-        unlockConditions: {
+      spendPolicy: {
+        type: 'uc',
+        policy: {
           signaturesRequired: 1,
           timelock: 0,
           publicKeys: [
@@ -20,14 +20,17 @@ export function getMockWalletAddressesResponse(): WalletAddressesResponse {
           ],
         },
       },
+      metadata: {
+        index: 0,
+      },
     },
     {
       address:
         '90c6057cdd2463eca61f83796e83152dbba28b6cb9a74831a043833051ec9f422726bfff2ee8',
       description: '',
-      metadata: {
-        index: 1,
-        unlockConditions: {
+      spendPolicy: {
+        type: 'uc',
+        policy: {
           signaturesRequired: 1,
           timelock: 0,
           publicKeys: [
@@ -35,20 +38,26 @@ export function getMockWalletAddressesResponse(): WalletAddressesResponse {
           ],
         },
       },
+      metadata: {
+        index: 1,
+      },
     },
     {
       address:
         '170173c40ca0f39f9618da30af14c390c7ce70248a3662a7a5d3d5a8a31c9fbfa2071e9f6518',
       description: '',
-      metadata: {
-        index: 2,
-        unlockConditions: {
+      spendPolicy: {
+        type: 'uc',
+        policy: {
           signaturesRequired: 1,
           timelock: 0,
           publicKeys: [
             'ed25519:65cac661a4acf36847c0aa67cbc6956e3449fd82a7430cfd673ea7fedbfcf5fa',
           ],
         },
+      },
+      metadata: {
+        index: 2,
       },
     },
   ]

--- a/libs/walletd-mock/src/scenarios/seedWallet.ts
+++ b/libs/walletd-mock/src/scenarios/seedWallet.ts
@@ -172,7 +172,9 @@ export function getMockScenarioSeedWallet() {
               type: 'uc',
               policy: {
                 timelock: 0,
-                publicKeys: null,
+                publicKeys: [
+                  'ed25519:ee122b2169bdae5776b55609e384e0c58372cd5c529d4edc9b9918b26f8e5535',
+                ],
                 signaturesRequired: 1,
               },
             },
@@ -198,7 +200,9 @@ export function getMockScenarioSeedWallet() {
               type: 'uc',
               policy: {
                 timelock: 0,
-                publicKeys: null,
+                publicKeys: [
+                  'ed25519:ee122b2169bdae5776b55609e384e0c58372cd5c529d4edc9b9918b26f8e5535',
+                ],
                 signaturesRequired: 1,
               },
             },
@@ -227,9 +231,9 @@ export function getMockScenarioSeedWallet() {
       address:
         'f2dbf56b5b0c698d7fbf43f646c76169d84e597e8b37fada97348beeecaa812d400ac4ce7981',
       description: '',
-      metadata: {
-        index: 0,
-        unlockConditions: {
+      spendPolicy: {
+        type: 'uc',
+        policy: {
           timelock: 0,
           signaturesRequired: 1,
           publicKeys: [
@@ -237,14 +241,17 @@ export function getMockScenarioSeedWallet() {
           ],
         },
       },
+      metadata: {
+        index: 0,
+      },
     },
     {
       address:
         '90c6057cdd2463eca61f83796e83152dbba28b6cb9a74831a043833051ec9f422726bfff2ee8',
       description: '',
-      metadata: {
-        index: 1,
-        unlockConditions: {
+      spendPolicy: {
+        type: 'uc',
+        policy: {
           timelock: 0,
           signaturesRequired: 1,
           publicKeys: [
@@ -252,20 +259,26 @@ export function getMockScenarioSeedWallet() {
           ],
         },
       },
+      metadata: {
+        index: 1,
+      },
     },
     {
       address:
         '170173c40ca0f39f9618da30af14c390c7ce70248a3662a7a5d3d5a8a31c9fbfa2071e9f6518',
       description: '',
-      metadata: {
-        index: 2,
-        unlockConditions: {
+      spendPolicy: {
+        type: 'uc',
+        policy: {
           timelock: 0,
           signaturesRequired: 1,
           publicKeys: [
             'ed25519:65cac661a4acf36847c0aa67cbc6956e3449fd82a7430cfd673ea7fedbfcf5fa',
           ],
         },
+      },
+      metadata: {
+        index: 2,
       },
     },
   ]

--- a/libs/walletd-types/src/types.ts
+++ b/libs/walletd-types/src/types.ts
@@ -1,4 +1,4 @@
-import { SpendPolicy, UnlockConditions } from '@siafoundation/types'
+import { SpendPolicy } from '@siafoundation/types'
 
 export type GatewayPeer = {
   address: string
@@ -33,7 +33,6 @@ export type Wallet = {
 
 export type WalletAddressMetadata = {
   index?: number
-  unlockConditions?: UnlockConditions
 }
 
 export type WalletAddress = {


### PR DESCRIPTION
- Generating addresses now stores the `spendPolicy` in the dedicated field rather than `unlockConditions` in the metadata.
- V1 signing now uses the address `spendPolicy`.
- Added V2 signing method.