### PR TITLE
refactor(explorer): rely on successfulInteractions for unscanned hosts

### DIFF
--- a/.changeset/mighty-lamps-occur.md
+++ b/.changeset/mighty-lamps-occur.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Improved unscanned host detection.

--- a/apps/explorer/components/Host/HostHeader.tsx
+++ b/apps/explorer/components/Host/HostHeader.tsx
@@ -3,7 +3,6 @@ import { ExplorerHost } from '@siafoundation/explored-types'
 import { hashToAvatar } from '../../lib/avatar'
 import { HostPricing } from './HostPricing'
 import { HostInfo } from './HostInfo'
-import { getHostSettings } from '../../lib/hostType'
 
 type Props = {
   host: ExplorerHost
@@ -27,7 +26,7 @@ export function HostHeader({ host }: Props) {
         />
         <div className="flex flex-wrap gap-3 items-start justify-between w-full">
           <HostInfo host={host} />
-          {getHostSettings(host) && <HostPricing host={host} />}
+          {host.successfulInteractions > 0 && <HostPricing host={host} />}
         </div>
       </div>
     </div>

--- a/apps/explorer/components/Host/index.tsx
+++ b/apps/explorer/components/Host/index.tsx
@@ -4,7 +4,6 @@ import { HostHeader } from './HostHeader'
 import { HostSettings } from './HostSettings'
 import { Panel, Text } from '@siafoundation/design-system'
 import { formatDistance } from 'date-fns'
-import { getHostSettings } from '../../lib/hostType'
 
 type Props = {
   host: ExplorerHost
@@ -13,7 +12,7 @@ type Props = {
 export function Host({ host }: Props) {
   return (
     <ContentLayout heading={<HostHeader host={host} />}>
-      {getHostSettings(host) ? (
+      {host.successfulInteractions > 0 ? (
         <HostSettings host={host} />
       ) : (
         <Panel className="p-4 flex items-center">

--- a/apps/explorer/lib/hostType.ts
+++ b/apps/explorer/lib/hostType.ts
@@ -1,9 +1,5 @@
 import { ExplorerHost } from '@siafoundation/explored-types'
 
-export function getHostSettings(host: ExplorerHost) {
-  return host.v2 ? host.rhpV4Settings : host.settings
-}
-
 export function getHostNetAddress(host: ExplorerHost) {
   let netAddress: string | undefined
 


### PR DESCRIPTION
We were carrying over a legacy Sia Central assumption here around the existence of  `host.settings`. With explored, we should instead rely on `host.successfulInteractions`.