### PR TITLE
fix(walletd): switching send modes unsets other amount

### DIFF
--- a/.changeset/odd-cycles-accept.md
+++ b/.changeset/odd-cycles-accept.md
@@ -1,0 +1,5 @@
+---
+'walletd': minor
+---
+
+Send mode only sends the amount of siacoin or siafunds specified in the active mode.

--- a/apps/walletd/dialogs/_sharedWalletSendV1/useComposeFormV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/useComposeFormV1.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
 } from '@siafoundation/design-system'
 import { useForm } from 'react-hook-form'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { SendParamsV1 } from './typesV1'
 import { Information16 } from '@siafoundation/react-icons'
 import { Maybe } from '@siafoundation/types'
@@ -274,6 +274,16 @@ export function useComposeFormV1({
   const customClaimAddress = form.watch('customClaimAddress')
   const includeFee = form.watch('includeFee')
   const sc = toHastings(siacoin || 0)
+
+  // Reset the siacoin or siafund field when the mode changes.
+  useEffect(() => {
+    if (mode === 'siafund') {
+      form.resetField('siacoin')
+    }
+    if (mode === 'siacoin') {
+      form.resetField('siafund')
+    }
+  }, [mode, form])
 
   const el = (
     <div className="flex flex-col gap-4">

--- a/apps/walletd/dialogs/_sharedWalletSendV2/useComposeFormV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/useComposeFormV2.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
 } from '@siafoundation/design-system'
 import { useForm } from 'react-hook-form'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { SendParamsV2 } from './typesV2'
 import { Information16 } from '@siafoundation/react-icons'
 import { Maybe } from '@siafoundation/types'
@@ -217,6 +217,16 @@ export function useComposeFormV2({
   const customChangeAddress = form.watch('customChangeAddress')
   const includeFee = form.watch('includeFee')
   const sc = toHastings(siacoin || 0)
+
+  // Reset the siacoin or siafund field when the mode changes.
+  useEffect(() => {
+    if (mode === 'siafund') {
+      form.resetField('siacoin')
+    }
+    if (mode === 'siacoin') {
+      form.resetField('siafund')
+    }
+  }, [mode, form])
 
   const el = (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
- Send mode only sends the amount of siacoin or siafunds specified in the active mode.