### PR TITLE
feat(renterd): host explorer v2 settings columns

### DIFF
--- a/.changeset/lemon-ghosts-sin.md
+++ b/.changeset/lemon-ghosts-sin.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The host explorer now has a version column.

--- a/.changeset/lovely-crews-build.md
+++ b/.changeset/lovely-crews-build.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The host explorer now has columns for v2 settings.

--- a/.changeset/olive-crabs-sparkle.md
+++ b/.changeset/olive-crabs-sparkle.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The host explorer address column now gets populates v2 host addresses.

--- a/apps/renterd/components/Hosts/HostsViewDropdownMenu.tsx
+++ b/apps/renterd/components/Hosts/HostsViewDropdownMenu.tsx
@@ -36,6 +36,12 @@ export function HostsViewDropdownMenu() {
       label: column.label,
       value: column.id,
     }))
+  const v2SettingsColumns = configurableColumns
+    .filter((c) => c.category === 'v2Settings')
+    .map((column) => ({
+      label: column.label,
+      value: column.id,
+    }))
   const priceTableColumns = configurableColumns
     .filter((c) => c.category === 'priceTable')
     .map((column) => ({
@@ -103,6 +109,24 @@ export function HostsViewDropdownMenu() {
           <BaseMenuItem>
             <PoolCombo
               options={autopilotColumns}
+              values={visibleColumnIds}
+              onChange={(value) => toggleColumnVisibility(value)}
+            />
+          </BaseMenuItem>
+        </>
+      ) : null}
+      {v2SettingsColumns.length ? (
+        <>
+          <MenuSectionLabelToggleAll
+            label="V2 settings (RHPv4)"
+            columns={v2SettingsColumns.map((c) => c.value)}
+            enabled={visibleColumnIds}
+            setColumnsVisible={setColumnsVisible}
+            setColumnsHidden={setColumnsHidden}
+          />
+          <BaseMenuItem>
+            <PoolCombo
+              options={v2SettingsColumns}
               values={visibleColumnIds}
               onChange={(value) => toggleColumnVisibility(value)}
             />

--- a/apps/renterd/contexts/hosts/dataset.ts
+++ b/apps/renterd/contexts/hosts/dataset.ts
@@ -65,7 +65,9 @@ export function useDataset({
 function getHostFields(host: Host, allContracts: Maybe<ContractData[]>) {
   return {
     id: host.publicKey,
-    netAddress: host.netAddress,
+    netAddress: host.v2SiamuxAddresses?.length
+      ? host.v2SiamuxAddresses[0]
+      : host.netAddress,
     publicKey: host.publicKey,
     lastScanSuccess: host.interactions.lastScanSuccess,
     lastScan:

--- a/apps/renterd/contexts/hosts/types.tsx
+++ b/apps/renterd/contexts/hosts/types.tsx
@@ -107,6 +107,19 @@ const autopilotColumns = [
   'ap_scoreVersion',
 ] as const
 
+const v2SettingsColumns = [
+  'v2_acceptingContracts',
+  'v2_maxCollateral',
+  'v2_maxContractDuration',
+  'v2_remainingStorage',
+  'v2_totalStorage',
+  'v2_storagePrice',
+  'v2_contractPrice',
+  'v2_collateral',
+  'v2_ingressPrice',
+  'v2_egressPrice',
+] as const
+
 const priceTableColumns = [
   'hpt_accountbalancecost',
   'hpt_collateralcost',
@@ -174,10 +187,12 @@ export type HostTableColumnGeneral = typeof generalColumns[number]
 export type HostTableColumnAutopilot = typeof autopilotColumns[number]
 export type HostTableColumnPriceTable = typeof priceTableColumns[number]
 export type HostTableColumnSettings = typeof settingsColumns[number]
+export type HostTableColumnV2Settings = typeof v2SettingsColumns[number]
 
 export type TableColumnId =
   | HostTableColumnGeneral
   | HostTableColumnAutopilot
+  | HostTableColumnV2Settings
   | HostTableColumnPriceTable
   | HostTableColumnSettings
 
@@ -192,6 +207,11 @@ export const columnsDefaultVisible: TableColumnId[] = [
   'hasContract',
   'ap_usable',
   'ap_scoreOverall',
+  'v2_remainingStorage',
+  'v2_totalStorage',
+  'v2_storagePrice',
+  'v2_ingressPrice',
+  'v2_egressPrice',
 ]
 
 // export type SortField = never


### PR DESCRIPTION
- The host explorer now has a version column.
- The host explorer now has columns for v2 settings.

![Screenshot 2025-03-26 at 4.35.19 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/a6192b39-7241-458a-8c56-deafd5dfba11.png)

![Screenshot 2025-03-26 at 4.35.07 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/6a293297-9503-4863-82e2-4ecb48012e98.png)

![Screenshot 2025-03-26 at 4.34.36 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/682810e3-db49-46c0-9211-b453a49fd869.png)

