### PR TITLE
feat(explorer): add v2 host type support

### DIFF
--- a/.changeset/brown-news-draw.md
+++ b/.changeset/brown-news-draw.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added support for v2 Hosts.

--- a/apps/explorer/app/host/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/host/[id]/opengraph-image.tsx
@@ -8,6 +8,7 @@ import { truncate } from '@siafoundation/design-system'
 import { CurrencyOption, currencyOptions } from '@siafoundation/react-core'
 import { to } from '@siafoundation/request'
 import { getExplored } from '../../../lib/explored'
+import { getHostNetAddress } from '../../../lib/hostType'
 
 export const revalidate = 0
 
@@ -52,11 +53,11 @@ export default async function Image({ params }) {
     )
   }
 
-  if (!host.settings) {
+  if (host.v2 ? !host.rhpV4Settings : !host.settings) {
     return getOGImage(
       {
         id: host.publicKey,
-        title: host.netAddress,
+        title: getHostNetAddress(host),
         subtitle: truncate(host.publicKey, 30),
         initials: 'H',
         avatar: true,
@@ -69,7 +70,9 @@ export default async function Image({ params }) {
     {
       label: 'storage',
       value: getStorageCost({
-        price: host.settings.storageprice,
+        price: host.v2
+          ? host.rhpV4Settings.prices.storagePrice
+          : host.settings.storageprice,
         exchange: {
           currency,
           rate: rate.toString(),
@@ -79,7 +82,9 @@ export default async function Image({ params }) {
     {
       label: 'download',
       value: getDownloadCost({
-        price: host.settings.downloadbandwidthprice,
+        price: host.v2
+          ? host.rhpV4Settings.prices.egressPrice
+          : host.settings.downloadbandwidthprice,
         exchange: {
           currency,
           rate: rate.toString(),
@@ -89,7 +94,9 @@ export default async function Image({ params }) {
     {
       label: 'upload',
       value: getUploadCost({
-        price: host.settings.uploadbandwidthprice,
+        price: host.v2
+          ? host.rhpV4Settings.prices.ingressPrice
+          : host.settings.uploadbandwidthprice,
         exchange: {
           currency,
           rate: rate.toString(),
@@ -101,7 +108,7 @@ export default async function Image({ params }) {
   return getOGImage(
     {
       id: host.publicKey,
-      title: host.netAddress,
+      title: getHostNetAddress(host),
       subtitle: truncate(host.publicKey, 30),
       initials: 'H',
       avatar: true,

--- a/apps/explorer/components/Home/HostListItem.tsx
+++ b/apps/explorer/components/Home/HostListItem.tsx
@@ -26,6 +26,7 @@ import { ExplorerHost } from '@siafoundation/explored-types'
 import BigNumber from 'bignumber.js'
 import { CurrencyOption, SWRError } from '@siafoundation/react-core'
 import LoadingCurrency from '../LoadingCurrency'
+import { getHostNetAddress } from '../../lib/hostType'
 
 type Props = {
   host: ExplorerHost
@@ -44,7 +45,9 @@ export function HostListItem({ host, exchange, entity }: Props) {
     () =>
       exchange.currency && exchange.rate ? (
         getStorageCost({
-          price: host.settings.storageprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.storagePrice
+            : host.settings.storageprice,
           exchange: {
             currency: { prefix: exchange.currency.prefix },
             rate: exchange.rate.toString(),
@@ -60,7 +63,9 @@ export function HostListItem({ host, exchange, entity }: Props) {
     () =>
       exchange.currency && exchange.rate ? (
         getDownloadCost({
-          price: host.settings.downloadbandwidthprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.egressPrice
+            : host.settings.downloadbandwidthprice,
           exchange: {
             currency: { prefix: exchange.currency.prefix },
             rate: exchange.rate.toString(),
@@ -76,7 +81,9 @@ export function HostListItem({ host, exchange, entity }: Props) {
     () =>
       exchange.currency && exchange.rate ? (
         getUploadCost({
-          price: host.settings.uploadbandwidthprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.ingressPrice
+            : host.settings.uploadbandwidthprice,
           exchange: {
             currency: { prefix: exchange.currency.prefix },
             rate: exchange.rate.toString(),
@@ -89,7 +96,14 @@ export function HostListItem({ host, exchange, entity }: Props) {
   )
 
   const remainingStorage = useMemo(
-    () => (host.settings ? humanBytes(host.settings.remainingstorage) : '-'),
+    () =>
+      (host.v2 ? host.rhpV4Settings : host.settings)
+        ? humanBytes(
+            host.v2
+              ? host.rhpV4Settings.remainingStorage
+              : host.settings.remainingstorage
+          )
+        : '-',
     [host]
   )
 
@@ -106,7 +120,7 @@ export function HostListItem({ host, exchange, entity }: Props) {
               weight="medium"
               underline="none"
             >
-              {host.netAddress}
+              {getHostNetAddress(host)}
             </Link>
           </div>
           <div className="flex-1" />

--- a/apps/explorer/components/Home/index.tsx
+++ b/apps/explorer/components/Home/index.tsx
@@ -28,6 +28,7 @@ import { Information20 } from '@siafoundation/react-icons'
 import { useActiveCurrencySiascanExchangeRate } from '@siafoundation/react-core'
 import LoadingCurrency from '../LoadingCurrency'
 import { useExploredAddress } from '../../hooks/useExploredAddress'
+import { getHostNetAddress } from '../../lib/hostType'
 
 export function Home({
   metrics,
@@ -264,14 +265,14 @@ export function Home({
             }
           >
             {hosts
-              .filter((host) => host.settings)
+              .filter((host) => (host.v2 ? host.rhpV4Settings : host.settings))
               .map((host) => (
                 <HostListItem
                   key={host.publicKey}
                   host={host}
                   exchange={exchange}
                   entity={{
-                    label: host.netAddress,
+                    label: getHostNetAddress(host),
                     initials: 'H',
                     avatar: hashToAvatar(host.publicKey),
                     href: routes.host.view.replace(':id', host.publicKey),

--- a/apps/explorer/components/Host/HostHeader.tsx
+++ b/apps/explorer/components/Host/HostHeader.tsx
@@ -3,6 +3,7 @@ import { ExplorerHost } from '@siafoundation/explored-types'
 import { hashToAvatar } from '../../lib/avatar'
 import { HostPricing } from './HostPricing'
 import { HostInfo } from './HostInfo'
+import { getHostSettings } from '../../lib/hostType'
 
 type Props = {
   host: ExplorerHost
@@ -26,7 +27,7 @@ export function HostHeader({ host }: Props) {
         />
         <div className="flex flex-wrap gap-3 items-start justify-between w-full">
           <HostInfo host={host} />
-          {host.settings && <HostPricing host={host} />}
+          {getHostSettings(host) && <HostPricing host={host} />}
         </div>
       </div>
     </div>

--- a/apps/explorer/components/Host/HostInfo.tsx
+++ b/apps/explorer/components/Host/HostInfo.tsx
@@ -13,6 +13,7 @@ import {
   WarningFilled16,
 } from '@siafoundation/react-icons'
 import { humanDate } from '@siafoundation/units'
+import { getHostNetAddress } from '../../lib/hostType'
 import { formatDistance } from 'date-fns'
 
 type Props = {
@@ -29,7 +30,7 @@ export function HostInfo({ host }: Props) {
       <ValueCopyable
         size="20"
         weight="semibold"
-        value={host.netAddress}
+        value={getHostNetAddress(host)}
         label="network address"
         maxLength={50}
       />
@@ -67,25 +68,39 @@ export function HostInfo({ host }: Props) {
             </Text>
           </Text>
         </Tooltip>
-        {host.settings && (
+        {(host.v2 ? host.rhpV4Settings : host.settings) && (
           <Tooltip
             content={
-              host.settings.acceptingcontracts
+              host.v2
+                ? host.rhpV4Settings.acceptingContracts
+                : host.settings.acceptingcontracts
                 ? 'Host is accepting contracts'
                 : 'Host is not accepting contracts'
             }
           >
             <Text
               size="14"
-              color={host.settings.acceptingcontracts ? 'green' : 'subtle'}
+              color={
+                (
+                  host.v2
+                    ? host.rhpV4Settings.acceptingContracts
+                    : host.settings.acceptingcontracts
+                )
+                  ? 'green'
+                  : 'subtle'
+              }
               className="flex gap-1 items-center"
             >
-              {host.settings.acceptingcontracts ? (
+              {host.v2 ? (
+                host.rhpV4Settings.acceptingContracts
+              ) : host.settings.acceptingcontracts ? (
                 <CheckmarkFilled16 />
               ) : (
                 <WarningFilled16 />
               )}
-              {host.settings.acceptingcontracts
+              {host.v2
+                ? host.rhpV4Settings.acceptingContracts
+                : host.settings.acceptingcontracts
                 ? 'Accepting contracts'
                 : 'Not accepting contracts'}
             </Text>
@@ -93,14 +108,23 @@ export function HostInfo({ host }: Props) {
         )}
       </div>
       <div className="flex flex-wrap gap-x-2 gap-y-1 items-center">
-        {host.settings.version.length ? (
+        {host.v2 ? (
+          <Tooltip
+            content={`Host version ${host.rhpV4Settings.protocolVersion}`}
+          >
+            <Text size="14" color="subtle" className="flex gap-1 items-center">
+              <Fork16 />
+              {host.rhpV4Settings.protocolVersion}
+            </Text>
+          </Tooltip>
+        ) : (
           <Tooltip content={`Host version ${host.settings.version}`}>
             <Text size="14" color="subtle" className="flex gap-1 items-center">
               <Fork16 />
               {host.settings.version}
             </Text>
           </Tooltip>
-        ) : null}
+        )}
         {host.location.countryCode.length ? (
           <Tooltip content={`Host located in ${host.location.countryCode}`}>
             <div className="flex gap-1 items-center">

--- a/apps/explorer/components/Host/HostPricing.tsx
+++ b/apps/explorer/components/Host/HostPricing.tsx
@@ -35,7 +35,9 @@ export function HostPricing({ host }: Props) {
     () =>
       exchange.currency && exchange.rate ? (
         getStorageCost({
-          price: host.settings.storageprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.storagePrice
+            : host.settings.storageprice,
           exchange: {
             currency: { prefix: exchange.currency.prefix },
             rate: exchange.rate.toString(),
@@ -51,7 +53,9 @@ export function HostPricing({ host }: Props) {
     () =>
       exchange.currency && exchange.rate ? (
         getDownloadCost({
-          price: host.settings.downloadbandwidthprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.egressPrice
+            : host.settings.downloadbandwidthprice,
           exchange: {
             currency: { prefix: exchange.currency.prefix },
             rate: exchange.rate.toString(),
@@ -67,7 +71,9 @@ export function HostPricing({ host }: Props) {
     () =>
       exchange.currency && exchange.rate ? (
         getUploadCost({
-          price: host.settings.uploadbandwidthprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.ingressPrice
+            : host.settings.uploadbandwidthprice,
           exchange: {
             currency: { prefix: exchange.currency.prefix },
             rate: exchange.rate.toString(),

--- a/apps/explorer/components/Host/HostSettings.tsx
+++ b/apps/explorer/components/Host/HostSettings.tsx
@@ -19,6 +19,7 @@ import { useActiveCurrencySiascanExchangeRate } from '@siafoundation/react-core'
 import LoadingCurrency from '../LoadingCurrency'
 import { siacoinToFiat } from '../../lib/currency'
 import { useExploredAddress } from '../../hooks/useExploredAddress'
+import { getHostNetAddress } from '../../lib/hostType'
 
 type Props = {
   host: ExplorerHost
@@ -39,12 +40,18 @@ export function HostSettings({ host }: Props) {
       {
         label: 'total storage',
         copyable: false,
-        value: humanBytes(host.settings.totalstorage),
+        value: humanBytes(
+          host.v2 ? host.rhpV4Settings.totalStorage : host.settings.totalstorage
+        ),
       },
       {
         label: 'remaining storage',
         copyable: false,
-        value: humanBytes(host.settings.remainingstorage),
+        value: humanBytes(
+          host.v2
+            ? host.rhpV4Settings.remainingStorage
+            : host.settings.remainingstorage
+        ),
       },
       {
         label: 'storage price',
@@ -52,7 +59,9 @@ export function HostSettings({ host }: Props) {
         value:
           exchange.currency && exchange.rate ? (
             `${getStorageCost({
-              price: host.settings.storageprice,
+              price: host.v2
+                ? host.rhpV4Settings.prices.storagePrice
+                : host.settings.storageprice,
               exchange: {
                 currency: { prefix: exchange.currency.prefix },
                 rate: exchange.rate.toString(),
@@ -62,7 +71,9 @@ export function HostSettings({ host }: Props) {
             <LoadingCurrency type="perTBMonth" />
           ),
         comment: `${getStorageCost({
-          price: host.settings.storageprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.storagePrice
+            : host.settings.storageprice,
         })}/month`,
       },
       {
@@ -71,7 +82,9 @@ export function HostSettings({ host }: Props) {
         value:
           exchange.currency && exchange.rate ? (
             getDownloadCost({
-              price: host.settings.downloadbandwidthprice,
+              price: host.v2
+                ? host.rhpV4Settings.prices.egressPrice
+                : host.settings.downloadbandwidthprice,
               exchange: {
                 currency: { prefix: exchange.currency.prefix },
                 rate: exchange.rate.toString(),
@@ -81,7 +94,9 @@ export function HostSettings({ host }: Props) {
             <LoadingCurrency type="perTB" />
           ),
         comment: getDownloadCost({
-          price: host.settings.downloadbandwidthprice,
+          price: host.v2
+            ? host.rhpV4Settings.prices.egressPrice
+            : host.settings.downloadbandwidthprice,
         }),
       },
       {
@@ -90,7 +105,9 @@ export function HostSettings({ host }: Props) {
         value:
           exchange.currency && exchange.rate ? (
             getUploadCost({
-              price: host.settings.uploadbandwidthprice,
+              price: host.v2
+                ? host.rhpV4Settings.prices.ingressPrice
+                : host.settings.uploadbandwidthprice,
               exchange: {
                 currency: { prefix: exchange.currency.prefix },
                 rate: exchange.rate.toString(),
@@ -99,7 +116,11 @@ export function HostSettings({ host }: Props) {
           ) : (
             <LoadingCurrency type="perTB" />
           ),
-        comment: getUploadCost({ price: host.settings.uploadbandwidthprice }),
+        comment: getUploadCost({
+          price: host.v2
+            ? host.rhpV4Settings.prices.ingressPrice
+            : host.settings.uploadbandwidthprice,
+        }),
       },
       {
         label: 'collateral',
@@ -107,7 +128,9 @@ export function HostSettings({ host }: Props) {
         value:
           exchange.currency && exchange.rate ? (
             getStorageCost({
-              price: host.settings.collateral,
+              price: host.v2
+                ? host.rhpV4Settings.prices.collateral
+                : host.settings.collateral,
               exchange: {
                 currency: { prefix: exchange.currency.prefix },
                 rate: exchange.rate.toString(),
@@ -116,37 +139,59 @@ export function HostSettings({ host }: Props) {
           ) : (
             <LoadingCurrency type="perTB" />
           ),
-        comment: getStorageCost({ price: host.settings.collateral }),
+        comment: getStorageCost({
+          price: host.v2
+            ? host.rhpV4Settings.prices.collateral
+            : host.settings.collateral,
+        }),
       },
       {
         label: 'max collateral',
         copyable: false,
         value:
           exchange.currency && exchange.rate ? (
-            siacoinToFiat(host.settings.maxcollateral, {
-              rate: exchange.rate,
-              currency: exchange.currency,
-            })
+            siacoinToFiat(
+              host.v2
+                ? host.rhpV4Settings.maxCollateral
+                : host.settings.maxcollateral,
+              {
+                rate: exchange.rate,
+                currency: exchange.currency,
+              }
+            )
           ) : (
             <LoadingCurrency />
           ),
-        comment: humanSiacoin(host.settings.maxcollateral),
+        comment: humanSiacoin(
+          host.v2
+            ? host.rhpV4Settings.maxCollateral
+            : host.settings.maxcollateral
+        ),
       },
       {
         label: 'contract price',
         copyable: false,
         value:
           exchange.currency && exchange.rate ? (
-            siacoinToFiat(host.settings.contractprice, {
-              rate: exchange.rate,
-              currency: exchange.currency,
-            })
+            siacoinToFiat(
+              host.v2
+                ? host.rhpV4Settings.prices.contractPrice
+                : host.settings.contractprice,
+              {
+                rate: exchange.rate,
+                currency: exchange.currency,
+              }
+            )
           ) : (
             <LoadingCurrency />
           ),
-        comment: humanSiacoin(host.settings.contractprice),
+        comment: humanSiacoin(
+          host.v2
+            ? host.rhpV4Settings.prices.contractPrice
+            : host.settings.contractprice
+        ),
       },
-      {
+      !host.v2 && {
         label: 'base RPC price',
         copyable: false,
         value:
@@ -164,7 +209,7 @@ export function HostSettings({ host }: Props) {
           1e6
         )} SC/million`,
       },
-      {
+      !host.v2 && {
         label: 'sector access price',
         copyable: false,
         value:
@@ -182,7 +227,7 @@ export function HostSettings({ host }: Props) {
           1e6
         )} SC/million`,
       },
-      {
+      !host.v2 && {
         label: 'ephemeral account expiry',
         copyable: false,
         value: host.settings.ephemeralaccountexpiry,
@@ -191,19 +236,27 @@ export function HostSettings({ host }: Props) {
         label: 'max duration',
         copyable: false,
         value: `${toFixedOrPrecision(
-          blocksToMonths(host.settings.maxduration),
+          blocksToMonths(
+            host.v2
+              ? host.rhpV4Settings.maxContractDuration
+              : host.settings.maxduration
+          ),
           {
             digits: 2,
           }
         )} months`,
-        comment: `${host.settings.maxduration} blocks`,
+        comment: `${
+          host.v2
+            ? host.rhpV4Settings.maxContractDuration
+            : host.settings.maxduration
+        } blocks`,
       },
-      {
+      !host.v2 && {
         label: 'max ephemeral account balance',
         copyable: false,
         sc: new BigNumber(host.settings.maxephemeralaccountbalance),
       },
-      {
+      !host.v2 && {
         label: 'sector size',
         copyable: false,
         value: humanBytes(host.settings.sectorsize),
@@ -211,9 +264,9 @@ export function HostSettings({ host }: Props) {
       {
         label: 'sia mux port',
         copyable: false,
-        value: host.settings.siamuxport,
+        value: getHostNetAddress(host).slice(-4),
       },
-      {
+      !host.v2 && {
         label: 'window size',
         copyable: false,
         value: `${toFixedOrPrecision(blocksToDays(host.settings.windowsize), {
@@ -229,9 +282,9 @@ export function HostSettings({ host }: Props) {
       <div className="flex flex-col">
         {!!priceTableValues?.length && (
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-20 gap-y-4">
-            {priceTableValues.map((item) => (
-              <ExplorerDatum key={item.label} {...item} />
-            ))}
+            {priceTableValues.map(
+              (item) => item && <ExplorerDatum key={item.label} {...item} />
+            )}
           </div>
         )}
       </div>

--- a/apps/explorer/components/Host/index.tsx
+++ b/apps/explorer/components/Host/index.tsx
@@ -4,6 +4,7 @@ import { HostHeader } from './HostHeader'
 import { HostSettings } from './HostSettings'
 import { Panel, Text } from '@siafoundation/design-system'
 import { formatDistance } from 'date-fns'
+import { getHostSettings } from '../../lib/hostType'
 
 type Props = {
   host: ExplorerHost
@@ -12,7 +13,7 @@ type Props = {
 export function Host({ host }: Props) {
   return (
     <ContentLayout heading={<HostHeader host={host} />}>
-      {host.settings ? (
+      {getHostSettings(host) ? (
         <HostSettings host={host} />
       ) : (
         <Panel className="p-4 flex items-center">

--- a/apps/explorer/lib/hostType.ts
+++ b/apps/explorer/lib/hostType.ts
@@ -1,0 +1,20 @@
+import { ExplorerHost } from '@siafoundation/explored-types'
+
+export function getHostSettings(host: ExplorerHost) {
+  return host.v2 ? host.rhpV4Settings : host.settings
+}
+
+export function getHostNetAddress(host: ExplorerHost) {
+  let netAddress: string | undefined
+
+  if (host.v2) {
+    netAddress = host.v2NetAddresses.find(
+      (address) => address.protocol === 'siamux'
+    )?.address
+  } else {
+    netAddress = host.settings.netaddress
+  }
+
+  if (!netAddress) throw new Error('netAddress undefined in getHostNetAddress')
+  return netAddress
+}

--- a/apps/explorer/lib/hosts.ts
+++ b/apps/explorer/lib/hosts.ts
@@ -49,28 +49,39 @@ function rankHosts(hosts: ExplorerHost[] | undefined) {
           ) +
         weights.downloadPrice *
           normalize(
-            host.settings.downloadbandwidthprice,
+            host.v2
+              ? host.rhpV4Settings.prices.egressPrice
+              : host.settings.downloadbandwidthprice,
             ranges.downloadPrice.min,
             ranges.downloadPrice.max,
             true
           ) +
         weights.uploadPrice *
           normalize(
-            host.settings.uploadbandwidthprice,
+            host.v2
+              ? host.rhpV4Settings.prices.ingressPrice
+              : host.settings.uploadbandwidthprice,
             ranges.uploadPrice.min,
             ranges.uploadPrice.max,
             true
           ) +
         weights.storagePrice *
           normalize(
-            host.settings.storageprice,
+            host.v2
+              ? host.rhpV4Settings.prices.storagePrice
+              : host.settings.storageprice,
             ranges.storagePrice.min,
             ranges.storagePrice.max,
             true
           ) +
         weights.usedStorage *
           normalize(
-            host.settings.totalstorage - host.settings.remainingstorage,
+            (host.v2
+              ? host.rhpV4Settings.totalStorage
+              : host.settings.totalstorage) -
+              (host.v2
+                ? host.rhpV4Settings.remainingStorage
+                : host.settings.remainingstorage),
             ranges.usedStorage.min,
             ranges.usedStorage.max
           ),

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -11,7 +11,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "types": ["jest", "node"],
+    "types": [
+      "jest",
+      "node"
+    ],
     "plugins": [
       {
         "name": "next"
@@ -27,7 +30,11 @@
     "next-env.d.ts",
     ".next/types/**/*.ts",
     ".next-development/types/**/*.ts",
-    ".next-development-testnet-zen/types/**/*.ts"
+    ".next-development-testnet-zen/types/**/*.ts",
+    "../../dist/apps/explorer/.next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "jest.config.ts"]
+  "exclude": [
+    "node_modules",
+    "jest.config.ts"
+  ]
 }

--- a/libs/explored-types/src/types.ts
+++ b/libs/explored-types/src/types.ts
@@ -390,6 +390,5 @@ export type ExplorerV2Host = {
   successfulInteractions: number
   failedInteractions: number
 
-  //
   rhpV4Settings: V2HostSettings
 }


### PR DESCRIPTION
This adds support for the v2 Host type in the explorer and closes #971.

There are two sharper edges here I see worth discussing, of the same ilk:

* Down stack, in the types update, we are going with a different typing strategy than `explored`--instead of being additive to `ExplorerHost`, we break this out into two types. One for v1 and one for v2, discriminating on `v2: boolean`.
* We also add a lot of `host.v2 ? ...` logic across the host slice of the explorer. I don't think this would be avoided by using one additive type. We'd instead be checking for `settings`, `priceTable`, and `rhpV4Settings` all the same. I've created some helpers around getting the netAddress and the settings as they pertain to checking whether they exist (is this a legacy assumption? It doesn't match the `explored` types for either one--that `settings` wouldn't exist).

One final note: the tests downstack from this PR will probably fail, and that's because the zen allow height has passed and we're seeing the underlying data change. This will probably mean we need to take this PRs tests as final truth.