### PR TITLE
feat(walletd): send network and transaction version details

### DIFF
--- a/.changeset/wild-adults-tie.md
+++ b/.changeset/wild-adults-tie.md
@@ -1,0 +1,5 @@
+---
+'walletd': minor
+---
+
+The send dialogs now indicate the network and transaction version details.

--- a/apps/walletd-e2e/src/fixtures/ledgerComposeSiacoin.ts
+++ b/apps/walletd-e2e/src/fixtures/ledgerComposeSiacoin.ts
@@ -13,12 +13,14 @@ export const ledgerComposeSiacoin = step(
       receiveAddress,
       amount,
       expectedFee,
+      transactionVersionIndicator,
     }: {
       walletName: string
       changeAddress: string
       receiveAddress: string
       amount: number
       expectedFee: number
+      transactionVersionIndicator: string
     }
   ) => {
     const amountWithFeeString = `${(amount + expectedFee).toFixed(3)} SC`
@@ -47,6 +49,9 @@ export const ledgerComposeSiacoin = step(
     await expect(sendDialog.getByLabel('Total')).toContainText(
       amountWithFeeString
     )
+    await expect(
+      sendDialog.getByText(transactionVersionIndicator)
+    ).toBeVisible()
     await sendDialog.getByRole('button', { name: 'Close' }).click()
   }
 )

--- a/apps/walletd-e2e/src/fixtures/ledgerComposeSiafund.ts
+++ b/apps/walletd-e2e/src/fixtures/ledgerComposeSiafund.ts
@@ -15,6 +15,7 @@ export const ledgerComposeSiafund = step(
       amount,
       expectedFee,
       expectedVersion,
+      transactionVersionIndicator,
     }: {
       walletName: string
       changeAddress: string
@@ -23,6 +24,7 @@ export const ledgerComposeSiafund = step(
       amount: number
       expectedFee: number
       expectedVersion: 'v1' | 'v2'
+      transactionVersionIndicator: string
     }
   ) => {
     const amountString = `${amount} SF`
@@ -54,6 +56,9 @@ export const ledgerComposeSiafund = step(
     }
     await expect(sendDialog.getByLabel('Amount')).toContainText(amountString)
     await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
+    await expect(
+      sendDialog.getByText(transactionVersionIndicator)
+    ).toBeVisible()
     await sendDialog.getByRole('button', { name: 'Close' }).click()
   }
 )

--- a/apps/walletd-e2e/src/fixtures/seedSendSiacoin.ts
+++ b/apps/walletd-e2e/src/fixtures/seedSendSiacoin.ts
@@ -16,6 +16,7 @@ export const sendSiacoinWithSeedWallet = step(
       amount,
       expectedFee,
       expectedVersion,
+      transactionVersionIndicator,
     }: {
       walletName: string
       mnemonic: string
@@ -24,6 +25,7 @@ export const sendSiacoinWithSeedWallet = step(
       amount: number
       expectedFee: number
       expectedVersion: 'v1' | 'v2'
+      transactionVersionIndicator: string
     }
   ) => {
     const amountWithFeeString = `${(amount + expectedFee).toFixed(3)} SC`
@@ -50,6 +52,9 @@ export const sendSiacoinWithSeedWallet = step(
     await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
     await expect(sendDialog.getByText('Total')).toBeVisible()
     await expect(sendDialog.getByText(amountWithFeeString)).toBeVisible()
+    await expect(
+      sendDialog.getByText(transactionVersionIndicator)
+    ).toBeVisible()
 
     await page
       .getByRole('button', { name: 'Sign and broadcast transaction' })

--- a/apps/walletd-e2e/src/fixtures/seedSendSiafund.ts
+++ b/apps/walletd-e2e/src/fixtures/seedSendSiafund.ts
@@ -17,6 +17,7 @@ export const sendSiafundWithSeedWallet = step(
       amount,
       expectedFee,
       expectedVersion,
+      transactionVersionIndicator,
     }: {
       walletName: string
       mnemonic: string
@@ -26,6 +27,7 @@ export const sendSiafundWithSeedWallet = step(
       amount: number
       expectedFee: number
       expectedVersion: 'v1' | 'v2'
+      transactionVersionIndicator: string
     }
   ) => {
     const amountString = `${amount} SF`
@@ -57,6 +59,9 @@ export const sendSiafundWithSeedWallet = step(
     }
     await expect(sendDialog.getByLabel('Amount')).toContainText(amountString)
     await expect(sendDialog.getByLabel('Network fee')).toContainText(feeString)
+    await expect(
+      sendDialog.getByText(transactionVersionIndicator)
+    ).toBeVisible()
 
     await page
       .getByRole('button', { name: 'Sign and broadcast transaction' })

--- a/apps/walletd-e2e/src/specs/ledgerSendSiacoin.spec.ts
+++ b/apps/walletd-e2e/src/specs/ledgerSendSiacoin.spec.ts
@@ -79,6 +79,8 @@ test('compose siacoin transaction with ledger wallet pre and post v2 fork allow 
     amount: amountV1,
     // v1 fee is 0.004
     expectedFee: 0.004,
+    transactionVersionIndicator:
+      'testCluster - constructing v1 transaction - switching to v2 at require height 500',
   })
 
   // Mine blocks to pass v2 fork allow height.
@@ -94,6 +96,8 @@ test('compose siacoin transaction with ledger wallet pre and post v2 fork allow 
     amount: amountV12,
     // v1 fee is 0.004
     expectedFee: 0.004,
+    transactionVersionIndicator:
+      'testCluster - constructing v1 transaction - switching to v2 at require height 500',
   })
 
   // Mine blocks to pass v2 fork require height.
@@ -105,5 +109,10 @@ test('compose siacoin transaction with ledger wallet pre and post v2 fork allow 
   await page.getByLabel('send').click()
   await expect(
     page.getByText('Ledger wallets do not support sending v2 transactions')
+  ).toBeVisible()
+  await expect(
+    page.getByText(
+      'testCluster - constructing v2 transaction - switched to v2 at require height 500'
+    )
   ).toBeVisible()
 })

--- a/apps/walletd-e2e/src/specs/ledgerSendSiafund.spec.ts
+++ b/apps/walletd-e2e/src/specs/ledgerSendSiafund.spec.ts
@@ -83,6 +83,8 @@ test('compose siafund transaction with ledger wallet pre and post v2 fork allow 
     // v1 fee is 0.004
     expectedFee: 0.004,
     expectedVersion: 'v1',
+    transactionVersionIndicator:
+      'testCluster - constructing v1 transaction - switching to v2 at require height 500',
   })
 
   // Mine blocks to pass v2 fork allow height.
@@ -99,6 +101,8 @@ test('compose siafund transaction with ledger wallet pre and post v2 fork allow 
     // v1 fee is 0.004
     expectedFee: 0.004,
     expectedVersion: 'v1',
+    transactionVersionIndicator:
+      'testCluster - constructing v1 transaction - switching to v2 at require height 500',
   })
 
   // Mine blocks to pass v2 fork require height.
@@ -110,5 +114,10 @@ test('compose siafund transaction with ledger wallet pre and post v2 fork allow 
   await page.getByLabel('send').click()
   await expect(
     page.getByText('Ledger wallets do not support sending v2 transactions')
+  ).toBeVisible()
+  await expect(
+    page.getByText(
+      'testCluster - constructing v2 transaction - switched to v2 at require height 500'
+    )
   ).toBeVisible()
 })

--- a/apps/walletd-e2e/src/specs/seedSendSiacoin.spec.ts
+++ b/apps/walletd-e2e/src/specs/seedSendSiacoin.spec.ts
@@ -70,6 +70,8 @@ test('send siacoin between wallets pre and post v2 fork allow height', async ({
     amount: amountV1,
     expectedFee: 0.004,
     expectedVersion: 'v1',
+    transactionVersionIndicator:
+      'testCluster - constructing v1 transaction - switching to v2 at allow height 400',
   })
 
   await mine(1)
@@ -97,6 +99,8 @@ test('send siacoin between wallets pre and post v2 fork allow height', async ({
     amount: amountV2,
     expectedFee: 0.02,
     expectedVersion: 'v2',
+    transactionVersionIndicator:
+      'testCluster - constructing v2 transaction - switched to v2 at allow height 400',
   })
 
   await mine(1)

--- a/apps/walletd-e2e/src/specs/seedSendSiafund.spec.ts
+++ b/apps/walletd-e2e/src/specs/seedSendSiafund.spec.ts
@@ -79,6 +79,8 @@ test('send siafund between wallets pre and post v2 fork allow height', async ({
     amount: amountV1,
     expectedFee: 0.004,
     expectedVersion: 'v1',
+    transactionVersionIndicator:
+      'testCluster - constructing v1 transaction - switching to v2 at allow height 400',
   })
 
   await mine(1)
@@ -108,6 +110,8 @@ test('send siafund between wallets pre and post v2 fork allow height', async ({
     amount: amountV2,
     expectedFee: 0.02,
     expectedVersion: 'v2',
+    transactionVersionIndicator:
+      'testCluster - constructing v2 transaction - switched to v2 at allow height 400',
   })
 
   await mine(1)

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/WalletSendLedgerDialogV1/index.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/WalletSendLedgerDialogV1/index.tsx
@@ -94,6 +94,7 @@ export function WalletSendLedgerDialogV1({
 
   return (
     <SendFlowDialogV1
+      type="ledger"
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/WalletSendLedgerDialogV2/index.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/WalletSendLedgerDialogV2/index.tsx
@@ -100,6 +100,7 @@ export function WalletSendLedgerDialogV2({
 
   return (
     <SendFlowDialogV2
+      type="ledger"
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@siafoundation/walletd-react'
 import { WalletSendLedgerDialogV2 } from './WalletSendLedgerDialogV2'
 import { WalletSendLedgerDialogV1 } from './WalletSendLedgerDialogV1'
-import { isPastV2RequireHeight } from '../_sharedWalletSendV2/hardforkV2'
+import { isPastV2RequireHeight } from '../_sharedWalletSend/hardforkV2'
 
 export type WalletSendLedgerDialogParams = {
   walletId: string

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/index.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV1/index.tsx
@@ -95,6 +95,7 @@ export function WalletSendSeedDialogV1({
 
   return (
     <SendFlowDialogV1
+      type="seed"
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV2/index.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV2/index.tsx
@@ -101,6 +101,7 @@ export function WalletSendSeedDialogV2({
 
   return (
     <SendFlowDialogV2
+      type="seed"
       trigger={trigger}
       open={open}
       onOpenChange={(val) => {

--- a/apps/walletd/dialogs/WalletSendSeedDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/index.tsx
@@ -4,7 +4,7 @@ import {
 } from '@siafoundation/walletd-react'
 import { WalletSendSeedDialogV2 } from './WalletSendSeedDialogV2'
 import { WalletSendSeedDialogV1 } from './WalletSendSeedDialogV1'
-import { isPastV2AllowHeight } from '../_sharedWalletSendV2/hardforkV2'
+import { isPastV2AllowHeight } from '../_sharedWalletSend/hardforkV2'
 
 export type WalletSendSeedDialogParams = {
   walletId: string

--- a/apps/walletd/dialogs/_sharedWalletSend/TransactionVersionIndicator.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSend/TransactionVersionIndicator.tsx
@@ -1,0 +1,65 @@
+import { Text } from '@siafoundation/design-system'
+import {
+  useConsensusNetwork,
+  useConsensusTip,
+} from '@siafoundation/walletd-react'
+import {
+  isPastV2AllowHeight,
+  isPastV2RequireHeight,
+  getHardforkV2RequireHeight,
+  getHardforkV2AllowHeight,
+  getNetwork,
+} from './hardforkV2'
+
+export function TransactionVersionIndicator({
+  type,
+}: {
+  type: 'seed' | 'ledger'
+}) {
+  const n = useConsensusNetwork()
+  const ct = useConsensusTip()
+  const height = ct.data?.height || 0
+  const network = getNetwork(n.data?.name)
+
+  const requireHeight = getHardforkV2RequireHeight(network).toLocaleString()
+  const allowHeight = getHardforkV2AllowHeight(network).toLocaleString()
+
+  const isV2Allowed = isPastV2AllowHeight({
+    network,
+    height,
+  })
+
+  const isV2Required = isPastV2RequireHeight({
+    network,
+    height,
+  })
+
+  if (type === 'ledger') {
+    let text = ''
+    if (isV2Required) {
+      text = `${network} - constructing v2 transaction - switched to v2 at require height ${requireHeight}`
+    } else {
+      text = `${network} - constructing v1 transaction - switching to v2 at require height ${requireHeight}`
+    }
+    return (
+      <Text color="verySubtle" size="10">
+        {text}
+      </Text>
+    )
+  }
+
+  let text = ''
+  if (isV2Required) {
+    text = `${network} - constructing v2 transaction - switched to v2 at allow height ${allowHeight}`
+  } else if (isV2Allowed) {
+    text = `${network} - constructing v2 transaction - switched to v2 at allow height ${allowHeight}`
+  } else {
+    text = `${network} - constructing v1 transaction - switching to v2 at allow height ${allowHeight}`
+  }
+
+  return (
+    <Text color="verySubtle" size="10">
+      {text}
+    </Text>
+  )
+}

--- a/apps/walletd/dialogs/_sharedWalletSend/hardforkV2.ts
+++ b/apps/walletd/dialogs/_sharedWalletSend/hardforkV2.ts
@@ -14,18 +14,32 @@
 // n.HardforkV2.AllowHeight = 400
 // n.HardforkV2.RequireHeight = 500
 
-const hardforkV2AllowHeights = {
+export const hardforkV2AllowHeights = {
   mainnet: 526_000,
   zen: 112_000,
   anagami: 2_016,
   testCluster: 400,
 }
 
-const hardforkV2RequireHeights = {
+export const hardforkV2RequireHeights = {
   mainnet: 530_000,
   zen: 114_000,
   anagami: 2_016 + 288,
   testCluster: 500,
+}
+
+export function getNetwork(network?: string) {
+  return process.env.NEXT_PUBLIC_TEST_CLUSTER === 'true'
+    ? 'testCluster'
+    : network || 'mainnet'
+}
+
+export function getHardforkV2AllowHeight(network: string) {
+  return hardforkV2AllowHeights[getNetwork(network)]
+}
+
+export function getHardforkV2RequireHeight(network: string) {
+  return hardforkV2RequireHeights[getNetwork(network)]
 }
 
 export function isPastV2AllowHeight({
@@ -35,11 +49,7 @@ export function isPastV2AllowHeight({
   network: string
   height: number
 }) {
-  const hardforkV2AllowHeight =
-    process.env.NEXT_PUBLIC_TEST_CLUSTER === 'true'
-      ? hardforkV2AllowHeights.testCluster
-      : hardforkV2AllowHeights[network || 'mainnet']
-
+  const hardforkV2AllowHeight = getHardforkV2AllowHeight(network)
   return height > hardforkV2AllowHeight
 }
 
@@ -50,10 +60,6 @@ export function isPastV2RequireHeight({
   network: string
   height: number
 }) {
-  const hardforkV2RequireHeight =
-    process.env.NEXT_PUBLIC_TEST_CLUSTER === 'true'
-      ? hardforkV2RequireHeights.testCluster
-      : hardforkV2RequireHeights[network || 'mainnet']
-
+  const hardforkV2RequireHeight = getHardforkV2RequireHeight(network)
   return height > hardforkV2RequireHeight
 }

--- a/apps/walletd/dialogs/_sharedWalletSendV1/SendFlowDialogV1.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV1/SendFlowDialogV1.tsx
@@ -7,6 +7,7 @@ import {
 import { SendDoneV1 } from './SendDoneV1'
 import { SendParamsV1, SendStep } from './typesV1'
 import { UseFormReturn } from 'react-hook-form'
+import { TransactionVersionIndicator } from '../_sharedWalletSend/TransactionVersionIndicator'
 
 export type SendDialogParams = {
   walletId: string
@@ -40,6 +41,7 @@ type Props = {
     submitLabel: string
     handleSubmit: () => void
   }
+  type: 'seed' | 'ledger'
 }
 
 export function SendFlowDialogV1({
@@ -53,6 +55,7 @@ export function SendFlowDialogV1({
   compose,
   setStep,
   controls,
+  type,
 }: Props) {
   return (
     <Dialog
@@ -70,7 +73,11 @@ export function SendFlowDialogV1({
       onSubmit={controls ? controls.handleSubmit : undefined}
       controls={
         controls?.form && (
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-3">
+            <Separator className="w-full" />
+            <div className="flex justify-center">
+              <TransactionVersionIndicator type={type} />
+            </div>
             <FormSubmitButton form={controls.form}>
               {controls.submitLabel}
             </FormSubmitButton>

--- a/apps/walletd/dialogs/_sharedWalletSendV2/SendFlowDialogV2.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSendV2/SendFlowDialogV2.tsx
@@ -9,6 +9,7 @@ import {
 import { SendParamsV2, SendStep } from './typesV2'
 import { UseFormReturn } from 'react-hook-form'
 import { SendDoneV2 } from './SendDoneV2'
+import { TransactionVersionIndicator } from '../_sharedWalletSend/TransactionVersionIndicator'
 
 export type SendDialogParams = {
   walletId: string
@@ -43,6 +44,7 @@ type Props = {
     handleSubmit: () => void
   }
   disabledMessage?: React.ReactNode
+  type: 'seed' | 'ledger'
 }
 
 export function SendFlowDialogV2({
@@ -57,6 +59,7 @@ export function SendFlowDialogV2({
   setStep,
   controls,
   disabledMessage,
+  type,
 }: Props) {
   return (
     <Dialog
@@ -74,7 +77,11 @@ export function SendFlowDialogV2({
       onSubmit={controls ? controls.handleSubmit : undefined}
       controls={
         controls?.form && (
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-3">
+            <Separator className="w-full" />
+            <div className="flex justify-center">
+              <TransactionVersionIndicator type={type} />
+            </div>
             {disabledMessage ? (
               <Button size="medium" onClick={() => onOpenChange(false)}>
                 Close


### PR DESCRIPTION
- The send dialogs now indicate the network and transaction version details.
  - Added for more visibility and easier future debugging.


![Screenshot 2025-02-14 at 2.46.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/22927e59-3f01-4880-a15f-6a57696a3c03.png)

![Screenshot 2025-02-14 at 2.46.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/1b66bdcc-8aa1-47de-8b70-ba7136300070.png)

