### PR TITLE
feat(explorer): sync banner, hardfork banner sync

### DIFF
--- a/.changeset/four-crews-cough.md
+++ b/.changeset/four-crews-cough.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The hardfork countdown only shows if the explorer is fully synced.

--- a/.changeset/real-foxes-fetch.md
+++ b/.changeset/real-foxes-fetch.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The explorer now shows a warning banner if syncing is in progress.

--- a/apps/explorer/components/Layout/index.tsx
+++ b/apps/explorer/components/Layout/index.tsx
@@ -7,6 +7,7 @@ import { NavDropdownMenu } from './NavDropdownMenu'
 import { Footer } from './Footer'
 import { Navbar } from './Navbar'
 import { HardforkCountdown } from '../HardforkCountdown'
+import { SyncWarning } from '../SyncWarning'
 
 type Props = {
   children: React.ReactNode
@@ -16,6 +17,7 @@ export function Layout({ children }: Props) {
   return (
     <div className="relative h-full bg-gray-100 dark:bg-graydark-50 overflow-hidden">
       <div className="relative z-10 h-full overflow-y-auto">
+        <SyncWarning />
         <HardforkCountdown network={network} />
         <Navbar
           appName={appName}

--- a/apps/explorer/components/SyncWarning/index.tsx
+++ b/apps/explorer/components/SyncWarning/index.tsx
@@ -1,0 +1,31 @@
+import { Text } from '@siafoundation/design-system'
+import { to } from '@siafoundation/request'
+import { getExplored } from '../../lib/explored'
+import { getIsSynced } from '../../lib/sync'
+import { Warning24 } from '@siafoundation/react-icons'
+
+export async function SyncWarning() {
+  const [consensusState, consensusStateError] = await to(
+    getExplored().consensusState()
+  )
+
+  if (consensusStateError || !consensusState)
+    throw new Error(
+      'explored consensusState request failed in HardforkCountdown'
+    )
+
+  const isSynced = getIsSynced(consensusState)
+  if (!isSynced) {
+    return (
+      <div className="w-full px-5 py-3 flex flex-col sm:flex-row gap-2 justify-center items-center bg-gray-100 dark:bg-graydark-50">
+        <Warning24 />
+        <Text color="contrast" weight="medium" className="text-sm md:text-lg">
+          Warning: the siascan explorer is currently syncing, data may be
+          incomplete.
+        </Text>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/apps/explorer/lib/sync.ts
+++ b/apps/explorer/lib/sync.ts
@@ -1,0 +1,9 @@
+import { hoursInMilliseconds } from '@siafoundation/units'
+
+// If the last block is greater than 12 hours ago, the node is not synced.
+export function getIsSynced(data?: { prevTimestamps: string[] }) {
+  return data?.prevTimestamps[0]
+    ? new Date(data?.prevTimestamps[0]).getTime() >
+        Date.now() - hoursInMilliseconds(12)
+    : false
+}


### PR DESCRIPTION
- Made some tweaks around sync status since the node height is not the actual network height until fully synced.

### Changes
- The hardfork countdown only shows if the explorer is fully synced.
- The explorer now shows a warning banner if syncing is in progress.


![Screenshot 2025-03-25 at 3.29.17 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/8d09b3c5-f939-4258-9e92-a1f8539fe7ec.png)

