### PR TITLE
feat(hostd): volume ID column

### DIFF
--- a/.changeset/slow-cherries-remain.md
+++ b/.changeset/slow-cherries-remain.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The volumes list now has an ID column.

--- a/apps/hostd/contexts/volumes/columns.tsx
+++ b/apps/hostd/contexts/volumes/columns.tsx
@@ -32,6 +32,16 @@ export const columns: VolumesTableColumn[] = [
     render: ({ data }) => <VolumeContextMenu id={data.id} />,
   },
   {
+    id: 'id',
+    label: 'id',
+    category: 'general',
+    render: ({ data }) => (
+      <Text font="mono" ellipsis>
+        {data.id}
+      </Text>
+    ),
+  },
+  {
     id: 'path',
     label: 'path',
     category: 'general',

--- a/apps/hostd/contexts/volumes/types.ts
+++ b/apps/hostd/contexts/volumes/types.ts
@@ -20,6 +20,7 @@ export type VolumeData = {
 
 export type TableColumnId =
   | 'actions'
+  | 'id'
   | 'path'
   | 'storage'
   | 'available'
@@ -31,6 +32,7 @@ export type TableColumnId =
 
 export const columnsDefaultVisible: TableColumnId[] = [
   'actions',
+  'id',
   'path',
   'storage',
   'available',


### PR DESCRIPTION
- The volumes list now has an ID column. https://github.com/SiaFoundation/hostd/issues/635

![Screenshot 2025-03-21 at 8.09.00 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/7f5bb3f6-61c4-4114-badf-e4cdd1dce137.png)

