### PR TITLE
refactor(walletd): ledger wallet warn at require height

### DIFF
--- a/.changeset/slimy-bags-beam.md
+++ b/.changeset/slimy-bags-beam.md
@@ -2,4 +2,4 @@
 'walletd': minor
 ---
 
-Added a warning in the v2 ledger send dialog explaining that sending funds with ledger is not yet available but coming soon.
+Ledger wallets will now disable sending transactions and display a warning once the hardfork require height is reached. The message explains that sending funds with ledger is not yet available but coming soon.

--- a/apps/walletd-e2e/src/specs/ledgerSendSiacoin.spec.ts
+++ b/apps/walletd-e2e/src/specs/ledgerSendSiacoin.spec.ts
@@ -11,7 +11,7 @@ import {
   testOnlyWorksOn,
   testRequiresClipboardPermissions,
 } from '@siafoundation/e2e'
-import { clusterd, mine } from '@siafoundation/clusterd'
+import { clusterd, mineToHeight } from '@siafoundation/clusterd'
 import { createLedgerWalletWithApi } from '../fixtures/ledger'
 import { rescanWallets } from '../fixtures/wallet'
 import { ledgerComposeSiacoin } from '../fixtures/ledgerComposeSiacoin'
@@ -26,6 +26,11 @@ const wallet1PublicKey0 =
 // Second wallet - receiver
 const wallet2Address0 =
   '4e7e288504d86ae2234ffc6989aa96e70eb555ace205eb2d0afaaca650536fd1de3b5ff8f90c'
+
+// Reason for the selected mining heights:
+// test cluster: internal/cluster/cmd/clusterd/main.go#L131-L132
+const v2AllowHeight = 400
+const v2RequireHeight = 500
 
 test.beforeEach(async ({ page }) => {
   await beforeTest(page)
@@ -72,11 +77,27 @@ test('compose siacoin transaction with ledger wallet pre and post v2 fork allow 
     receiveAddress: wallet2Address0,
     changeAddress: wallet1Address0,
     amount: amountV1,
+    // v1 fee is 0.004
     expectedFee: 0.004,
   })
 
-  // Mine blocks to pass v2 fork height.
-  await mine(100)
+  // Mine blocks to pass v2 fork allow height.
+  await mineToHeight(v2AllowHeight + 1)
+  await page.reload()
+
+  // Verify still composes v1 transaction.
+  const amountV12 = random(1, 20)
+  await ledgerComposeSiacoin(page, {
+    walletName: wallet1Name,
+    receiveAddress: wallet2Address0,
+    changeAddress: wallet1Address0,
+    amount: amountV12,
+    // v1 fee is 0.004
+    expectedFee: 0.004,
+  })
+
+  // Mine blocks to pass v2 fork require height.
+  await mineToHeight(v2RequireHeight + 1)
   await page.reload()
 
   // Verify can not compose v2 transaction.

--- a/apps/walletd-e2e/src/specs/ledgerSendSiafund.spec.ts
+++ b/apps/walletd-e2e/src/specs/ledgerSendSiafund.spec.ts
@@ -11,7 +11,7 @@ import {
   testOnlyWorksOn,
   testRequiresClipboardPermissions,
 } from '@siafoundation/e2e'
-import { clusterd, mine } from '@siafoundation/clusterd'
+import { clusterd, mineToHeight } from '@siafoundation/clusterd'
 import { createLedgerWalletWithApi } from '../fixtures/ledger'
 import { rescanWallets } from '../fixtures/wallet'
 import { ledgerComposeSiafund } from '../fixtures/ledgerComposeSiafund'
@@ -26,6 +26,11 @@ const wallet1PublicKey0 =
 // Second wallet - receiver
 const wallet2Address0 =
   '4e7e288504d86ae2234ffc6989aa96e70eb555ace205eb2d0afaaca650536fd1de3b5ff8f90c'
+
+// Reason for the selected mining heights:
+// test cluster: internal/cluster/cmd/clusterd/main.go#L131-L132
+const v2AllowHeight = 400
+const v2RequireHeight = 500
 
 test.beforeEach(async ({ page }) => {
   await beforeTest(page, {
@@ -75,12 +80,29 @@ test('compose siafund transaction with ledger wallet pre and post v2 fork allow 
     receiveAddress: wallet2Address0,
     changeAddress: wallet1Address0,
     amount: amountV1,
+    // v1 fee is 0.004
     expectedFee: 0.004,
     expectedVersion: 'v1',
   })
 
-  // Mine blocks to pass v2 fork height.
-  await mine(100)
+  // Mine blocks to pass v2 fork allow height.
+  await mineToHeight(v2AllowHeight + 1)
+  await page.reload()
+
+  // Verify still composes v1 transaction.
+  const amountV12 = random(1, 20)
+  await ledgerComposeSiafund(page, {
+    walletName: wallet1Name,
+    receiveAddress: wallet2Address0,
+    changeAddress: wallet1Address0,
+    amount: amountV12,
+    // v1 fee is 0.004
+    expectedFee: 0.004,
+    expectedVersion: 'v1',
+  })
+
+  // Mine blocks to pass v2 fork require height.
+  await mineToHeight(v2RequireHeight + 1)
   await page.reload()
 
   // Verify can not compose v2 transaction.

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@siafoundation/walletd-react'
 import { WalletSendLedgerDialogV2 } from './WalletSendLedgerDialogV2'
 import { WalletSendLedgerDialogV1 } from './WalletSendLedgerDialogV1'
-import { getCurrentVersion } from '../_sharedWalletSendV2/hardforkV2'
+import { isPastV2RequireHeight } from '../_sharedWalletSendV2/hardforkV2'
 
 export type WalletSendLedgerDialogParams = {
   walletId: string
@@ -26,12 +26,12 @@ export function WalletSendLedgerDialog({
   const n = useConsensusNetwork()
   const ct = useConsensusTip()
 
-  const version = getCurrentVersion({
+  const isV2Required = isPastV2RequireHeight({
     network: n.data?.name || 'mainnet',
     height: ct.data?.height || 0,
   })
 
-  if (version === 'v2') {
+  if (isV2Required) {
     return (
       <WalletSendLedgerDialogV2
         trigger={trigger}

--- a/apps/walletd/dialogs/WalletSendSeedDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@siafoundation/walletd-react'
 import { WalletSendSeedDialogV2 } from './WalletSendSeedDialogV2'
 import { WalletSendSeedDialogV1 } from './WalletSendSeedDialogV1'
-import { getCurrentVersion } from '../_sharedWalletSendV2/hardforkV2'
+import { isPastV2AllowHeight } from '../_sharedWalletSendV2/hardforkV2'
 
 export type WalletSendSeedDialogParams = {
   walletId: string
@@ -26,12 +26,12 @@ export function WalletSendSeedDialog({
   const n = useConsensusNetwork()
   const ct = useConsensusTip()
 
-  const version = getCurrentVersion({
+  const isV2Allowed = isPastV2AllowHeight({
     network: n.data?.name || 'mainnet',
     height: ct.data?.height || 0,
   })
 
-  if (version === 'v2') {
+  if (isV2Allowed) {
     return (
       <WalletSendSeedDialogV2
         trigger={trigger}

--- a/apps/walletd/dialogs/_sharedWalletSendV2/hardforkV2.ts
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/hardforkV2.ts
@@ -21,7 +21,14 @@ const hardforkV2AllowHeights = {
   testCluster: 400,
 }
 
-export function getCurrentVersion({
+const hardforkV2RequireHeights = {
+  mainnet: 530_000,
+  zen: 114_000,
+  anagami: 2_016 + 288,
+  testCluster: 500,
+}
+
+export function isPastV2AllowHeight({
   network,
   height,
 }: {
@@ -33,5 +40,20 @@ export function getCurrentVersion({
       ? hardforkV2AllowHeights.testCluster
       : hardforkV2AllowHeights[network || 'mainnet']
 
-  return height > hardforkV2AllowHeight ? 'v2' : 'v1'
+  return height > hardforkV2AllowHeight
+}
+
+export function isPastV2RequireHeight({
+  network,
+  height,
+}: {
+  network: string
+  height: number
+}) {
+  const hardforkV2RequireHeight =
+    process.env.NEXT_PUBLIC_TEST_CLUSTER === 'true'
+      ? hardforkV2RequireHeights.testCluster
+      : hardforkV2RequireHeights[network || 'mainnet']
+
+  return height > hardforkV2RequireHeight
 }


### PR DESCRIPTION
- Updated ledger wallets to continue sending v1 txn after the allow height and disable at the require height.
  - Added tests that check the 3 phases.
- Seed wallets still switch to v2 at the allow height.
