### PR TITLE
test(explorer): disable contract renewedFrom, renewedTo, and adjust constant

### DIFF
--- a/apps/explorer-e2e/src/fixtures/constants.ts
+++ b/apps/explorer-e2e/src/fixtures/constants.ts
@@ -66,7 +66,7 @@ export const TEST_CONTRACT_1 = {
     unlockHash: 'c50b70e7dd79...',
     revisionNumber: '18,446,744,0...',
     status: 'obligation succeeded',
-    missedProofTitle: 'Missed proof outputs (2)',
+    missedProofTitle: 'Missed proof outputs (3)',
     validProofTitle: 'Valid proof outputs (2)',
   },
 }

--- a/apps/explorer-e2e/src/specs/contract.spec.ts
+++ b/apps/explorer-e2e/src/specs/contract.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test'
 import { ExplorerApp } from '../fixtures/ExplorerApp'
 import {
-  RENEWED_FROM_BUTTON,
-  RENEWED_TO_BUTTON,
+  // RENEWED_FROM_BUTTON,
+  // RENEWED_TO_BUTTON,
   TEST_CONTRACT_1,
 } from '../fixtures/constants'
 import { keys } from '../utils'
@@ -37,16 +37,16 @@ test('contract displays the intended data', async ({ page }) => {
   }
 })
 
-test('contract can navigate to renewed from contract', async ({ page }) => {
-  await explorerApp.goTo('/contract/' + TEST_CONTRACT_1.id)
-  await page.getByTestId(RENEWED_FROM_BUTTON).click()
+// test('contract can navigate to renewed from contract', async ({ page }) => {
+//   await explorerApp.goTo('/contract/' + TEST_CONTRACT_1.id)
+//   await page.getByTestId(RENEWED_FROM_BUTTON).click()
 
-  await expect(page.getByText(TEST_CONTRACT_1.renewedFromTitle)).toBeVisible()
-})
+//   await expect(page.getByText(TEST_CONTRACT_1.renewedFromTitle)).toBeVisible()
+// })
 
-test('contract can navigate to renewed to contract', async ({ page }) => {
-  await explorerApp.goTo('/contract/' + TEST_CONTRACT_1.id)
-  await page.getByTestId(RENEWED_TO_BUTTON).click()
+// test('contract can navigate to renewed to contract', async ({ page }) => {
+//   await explorerApp.goTo('/contract/' + TEST_CONTRACT_1.id)
+//   await page.getByTestId(RENEWED_TO_BUTTON).click()
 
-  await expect(page.getByText(TEST_CONTRACT_1.renewedToTitle)).toBeVisible()
-})
+//   await expect(page.getByText(TEST_CONTRACT_1.renewedToTitle)).toBeVisible()
+// })


### PR DESCRIPTION
This disables the tests that will fail as a result of disabling the renewedFrom and renewedTo buttons until such time as those are available. That said, the next PR up the stack will fail. The one after that I'm aiming to succeed with this PR. The final one, adjusting the testing suite to fully utilize clusterd, obviously changes all this. I wanted to see the pre-cluster testing succeed to verify assumptions, if that makes sense.