### PR TITLE
fix(e2e): stabilize e2e tests

### DIFF
--- a/.changeset/wild-pianos-hammer.md
+++ b/.changeset/wild-pianos-hammer.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/clusterd': patch
+---
+
+waitFor now waits for the current condition to return before next iteration.

--- a/apps/explorer-e2e/project.json
+++ b/apps/explorer-e2e/project.json
@@ -24,7 +24,7 @@
     "e2e": {
       "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/explorer-e2e"],
-      "dependsOn": ["^build", "build-cluster"],
+      "dependsOn": ["build-cluster"],
       "options": {
         "config": "apps/explorer-e2e/playwright.config.ts"
       }

--- a/apps/hostd-e2e/src/fixtures/volumes.ts
+++ b/apps/hostd-e2e/src/fixtures/volumes.ts
@@ -46,7 +46,16 @@ export const deleteVolume = step(
       page.getByText('Volume is now being permanently deleted')
     ).toBeVisible()
     const row = page.getByRole('row', { name: fullPath })
-    await expect(row.getByText('removing')).toBeVisible()
+    await expect
+      .poll(
+        async () =>
+          (await row.getByText('removing').isVisible()) ||
+          (await page
+            .getByTestId('volumesTable')
+            .getByText(fullPath)
+            .isHidden())
+      )
+      .toBe(true)
   }
 )
 

--- a/internal/cluster/cmd/clusterd/main.go
+++ b/internal/cluster/cmd/clusterd/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	zap.RedirectStdLog(log)
 
-	if hostdCount == 0 && renterdCount == 0 && walletdCount == 0 {
+	if hostdCount == 0 && renterdCount == 0 && walletdCount == 0 && exploredCount == 0 {
 		log.Panic("no nodes to run")
 	}
 

--- a/internal/cluster/go.mod
+++ b/internal/cluster/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 toolchain go1.23.4
 
 require (
-	go.sia.tech/cluster v0.1.3-0.20250429184218-965bc9400872
+	go.sia.tech/cluster v0.1.3-0.20250502195935-d28b7bd4e6de
 	go.sia.tech/core v0.12.0
 	go.sia.tech/coreutils v0.13.2
 	go.sia.tech/explored v0.0.0-20250430142716-e1daab1b0823

--- a/internal/cluster/go.sum
+++ b/internal/cluster/go.sum
@@ -80,8 +80,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
-go.sia.tech/cluster v0.1.3-0.20250429184218-965bc9400872 h1:FbopCeklP8KdEjRdINo7oPIaqQEEEphHtOvC8K8P1b4=
-go.sia.tech/cluster v0.1.3-0.20250429184218-965bc9400872/go.mod h1:5t5ttkrhFeb1YT4mB1s8sptTpLoBBw5JXuEQl/Mv4ic=
+go.sia.tech/cluster v0.1.3-0.20250502195935-d28b7bd4e6de h1:WA7055dBXpy+qUxeyq+HOWj3HdwU/q140epg9mq/tnI=
+go.sia.tech/cluster v0.1.3-0.20250502195935-d28b7bd4e6de/go.mod h1:SrD1eLrQr2ocxqiFjJ2dFdLEPsWFczEcqGqqKslv/Gw=
 go.sia.tech/core v0.12.0 h1:nuHjUE3MnYPQ+BKo44DD64332jBGVZlH657c5RIomXw=
 go.sia.tech/core v0.12.0/go.mod h1:ycpNTb9Y7Vtnq6HQ3iqOxeywLnjDs0udD3ZVq6KE13Y=
 go.sia.tech/coreutils v0.13.2 h1:SlxQ6onhdjGrTB8I/TxFwIbFTM0mzH5amDoAQMkjmOI=

--- a/libs/design-system/README.md
+++ b/libs/design-system/README.md
@@ -2,6 +2,6 @@
 
 Welcome to the Sia Design System. The Design System is build with React, Radix, and Tailwind.
 
-## Running unit tests
+## Testing
 
 Run `nx test design-system` to execute the unit tests via [Jest](https://jestjs.io).


### PR DESCRIPTION
PR with a bunch of improvements found while debugging the cluster startup issues:

- Update cluster deps.
- Improve flaky hostd volume test.
- Removed unnecessary `^build` from the explorer-e2e e2e target (should make startup _much_ faster, it was doing a production (slow) build of explorer that was not even being used cc @telestrial)
- Fixed `waitFor`. If the condition hung or errored would prevent natural test timeout on CI.
- Fixed -explored=1 startup errors in `cmd`.