### PR TITLE
chore: eslint ignore .next-*

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 .next
+.next-*


### PR DESCRIPTION
- Ensures the new next directories introduced in #958 are not linted.