### PR TITLE
feat(react-core): add optional API parameter to useExchangeRates methods

### DIFF
--- a/.changeset/metal-rats-smile.md
+++ b/.changeset/metal-rats-smile.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Added optional API parameter for exchange rates.

--- a/libs/react-core/src/useExchangeRate.tsx
+++ b/libs/react-core/src/useExchangeRate.tsx
@@ -16,17 +16,19 @@ export function useSiascanExchangeRate({
   currency,
   config,
   disabled,
+  api = 'https://api.siascan.com',
 }: {
   currency?: CurrencyId
   config?: RequestConfig<void, number>
   disabled?: boolean
+  api?: string
 }) {
   const { settings, currencyOptions } = useAppSettings()
   const rate = useGetSwr<{ currency?: CurrencyId }, number>({
     params: {
       currency,
     },
-    api: 'https://api.siascan.com',
+    api,
     route: '/exchange-rate/siacoin/:currency',
     config: {
       ...config,
@@ -58,15 +60,18 @@ export function useSiascanExchangeRate({
 export function useActiveCurrencySiascanExchangeRate({
   config,
   disabled,
+  api,
 }: {
   config?: RequestConfig<void, number>
   disabled?: boolean
+  api?: string
 }) {
   const { settings } = useAppSettings()
   return useSiascanExchangeRate({
     currency: settings.currency.id,
     config,
     disabled,
+    api,
   })
 }
 


### PR DESCRIPTION
This is temporary. We'll eventually need to coordinate changing this over to explored, and then we can remove the parameter drilling.