### PR TITLE
fix(walletd,types): fix signing v2 transactions

### DIFF
--- a/.changeset/flat-beds-hope.md
+++ b/.changeset/flat-beds-hope.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/types': patch
+---
+
+Unified V2 input types for signing

--- a/.changeset/flat-beds-hope.md
+++ b/.changeset/flat-beds-hope.md
@@ -2,4 +2,4 @@
 '@siafoundation/types': patch
 ---
 
-Unified V2 input types for signing
+Unified V2 input types for signing.

--- a/.changeset/slow-carpets-add.md
+++ b/.changeset/slow-carpets-add.md
@@ -1,0 +1,5 @@
+---
+'walletd': patch
+---
+
+Fixed V2 signing for wallets that do not have siafund outputs

--- a/.changeset/slow-carpets-add.md
+++ b/.changeset/slow-carpets-add.md
@@ -2,4 +2,4 @@
 'walletd': patch
 ---
 
-Fixed V2 signing for wallets that do not have siafund outputs
+Fixed V2 signing for wallets that do not have siafund outputs.

--- a/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV2/useSignAndBroadcastV2.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/WalletSendSeedDialogV2/useSignAndBroadcastV2.tsx
@@ -1,8 +1,6 @@
 import {
   useConsensusNetwork,
-  useWalletOutputsSiacoin,
   useConsensusTipState,
-  useWalletOutputsSiafund,
 } from '@siafoundation/walletd-react'
 import { useWallets } from '../../../contexts/wallets'
 import { useCallback } from 'react'
@@ -17,19 +15,6 @@ import { Result } from '@siafoundation/types'
 export function useSignAndBroadcastV2() {
   const { wallet, cacheWalletMnemonic } = useWallets()
   const walletId = wallet?.id
-
-  const siacoinOutputs = useWalletOutputsSiacoin({
-    disabled: !walletId,
-    params: {
-      id: walletId,
-    },
-  })
-  const siafundOutputs = useWalletOutputsSiafund({
-    disabled: !walletId,
-    params: {
-      id: walletId,
-    },
-  })
   const { dataset: addresses } = useWalletAddresses({ id: walletId })
   const cs = useConsensusTipState()
   const cn = useConsensusNetwork()
@@ -69,8 +54,6 @@ export function useSignAndBroadcastV2() {
         consensusState: cs.data,
         consensusNetwork: cn.data,
         addresses,
-        siacoinOutputs: siacoinOutputs.data?.outputs,
-        siafundOutputs: siafundOutputs.data?.outputs,
       })
 
       if ('error' in signingResult) {
@@ -95,8 +78,6 @@ export function useSignAndBroadcastV2() {
       walletId,
       cs.data,
       cn.data,
-      siacoinOutputs.data,
-      siafundOutputs.data,
       cacheWalletMnemonic,
       broadcast,
     ]

--- a/apps/walletd/lib/__snapshots__/signSeedV2.spec.ts.snap
+++ b/apps/walletd/lib/__snapshots__/signSeedV2.spec.ts.snap
@@ -31,7 +31,7 @@ Object {
             "type": "uc",
           },
           "signatures": Array [
-            "32104521d75f2155c893eb352beee47c42f25c1d28bd5648076f3873f0b30188271ccf903df206c47167be4bf331ab927930bda32413d2078bda29f34ee1dc01",
+            "331f4cc015c5829ef40f5036be9f020bf644cd9488d8590b3b19ec4fb5f76446e2c33f7218fe58c0b7cf5ee687d5c7a5382b48494d0a2f4d0ffcd49752e76f0a",
           ],
         },
       },

--- a/apps/walletd/lib/signSeedV2.spec.ts
+++ b/apps/walletd/lib/signSeedV2.spec.ts
@@ -16,8 +16,6 @@ describe('signSeedV2', () => {
         transaction: mocks.walletConstructV2Response.transaction,
         consensusState: mocks.consensusState,
         consensusNetwork: mocks.consensusNetwork,
-        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
-        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
         addresses: getMockAddresses(mocks),
       })
     ).toMatchSnapshot()
@@ -31,8 +29,6 @@ describe('signSeedV2', () => {
         transaction: mocks.walletConstructV2Response.transaction,
         consensusState: mocks.consensusState,
         consensusNetwork: mocks.consensusNetwork,
-        siacoinOutputs: [],
-        siafundOutputs: [],
         addresses: getMockAddresses(mocks),
       })
     ).toEqual({
@@ -48,8 +44,6 @@ describe('signSeedV2', () => {
         transaction: mocks.walletConstructV2Response.transaction,
         consensusState: mocks.consensusState,
         consensusNetwork: mocks.consensusNetwork,
-        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
-        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
         addresses: [
           {
             id: 'id',
@@ -74,8 +68,6 @@ describe('signSeedV2', () => {
         transaction: mocks.walletConstructV2Response.transaction,
         consensusState: mocks.consensusState,
         consensusNetwork: mocks.consensusNetwork,
-        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
-        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
         addresses: [
           {
             id: 'id',
@@ -102,8 +94,6 @@ describe('signSeedV2', () => {
         transaction: mocks.walletConstructV2Response.transaction,
         consensusState: mocks.consensusState,
         consensusNetwork: mocks.consensusNetwork,
-        siacoinOutputs: mocks.walletOutputsSiacoinResponse.outputs,
-        siafundOutputs: mocks.walletOutputsSiafundResponse.outputs,
         addresses,
       })
     ).toEqual({

--- a/apps/walletd/lib/signSeedV2.spec.ts
+++ b/apps/walletd/lib/signSeedV2.spec.ts
@@ -21,21 +21,6 @@ describe('signSeedV2', () => {
     ).toMatchSnapshot()
   })
 
-  it('errors when an utxo is missing', async () => {
-    const mocks = getMockScenarioSeedWallet()
-    expect(
-      signTransactionSeedV2({
-        mnemonic: mocks.mnemonic,
-        transaction: mocks.walletConstructV2Response.transaction,
-        consensusState: mocks.consensusState,
-        consensusNetwork: mocks.consensusNetwork,
-        addresses: getMockAddresses(mocks),
-      })
-    ).toEqual({
-      error: 'Missing utxo',
-    })
-  })
-
   it('errors when a public keys address is missing', async () => {
     const mocks = getMockScenarioSeedWallet()
     expect(
@@ -56,7 +41,7 @@ describe('signSeedV2', () => {
         ],
       })
     ).toEqual({
-      error: 'Missing address',
+      error: `Missing address ${mocks.walletConstructV2Response.transaction.siacoinInputs[0].parent.siacoinOutput.address}`,
     })
   })
 
@@ -73,31 +58,14 @@ describe('signSeedV2', () => {
             id: 'id',
             walletId: 'id',
             address:
-              mocks.walletOutputsSiacoinResponse.outputs[1].siacoinOutput
-                .address,
+              mocks.walletConstructV2Response.transaction.siacoinInputs[0]
+                .parent.siacoinOutput.address,
             metadata: {},
           },
         ],
       })
     ).toEqual({
       error: 'Missing address index',
-    })
-  })
-
-  it('errors when an address is missing its public key', async () => {
-    const mocks = getMockScenarioSeedWallet()
-    const addresses = getMockAddresses(mocks)
-    addresses[0].spendPolicy.policy.publicKeys[0] = undefined
-    expect(
-      signTransactionSeedV2({
-        mnemonic: mocks.mnemonic,
-        transaction: mocks.walletConstructV2Response.transaction,
-        consensusState: mocks.consensusState,
-        consensusNetwork: mocks.consensusNetwork,
-        addresses,
-      })
-    ).toEqual({
-      error: 'Missing address public key',
     })
   })
 })

--- a/apps/walletd/lib/signSeedV2.ts
+++ b/apps/walletd/lib/signSeedV2.ts
@@ -51,16 +51,6 @@ export function signTransactionSeedV2({
       return { error: indexResponse.error }
     }
     const { index } = indexResponse
-
-    const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
-      mnemonic,
-      indexResponse.index
-    )
-
-    if ('error' in pkResponse) {
-      return { error: pkResponse.error }
-    }
-
     const signResult = addSignaturesV2({
       mnemonic,
       input,
@@ -83,16 +73,6 @@ export function signTransactionSeedV2({
       return { error: indexResponse.error }
     }
     const { index } = indexResponse
-
-    const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
-      mnemonic,
-      indexResponse.index
-    )
-
-    if ('error' in pkResponse) {
-      return { error: pkResponse.error }
-    }
-
     const signResult = addSignaturesV2({
       mnemonic,
       input,

--- a/apps/walletd/lib/signV2.ts
+++ b/apps/walletd/lib/signV2.ts
@@ -1,7 +1,4 @@
-import {
-  Result,
-  V2TransactionInput,
-} from '@siafoundation/types'
+import { Result, V2TransactionInput } from '@siafoundation/types'
 import { AddressData } from '../contexts/addresses/types'
 import { getSDK } from '@siafoundation/sdk'
 
@@ -9,17 +6,14 @@ export function addSignaturesV2({
   mnemonic,
   input,
   sigHash,
-  index
-} : {
+  index,
+}: {
   mnemonic: string
   input: V2TransactionInput
   sigHash: string
   index: number
-}): Result<{ error?: string }> {  
-  const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
-    mnemonic,
-    index
-  )
+}): Result<{ error?: string }> {
+  const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(mnemonic, index)
 
   if ('error' in pkResponse) {
     return { error: pkResponse.error }
@@ -40,10 +34,10 @@ export function addSignaturesV2({
 export function getAddressKeyIndex({
   address,
   addresses,
-} : {
+}: {
   address: string
   addresses: AddressData[]
-}): Result<{ index: number, error?: string }> {
+}): Result<{ index: number; error?: string }> {
   const addressData = addresses.find((a) => a.address === address)
   if (!addressData) {
     return { error: `Missing address ${address}` }

--- a/apps/walletd/lib/signV2.ts
+++ b/apps/walletd/lib/signV2.ts
@@ -1,308 +1,56 @@
 import {
   Result,
-  SiacoinElement,
-  SiafundElement,
-  V2SiacoinInput,
-  V2SiafundInput,
-  V2Transaction,
+  V2TransactionInput,
 } from '@siafoundation/types'
 import { AddressData } from '../contexts/addresses/types'
 import { getSDK } from '@siafoundation/sdk'
 
-export function addSignaturesSiacoinV2({
+export function addSignaturesV2({
   mnemonic,
-  transaction,
-  addresses,
-  siacoinOutputs,
+  input,
   sigHash,
-}: {
+  index
+} : {
   mnemonic: string
-  transaction: V2Transaction
-  addresses: AddressData[]
-  siacoinOutputs: SiacoinElement[]
+  input: V2TransactionInput
   sigHash: string
-}): { error?: string } {
-  if (!addresses) {
-    return { error: 'No addresses' }
-  }
-  if (!siacoinOutputs) {
-    return { error: 'No outputs' }
-  }
+  index: number
+}): Result<{ error?: string }> {  
+  const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
+    mnemonic,
+    index
+  )
 
-  const scoIdsToSign =
-    transaction.siacoinInputs?.map((sci) => sci.parent.id) ?? []
-
-  // For each toSign ID, find the parent utxo funding element.
-  for (const outputId of scoIdsToSign) {
-    const meta = getToSignSiacoinMetadataV2({
-      outputId,
-      addresses,
-      siacoinOutputs,
-      transaction,
-    })
-
-    if ('error' in meta) {
-      return { error: meta.error }
-    }
-
-    if (
-      meta.siacoinUtxo &&
-      meta.address.metadata.index !== undefined &&
-      meta.address.spendPolicy
-    ) {
-      const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
-        mnemonic,
-        meta.address.metadata.index
-      )
-      if ('error' in pkResponse) {
-        return { error: pkResponse.error }
-      }
-      const signHashResponse = getSDK().wallet.signHash(
-        pkResponse.privateKey,
-        sigHash
-      )
-      if ('error' in signHashResponse) {
-        return { error: signHashResponse.error }
-      }
-      meta.siacoinInput.satisfiedPolicy.signatures = [
-        signHashResponse.signature,
-      ]
-    }
+  if ('error' in pkResponse) {
+    return { error: pkResponse.error }
   }
 
+  const signHashResponse = getSDK().wallet.signHash(
+    pkResponse.privateKey,
+    sigHash
+  )
+
+  if ('error' in signHashResponse) {
+    return { error: signHashResponse.error }
+  }
+  input.satisfiedPolicy.signatures = [signHashResponse.signature]
   return {}
 }
 
-export function addSignaturesSiafundV2({
-  mnemonic,
-  transaction,
+export function getAddressKeyIndex({
+  address,
   addresses,
-  siafundOutputs,
-  sigHash,
-}: {
-  mnemonic: string
-  transaction: V2Transaction
+} : {
+  address: string
   addresses: AddressData[]
-  siafundOutputs: SiafundElement[]
-  sigHash: string
-}): { error?: string } {
-  if (!addresses) {
-    return { error: 'No addresses' }
-  }
-  if (!siafundOutputs) {
-    return { error: 'No outputs' }
-  }
-
-  const sfoIdsToSign =
-    transaction.siafundInputs?.map((sfi) => sfi.parent.id) ?? []
-
-  // For each toSign ID, find the parent utxo funding element.
-  for (const outputId of sfoIdsToSign) {
-    const meta = getToSignSiafundMetadataV2({
-      outputId,
-      addresses,
-      siafundOutputs,
-      transaction,
-    })
-
-    if ('error' in meta) {
-      return { error: meta.error }
-    }
-
-    if (
-      meta.siafundUtxo &&
-      meta.address.metadata.index !== undefined &&
-      meta.address.spendPolicy
-    ) {
-      const pkResponse = getSDK().wallet.keyPairFromSeedPhrase(
-        mnemonic,
-        meta.address.metadata.index
-      )
-      if ('error' in pkResponse) {
-        return { error: pkResponse.error }
-      }
-      const signHashResponse = getSDK().wallet.signHash(
-        pkResponse.privateKey,
-        sigHash
-      )
-      if ('error' in signHashResponse) {
-        return { error: signHashResponse.error }
-      }
-      meta.siafundInput.satisfiedPolicy.signatures = [
-        signHashResponse.signature,
-      ]
-    }
-  }
-
-  return {}
-}
-
-function getSiacoinUtxoAndAddressV2({
-  scoId,
-  addresses,
-  siacoinOutputs,
-}: {
-  scoId: string
-  addresses: AddressData[]
-  siacoinOutputs: SiacoinElement[]
-}): Result<{ utxo: SiacoinElement; address: AddressData }> {
-  // find the utxo by toSign ID
-  const utxo = siacoinOutputs?.find((sco) => sco.id === scoId)
-  if (!utxo) {
-    return { error: 'Missing utxo' }
-  }
-
-  // Find the utxo's address metadata which has the index and public key saved.
-  // The public key was computed and saved when the address was generated.
-  const addressData = addresses?.find(
-    (a) => a.address === utxo.siacoinOutput.address
-  )
-
+}): Result<{ index: number, error?: string }> {
+  const addressData = addresses.find((a) => a.address === address)
   if (!addressData) {
-    return { error: 'Missing address' }
-  }
-  if (!addressData.metadata) {
+    return { error: `Missing address ${address}` }
+  } else if (!addressData.metadata) {
     return { error: 'Missing address metadata' }
-  }
-  if (addressData.metadata.index === undefined) {
+  } else if (addressData.metadata.index === undefined) {
     return { error: 'Missing address index' }
   }
-  if (!addressData.spendPolicy) {
-    return { error: 'Missing address spend policy' }
-  }
-  if (!addressData.spendPolicy.policy.publicKeys[0]) {
-    return { error: 'Missing address public key' }
-  }
-
-  return {
-    utxo,
-    address: addressData,
-  }
-}
-
-function getSiafundUtxoAndAddressV2({
-  sfoId,
-  addresses,
-  siafundOutputs,
-}: {
-  sfoId: string
-  addresses: AddressData[]
-  siafundOutputs: SiafundElement[]
-}): Result<{ utxo: SiafundElement; address: AddressData }> {
-  // find the utxo by toSign ID
-  const utxo = siafundOutputs?.find((sfo) => sfo.id === sfoId)
-  if (!utxo) {
-    return { error: 'Missing utxo' }
-  }
-
-  // find the utxo's address metadata which has the index and public key saved
-  // the public key was computed and saved when the address was generated
-  const addressData = addresses?.find(
-    (a) => a.address === utxo.siafundOutput.address
-  )
-
-  if (!addressData) {
-    return { error: 'Missing address' }
-  }
-  if (!addressData.metadata) {
-    return { error: 'Missing address metadata' }
-  }
-  if (addressData.metadata.index === undefined) {
-    return { error: 'Missing address index' }
-  }
-  if (!addressData.spendPolicy) {
-    return { error: 'Missing address spend policy' }
-  }
-  if (!addressData.spendPolicy.policy.publicKeys[0]) {
-    return { error: 'Missing address public key' }
-  }
-
-  return {
-    utxo,
-    address: addressData,
-  }
-}
-
-function getToSignSiacoinMetadataV2({
-  outputId,
-  transaction,
-  addresses,
-  siacoinOutputs,
-}: {
-  outputId: string
-  transaction: V2Transaction
-  addresses: AddressData[]
-  siacoinOutputs: SiacoinElement[]
-}): Result<{
-  address: AddressData
-  siacoinUtxo: SiacoinElement
-  siacoinInput: V2SiacoinInput
-}> {
-  // Find the parent utxo funding element for each input.
-  const scUtxoAddr = getSiacoinUtxoAndAddressV2({
-    scoId: outputId,
-    addresses,
-    siacoinOutputs,
-  })
-
-  if ('error' in scUtxoAddr) {
-    return { error: scUtxoAddr.error }
-  }
-
-  // Find the siacoin input by matching the toSign ID to the siacoin input's parent ID.
-  const sci = transaction.siacoinInputs?.find(
-    (sci) => sci.parent.id === scUtxoAddr.utxo.id
-  )
-
-  if (!sci) {
-    return { error: 'Missing input' }
-  }
-
-  return {
-    address: scUtxoAddr.address,
-    siacoinUtxo: scUtxoAddr.utxo,
-    siacoinInput: sci,
-  }
-}
-
-function getToSignSiafundMetadataV2({
-  outputId,
-  transaction,
-  addresses,
-  siafundOutputs,
-}: {
-  outputId: string
-  transaction: V2Transaction
-  addresses: AddressData[]
-  siafundOutputs: SiafundElement[]
-}): Result<{
-  address: AddressData
-  siafundUtxo: SiafundElement
-  siafundInput: V2SiafundInput
-}> {
-  // Find the parent utxo funding element for each input.
-  const sfUtxoAddr = getSiafundUtxoAndAddressV2({
-    sfoId: outputId,
-    addresses,
-    siafundOutputs,
-  })
-
-  if ('error' in sfUtxoAddr) {
-    return { error: sfUtxoAddr.error }
-  }
-
-  // Find the siafund input by matching the toSign ID to the siafund input's parent ID.
-  const sfi = transaction.siafundInputs?.find(
-    (sfi) => sfi.parent.id === sfUtxoAddr.utxo.id
-  )
-
-  if (!sfi) {
-    return { error: 'Missing input' }
-  }
-
-  return {
-    address: sfUtxoAddr.address,
-    siafundUtxo: sfUtxoAddr.utxo,
-    siafundInput: sfi,
-  }
+  return { index: addressData.metadata.index }
 }

--- a/libs/clusterd/src/index.ts
+++ b/libs/clusterd/src/index.ts
@@ -50,7 +50,7 @@ const maxTimeWaitingForAllNodesToStartup = 100_000
 const maxTimeWaitingForContractsToForm = 60_000
 
 const randomAddress =
-  '3af8e2a77c4b666dfc3cf7f68dfabaf61fa9d7707cbcd4308a5b75b63a9452e3edc505af3c79'
+  '0373a398eae5a7a682ff516d44cf122613c45aae75eac98fc094e3a5979d496088e656bcf925'
 
 export async function setupCluster({
   renterdCount = 0,

--- a/libs/types/src/v2.ts
+++ b/libs/types/src/v2.ts
@@ -24,6 +24,10 @@ export type V2SiacoinInput = {
   satisfiedPolicy: SatisfiedPolicy
 }
 
+export interface V2TransactionInput {
+  satisfiedPolicy: SatisfiedPolicy
+}
+
 export type V2SiafundInput = {
   parent: SiafundElement
   claimAddress: Address


### PR DESCRIPTION
When signing a V2 transaction if the wallet does not have any Siafund inputs, "No outputs" is returned. This simplifies the signing logic by using the metadata already on the input instead of fetching the list of inputs from the wallet first.