### PR TITLE
fix(explorer): add top hosts cache revalidation on undefined or empty

### DIFF
--- a/.changeset/loud-emus-sin.md
+++ b/.changeset/loud-emus-sin.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Improved top host list redundancy.

--- a/apps/explorer/config/index.ts
+++ b/apps/explorer/config/index.ts
@@ -6,6 +6,7 @@ export const siteName = 'siascan.com'
 export const appName = 'siascan'
 export const appLink = webLinks.explore.mainnet
 export const isMainnet = true
+export const topHostsCacheTag = 'top-hosts'
 
 // APIs
 export const faucetApi = 'https://api.siascan.com/zen/faucet'


### PR DESCRIPTION
This addresses something I'm seeing live but I've also seen in local development. if `explored` is down or its `hosts` route fails, `undefined` or `[]` is cached, depending on what went wrong. Subsequent day-long cached returns are undefined/empty. In either case, we'll revalidate the cache, running the function within `unstable_cache` again, making our call and sorting again. This should keep us trying to build a good top hosts cache in the face of service interruptions.
