### PR TITLE
fix(hostd): volume stats alignment

### DIFF
--- a/.changeset/slow-cherries-remain.md
+++ b/.changeset/slow-cherries-remain.md
@@ -2,4 +2,4 @@
 'hostd': minor
 ---
 
-The volumes list now has an ID column.
+The volumes list now has an ID column. Closes https://github.com/SiaFoundation/hostd/issues/635

--- a/.changeset/twenty-items-lay.md
+++ b/.changeset/twenty-items-lay.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+Fixed the alignment of volume stats in the subnav.

--- a/apps/hostd/components/Volumes/VolumesFiltersBar.tsx
+++ b/apps/hostd/components/Volumes/VolumesFiltersBar.tsx
@@ -12,7 +12,7 @@ export function VolumesFiltersBar() {
   const free = total - used
 
   return (
-    <div className="flex gap-2 justify-between w-full">
+    <div className="flex gap-2 justify-between items-center w-full">
       <div className="flex gap-4">
         <Text size="12" font="mono" weight="medium">{`${humanBytes(
           used


### PR DESCRIPTION
- Fixed the alignment of volume stats in the subnav.

### before:
![Screenshot 2025-03-21 at 8.12.00 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/7582a647-7448-4fbf-9829-e260d1d51ba5.png)

### after:
![Screenshot 2025-03-21 at 8.12.19 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/63a25857-ddbc-4847-bb69-12bb0aa4c144.png)



