### PR TITLE
fix(hostd): contact explorer total and modes

### DIFF
--- a/.changeset/clean-ducks-carry.md
+++ b/.changeset/clean-ducks-carry.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+The contract explorer now has distinct v1 and v2 viewing modes.

--- a/.changeset/wet-colts-care.md
+++ b/.changeset/wet-colts-care.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+Fixed an issue where the contract explorer did not show the correct total number of contracts.

--- a/apps/hostd-e2e/src/fixtures/contracts.ts
+++ b/apps/hostd-e2e/src/fixtures/contracts.ts
@@ -1,5 +1,9 @@
 import { expect, Page } from '@playwright/test'
-import { maybeExpectAndReturn, step } from '@siafoundation/e2e'
+import {
+  maybeExpectAndReturn,
+  step,
+  toggleColumnVisibility,
+} from '@siafoundation/e2e'
 
 export const getContractRowById = step(
   'get contract row by ID',
@@ -19,15 +23,19 @@ export const getContractsSummaryRow = step(
   }
 )
 
+export function locateContractRowByIndex(page: Page, index: number) {
+  return page
+    .getByTestId('contractsTable')
+    .locator('tbody')
+    .getByRole('row')
+    .nth(index)
+}
+
 export const getContractRowByIndex = step(
   'get contract row by index',
   async (page: Page, index: number, shouldExpect?: boolean) => {
     return maybeExpectAndReturn(
-      page
-        .getByTestId('contractsTable')
-        .locator('tbody')
-        .getByRole('row')
-        .nth(index),
+      locateContractRowByIndex(page, index),
       shouldExpect
     )
   }
@@ -54,5 +62,26 @@ export const getContractRowsAll = step(
   'get contract rows',
   async (page: Page) => {
     return getContractRows(page).all()
+  }
+)
+
+export const setVersionMode = step(
+  'set version mode',
+  async (page: Page, version: 'v1' | 'v2') => {
+    await page.getByLabel('contracts version mode').click()
+    await page.getByText(`View ${version} contracts`).click()
+  }
+)
+
+export const expectVersionMode = step(
+  'expect version mode',
+  async (page, version: 'v1' | 'v2') => {
+    await toggleColumnVisibility(page, 'version', true)
+    await expect(page.getByLabel('contracts version mode')).toHaveText(version)
+    await expect(
+      locateContractRowByIndex(page, 0)
+        .getByTestId('version')
+        .getByText(version)
+    ).toBeVisible()
   }
 )

--- a/apps/hostd/components/Contracts/ContractsCmd/ContractsFilterCmd/ContractFilterCmdGroups/Status.tsx
+++ b/apps/hostd/components/Contracts/ContractsCmd/ContractsFilterCmd/ContractFilterCmdGroups/Status.tsx
@@ -1,46 +1,47 @@
-import {
-  ClientFilterItem,
-  ServerFilterItem,
-} from '@siafoundation/design-system'
+import { ServerFilterItem } from '@siafoundation/design-system'
 import { CommandGroup, CommandItemSearch } from '../../../../CmdRoot/Item'
 import { Page } from '../../../../CmdRoot/types'
-import { ContractData } from '../../../../../contexts/contracts/types'
+import { useContracts } from '../../../../../contexts/contracts'
 
 export const contractsFilterStatusPage = {
   namespace: 'contracts/filterStatus',
   label: 'Contracts filter by status',
 }
 
-const options: ClientFilterItem<ContractData>[] = [
+const optionsV1: ServerFilterItem[] = [
   {
     id: 'filterStatusActive',
     value: 'active',
     label: 'Contract is active',
-    fn: (c) => c.status === 'active',
   },
   {
     id: 'filterStatusSuccessful',
     value: 'successful',
     label: 'Contract was successful',
-    fn: (c) => c.status === 'successful',
   },
   {
     id: 'filterStatusPending',
     value: 'pending',
     label: 'Contract is pending',
-    fn: (c) => c.status === 'pending',
   },
   {
     id: 'filterStatusRejected',
     value: 'rejected',
     label: 'Contract was rejected',
-    fn: (c) => c.status === 'rejected',
   },
   {
     id: 'filterStatusFailed',
     value: 'failed',
     label: 'Contract has failed',
-    fn: (c) => c.status === 'failed',
+  },
+]
+
+const optionsV2: ServerFilterItem[] = [
+  ...optionsV1,
+  {
+    id: 'filterStatusRenewed',
+    value: 'renewed',
+    label: 'Contract was renewed',
   },
 ]
 
@@ -51,6 +52,8 @@ export function StatusCmdGroup({
   currentPage: Page
   select: (filter: ServerFilterItem) => void
 }) {
+  const { versionMode } = useContracts()
+  const options = versionMode === 'v1' ? optionsV1 : optionsV2
   return (
     <CommandGroup
       currentPage={currentPage}

--- a/apps/hostd/components/Contracts/ContractsFiltersBar.tsx
+++ b/apps/hostd/components/Contracts/ContractsFiltersBar.tsx
@@ -1,13 +1,55 @@
-import { PaginatorKnownTotal } from '@siafoundation/design-system'
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuItem,
+  PaginatorKnownTotal,
+} from '@siafoundation/design-system'
 import { useContracts } from '../../contexts/contracts'
 import { ContractsFilterMenu } from './ContractsFilterMenu'
 
 export function ContractsFiltersBar() {
-  const { offset, limit, datasetFilteredTotal, datasetState } = useContracts()
+  const {
+    offset,
+    limit,
+    datasetFilteredTotal,
+    datasetState,
+    versionMode,
+    setVersionMode,
+  } = useContracts()
 
   return (
-    <div className="flex gap-2 justify-between w-full">
-      <ContractsFilterMenu />
+    <div className="flex gap-2 w-full">
+      <div>
+        <DropdownMenu
+          contentProps={{
+            side: 'bottom',
+            align: 'start',
+          }}
+          trigger={
+            <Button
+              aria-label="contracts version mode"
+              tip={
+                versionMode === 'v2'
+                  ? 'Currently viewing v2 contracts'
+                  : 'Currently viewing v1 contracts'
+              }
+              variant="active"
+            >
+              {versionMode === 'v2' ? 'v2' : 'v1'}
+            </Button>
+          }
+        >
+          <DropdownMenuItem onSelect={() => setVersionMode('v2')}>
+            View v2 contracts
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setVersionMode('v1')}>
+            View v1 contracts
+          </DropdownMenuItem>
+        </DropdownMenu>
+      </div>
+      <div className="flex-1">
+        <ContractsFilterMenu />
+      </div>
       <PaginatorKnownTotal
         offset={offset}
         limit={limit}

--- a/apps/hostd/contexts/contracts/dataset.ts
+++ b/apps/hostd/contexts/contracts/dataset.ts
@@ -6,22 +6,30 @@ import BigNumber from 'bignumber.js'
 import { Maybe } from '@siafoundation/types'
 
 export function useDataset({
+  versionMode,
   response,
   responseV2,
 }: {
+  versionMode: 'v1' | 'v2'
   response: ReturnType<typeof useContracts>
   responseV2: ReturnType<typeof useContractsV2>
 }) {
   return useMemo<Maybe<ContractData[]>>(() => {
-    if (!response.data || !responseV2.data) {
+    if (versionMode === 'v1') {
+      if (response.data) {
+        return (
+          response.data.contracts?.map((c) => getContractFieldsFromV1(c)) || []
+        )
+      }
       return undefined
     }
-    const v1 =
-      response.data.contracts?.map((c) => getContractFieldsFromV1(c)) || []
-    const v2 =
-      responseV2.data.contracts?.map((c) => getContractFieldsFromV2(c)) || []
-    return [...v1, ...v2]
-  }, [response.data, responseV2.data])
+    if (responseV2.data) {
+      return (
+        responseV2.data.contracts?.map((c) => getContractFieldsFromV2(c)) || []
+      )
+    }
+    return undefined
+  }, [versionMode, response.data, responseV2.data])
 }
 
 function getContractFieldsFromV1(c: Contract): ContractData {

--- a/apps/hostd/contexts/contracts/types.ts
+++ b/apps/hostd/contexts/contracts/types.ts
@@ -1,5 +1,6 @@
 import { FileContractID, Hash256 } from '@siafoundation/types'
 import BigNumber from 'bignumber.js'
+import { V2ContractFilterSortField } from '@siafoundation/hostd-types'
 
 export type ContractData = {
   id: string
@@ -72,62 +73,36 @@ export type SortField =
   | 'status'
   | 'timeline'
   | 'negotiationHeight'
-  | 'contractHeightStart'
   | 'proofWindowHeightEnd'
-  | 'resolutionHeight'
-  | 'payoutHeight'
+
 export const sortOptions: {
   id: SortField
   label: string
   category: string
-  clientId:
-    | 'status'
-    | 'negotiationHeight'
-    | 'contractHeightStart'
-    | 'proofWindowHeightEnd'
-    | 'resolutionHeight'
-    | 'payoutHeight'
+  serverId: V2ContractFilterSortField
 }[] = [
   {
     id: 'status',
-    clientId: 'status',
+    serverId: 'status',
     label: 'status',
     category: 'general',
   },
   {
     id: 'timeline',
-    clientId: 'contractHeightStart',
+    serverId: 'negotiationHeight',
     label: 'timeline',
     category: 'time',
   },
   {
     id: 'negotiationHeight',
-    clientId: 'negotiationHeight',
+    serverId: 'negotiationHeight',
     label: 'negotiation height',
     category: 'time',
   },
   {
-    id: 'contractHeightStart',
-    clientId: 'contractHeightStart',
-    label: 'formation height',
-    category: 'time',
-  },
-  {
     id: 'proofWindowHeightEnd',
-    clientId: 'proofWindowHeightEnd',
+    serverId: 'expirationHeight',
     label: 'expiration height',
-    category: 'time',
-  },
-  {
-    id: 'resolutionHeight',
-    clientId: 'resolutionHeight',
-    label: 'resolution height',
-    category: 'time',
-  },
-  {
-    id: 'payoutHeight',
-    clientId: 'payoutHeight',
-    label: 'payout height',
     category: 'time',
   },
 ]

--- a/apps/hostd/dialogs/ContractsFilterContractIdDialog.tsx
+++ b/apps/hostd/dialogs/ContractsFilterContractIdDialog.tsx
@@ -1,23 +1,19 @@
 import {
-  ClientFilterItem,
   Dialog,
   FormFieldFormik,
   FormSubmitButtonFormik,
+  ServerFilterItem,
 } from '@siafoundation/design-system'
 import { useContracts } from '../contexts/contracts'
 import { useFormik } from 'formik'
 import * as Yup from 'yup'
 import { useDialog } from '../contexts/dialog'
-import { ContractData } from '../contexts/contracts/types'
 
-export function filterContractId(
-  contractId: string
-): ClientFilterItem<ContractData> {
+export function filterContractId(contractId: string): ServerFilterItem {
   return {
     id: 'filterContractId',
     value: contractId,
     label: `contract ID is ${contractId}`,
-    fn: (c) => c.id === contractId,
   }
 }
 


### PR DESCRIPTION
- Extends the work (and reverts the change from server to client filtering) done in https://github.com/SiaFoundation/web/pull/989 and adds two distinct modes.

### Changes
- The contract explorer now has distinct v1 and v2 viewing modes.
- Fixed an issue where the contract explorer did not show the correct total number of contracts.


![Screenshot 2025-03-28 at 1.32.22 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/3bc85395-e788-4b98-a172-1bb51f13212d.png)

![Screenshot 2025-03-28 at 1.32.18 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/03e58ff0-34ca-446e-a350-cc1176021699.png)

