### PR TITLE
fix(explorer): v2 total and remaining storage to bytes

### DIFF
--- a/.changeset/purple-keys-sniff.md
+++ b/.changeset/purple-keys-sniff.md
@@ -1,0 +1,5 @@
+---
+'explorer': patch
+---
+
+Fixed the units for v2 host settings total and remaining storage.

--- a/apps/explorer/components/Home/HostListItem.tsx
+++ b/apps/explorer/components/Home/HostListItem.tsx
@@ -19,6 +19,7 @@ import {
   getStorageCost,
   getUploadCost,
   humanBytes,
+  sectorsToBytes,
 } from '@siafoundation/units'
 import { useMemo } from 'react'
 import { routes } from '../../config/routes'
@@ -100,7 +101,7 @@ export function HostListItem({ host, exchange, entity }: Props) {
       (host.v2 ? host.v2Settings : host.settings)
         ? humanBytes(
             host.v2
-              ? host.v2Settings.remainingStorage
+              ? sectorsToBytes(host.v2Settings.remainingStorage)
               : host.settings.remainingstorage
           )
         : '-',

--- a/apps/explorer/components/Host/HostSettings.tsx
+++ b/apps/explorer/components/Host/HostSettings.tsx
@@ -13,6 +13,7 @@ import {
   getDownloadCost,
   getStorageCost,
   getUploadCost,
+  sectorsToBytes,
 } from '@siafoundation/units'
 import { ExplorerHost } from '@siafoundation/explored-types'
 import { useActiveCurrencySiascanExchangeRate } from '@siafoundation/react-core'
@@ -41,7 +42,9 @@ export function HostSettings({ host }: Props) {
         label: 'total storage',
         copyable: false,
         value: humanBytes(
-          host.v2 ? host.v2Settings.totalStorage : host.settings.totalstorage
+          host.v2
+            ? sectorsToBytes(host.v2Settings.totalStorage)
+            : host.settings.totalstorage
         ),
       },
       {
@@ -49,7 +52,7 @@ export function HostSettings({ host }: Props) {
         copyable: false,
         value: humanBytes(
           host.v2
-            ? host.v2Settings.remainingStorage
+            ? sectorsToBytes(host.v2Settings.remainingStorage)
             : host.settings.remainingstorage
         ),
       },

--- a/apps/explorer/lib/hosts.ts
+++ b/apps/explorer/lib/hosts.ts
@@ -1,6 +1,7 @@
 import { ExplorerHost } from '@siafoundation/explored-types'
 import { to } from '@siafoundation/request'
 import { getExplored } from './explored'
+import { sectorsToBytes } from '@siafoundation/units'
 
 const weights = {
   age: 0.3,
@@ -77,10 +78,10 @@ function rankHosts(hosts: ExplorerHost[] | undefined) {
         weights.usedStorage *
           normalize(
             (host.v2
-              ? host.v2Settings.totalStorage
+              ? sectorsToBytes(host.v2Settings.totalStorage).toNumber()
               : host.settings.totalstorage) -
               (host.v2
-                ? host.v2Settings.remainingStorage
+                ? sectorsToBytes(host.v2Settings.remainingStorage).toNumber()
                 : host.settings.remainingstorage),
             ranges.usedStorage.min,
             ranges.usedStorage.max


### PR DESCRIPTION
- Fixed the units for v2 host settings total and remaining storage.
  - These fields were in bytes in v1, for v2 they are in sectors.
