### PR TITLE
refactor(explorer): use client side rendering for timestamps

### DIFF
--- a/.changeset/gentle-jobs-compare.md
+++ b/.changeset/gentle-jobs-compare.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Improved app performance/display around local timestamps.

--- a/apps/explorer/components/Contract/index.tsx
+++ b/apps/explorer/components/Contract/index.tsx
@@ -18,6 +18,7 @@ import { useActiveCurrencySiascanExchangeRate } from '@siafoundation/react-core'
 import { exploredApi } from '../../config'
 import { siacoinToFiat } from '../../lib/currency'
 import LoadingCurrency from '../LoadingCurrency'
+import LoadingTimestamp from '../LoadingTimestamp'
 
 type Props = {
   previousRevisions: ExplorerFileContract[] | undefined
@@ -91,11 +92,14 @@ export function Contract({
       {
         label: 'negotiation time',
         copyable: false,
-        value:
-          blockHeightToHumanDate(
-            currentHeight,
-            contract.confirmationIndex.height
-          ) || '-',
+        value: (
+          <LoadingTimestamp>
+            {blockHeightToHumanDate(
+              currentHeight,
+              contract.confirmationIndex.height
+            )}
+          </LoadingTimestamp>
+        ),
       },
       {
         label: 'expiration height',
@@ -105,8 +109,11 @@ export function Contract({
       {
         label: 'expiration time',
         copyable: false,
-        value:
-          blockHeightToHumanDate(currentHeight, contract.windowStart) || '-',
+        value: (
+          <LoadingTimestamp>
+            {blockHeightToHumanDate(currentHeight, contract.windowStart)}
+          </LoadingTimestamp>
+        ),
       },
       {
         label: 'proof height',
@@ -118,9 +125,13 @@ export function Contract({
       {
         label: 'proof time',
         copyable: false,
-        value: contract.proofIndex
-          ? blockHeightToHumanDate(currentHeight, contract.proofIndex.height)
-          : '-',
+        value: contract.proofIndex ? (
+          <LoadingTimestamp>
+            {blockHeightToHumanDate(currentHeight, contract.proofIndex.height)}
+          </LoadingTimestamp>
+        ) : (
+          '-'
+        ),
       },
       {
         label: 'proof deadline height',
@@ -130,7 +141,11 @@ export function Contract({
       {
         label: 'proof deadline time',
         copyable: false,
-        value: blockHeightToHumanDate(currentHeight, contract.windowEnd) || '-',
+        value: (
+          <LoadingTimestamp>
+            {blockHeightToHumanDate(currentHeight, contract.windowEnd)}
+          </LoadingTimestamp>
+        ),
       },
       {
         label: 'payout height',
@@ -140,11 +155,14 @@ export function Contract({
       {
         label: 'payout time',
         copyable: false,
-        value:
-          blockHeightToHumanDate(
-            currentHeight,
-            determinePayoutHeight(contract)
-          ) || '-',
+        value: (
+          <LoadingTimestamp>
+            {blockHeightToHumanDate(
+              currentHeight,
+              determinePayoutHeight(contract)
+            )}
+          </LoadingTimestamp>
+        ),
       },
       {
         label: 'revision number',

--- a/apps/explorer/components/LoadingTimestamp.tsx
+++ b/apps/explorer/components/LoadingTimestamp.tsx
@@ -1,0 +1,13 @@
+import { ClientSideOnly, Skeleton } from '@siafoundation/design-system'
+
+export default function LoadingTimestamp({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <ClientSideOnly fallback={<Skeleton className="w-[200px] h-[20px]" />}>
+      {children}
+    </ClientSideOnly>
+  )
+}

--- a/apps/explorer/components/Transaction/TransactionHeader.tsx
+++ b/apps/explorer/components/Transaction/TransactionHeader.tsx
@@ -2,6 +2,7 @@ import { Badge, Text, Tooltip } from '@siafoundation/design-system'
 import { humanDate } from '@siafoundation/units'
 import { routes } from '../../config/routes'
 import { EntityHeading } from '../EntityHeading'
+import LoadingTimestamp from '../LoadingTimestamp'
 
 export type TransactionHeaderData = {
   id: string
@@ -27,14 +28,16 @@ export function TransactionHeader({ title, transactionHeaderData }: Props) {
       />
       <div className="flex gap-4 items-center overflow-hidden">
         {!!timestamp && (
-          <Tooltip content={timestamp}>
-            <Text font="mono" color="subtle" ellipsis>
-              {humanDate(timestamp, {
-                dateStyle: 'medium',
-                timeStyle: 'short',
-              })}
-            </Text>
-          </Tooltip>
+          <LoadingTimestamp>
+            <Tooltip content={timestamp}>
+              <Text font="mono" color="subtle" ellipsis>
+                {humanDate(timestamp, {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}{' '}
+              </Text>
+            </Tooltip>
+          </LoadingTimestamp>
         )}
         {!!blockHeight && (
           <Badge variant="accent">

--- a/libs/design-system/src/components/BlockList.tsx
+++ b/libs/design-system/src/components/BlockList.tsx
@@ -7,6 +7,8 @@ import { formatDistance } from 'date-fns'
 import { EntityAvatar } from './EntityAvatar'
 import { cx } from 'class-variance-authority'
 import { EntityListSkeleton } from './EntityListSkeleton'
+import { ClientSideOnly } from './ClientSideOnly'
+import { Skeleton } from '../core/Skeleton'
 
 type BlockListItemProps = {
   miningPool?: string
@@ -99,9 +101,13 @@ export function BlockList({
                         : ''}
                     </Text>
                     <Text color="subtle">
-                      {formatDistance(new Date(block.timestamp), new Date(), {
-                        addSuffix: true,
-                      })}
+                      <ClientSideOnly
+                        fallback={<Skeleton className="w-[100px] h-[24px]" />}
+                      >
+                        {formatDistance(new Date(block.timestamp), new Date(), {
+                          addSuffix: true,
+                        })}
+                      </ClientSideOnly>
                     </Text>
                   </div>
                 </div>


### PR DESCRIPTION
This PR puts the result of `blockHeightToHumanDate` operations within the `explorer` totally on the client's side, using a ... `animate-pulse` fallback. As far as client is concerned, I expect them to barely experience this fallback given the speed of the operation (EDIT: looking at the live preview, this appears to be true. It's basically imperceptible.). We do also benefit visually here by not showing the server timestamp and then switching to the client's. However, the biggest gain is in local development under `strict mode`, as affected components were switching to client-side rendering. This should help us more accurately assess clients' loading experience in development, which I believe is a strong reason to take this approach.