### PR TITLE
chore(explorer-e2e): e2e target should build dependencies

### DIFF
--- a/apps/explorer-e2e/project.json
+++ b/apps/explorer-e2e/project.json
@@ -24,7 +24,7 @@
     "e2e": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/explorer-e2e"],
-      "dependsOn": ["build-cluster"],
+      "dependsOn": ["^build", "build-cluster"],
       "options": {
         "config": "apps/explorer-e2e/playwright.config.ts"
       }

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -11,7 +11,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "types": ["jest", "node"],
+    "types": [
+      "jest",
+      "node"
+    ],
     "plugins": [
       {
         "name": "next"
@@ -27,7 +30,11 @@
     "next-env.d.ts",
     ".next/types/**/*.ts",
     ".next-development/types/**/*.ts",
-    ".next-development-testnet-zen/types/**/*.ts"
+    ".next-development-testnet-zen/types/**/*.ts",
+    "../../dist/apps/explorer/.next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "jest.config.ts"]
+  "exclude": [
+    "node_modules",
+    "jest.config.ts"
+  ]
 }


### PR DESCRIPTION
- Add missing build dependencies. This will ensure all libraries used in explorer-e2e are automatically built before the e2e target runs.
