### PR TITLE
fix(hostd): issue with events v2ContractResolution type

### DIFF
--- a/.changeset/fifty-carrots-pay.md
+++ b/.changeset/fifty-carrots-pay.md
@@ -1,0 +1,7 @@
+---
+'hostd': patch
+'renterd': patch
+'walletd': patch
+---
+
+Fixed an issue where a v2ContractResolution event in the wallet would crash the app. Closes https://github.com/SiaFoundation/hostd/issues/629

--- a/.changeset/grumpy-jars-tell.md
+++ b/.changeset/grumpy-jars-tell.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/types': patch
+---
+
+Removed parent from the data field of WalletEventContractResolutionV2.

--- a/libs/types/src/events.ts
+++ b/libs/types/src/events.ts
@@ -7,11 +7,7 @@ import {
   Hash256,
   Address,
 } from './core'
-import {
-  V2Transaction,
-  V2FileContractResolutionType,
-  V2FileContractElement,
-} from './v2'
+import { V2Transaction, V2FileContractResolutionType } from './v2'
 
 export type UnconfirmedChainIndex = {
   height: number
@@ -51,7 +47,6 @@ export type WalletEventContractResolutionV1 = WalletEventBase & {
 export type WalletEventContractResolutionV2 = WalletEventBase & {
   type: 'v2ContractResolution'
   data: {
-    parent: V2FileContractElement
     resolution: V2FileContractResolutionType
     siacoinElement: SiacoinElement
     missed: boolean

--- a/libs/units/src/events.ts
+++ b/libs/units/src/events.ts
@@ -20,7 +20,7 @@ export function getEventContractId(e: WalletEvent) {
     return e.data.parent.id
   }
   if (e.type === 'v2ContractResolution') {
-    return e.data.parent.id
+    return e.data.resolution.parent.id
   }
   return undefined
 }


### PR DESCRIPTION
- Fixed an issue where a v2ContractResolution event in the wallet would crash the app. https://github.com/SiaFoundation/hostd/issues/629
- Removed parent from the data field of WalletEventContractResolutionV2.
