### PR TITLE
Update index.tsx - Change email text

### DIFF
--- a/apps/website/pages/about-sia-foundation/index.tsx
+++ b/apps/website/pages/about-sia-foundation/index.tsx
@@ -92,7 +92,7 @@ function Foundation({ team, featured, reports }: Props) {
                   our documentation
                 </Link>
                 . For general inquiries email{' '}
-                <Link href={`mailto:${webLinks.email}`}>info@sia.tech</Link>. If
+                <Link href={`mailto:${webLinks.email}`}>hello@sia.tech</Link>. If
                 you are interested in a career at The Sia Foundation please see
                 our{' '}
                 <Link href={webLinks.jobs} target="_blank">


### PR DESCRIPTION
The contact email text on this page was listed as "info@sia.tech", which is an email address we don't have. The acual mailto: in the link was hello@sia.tech which was correct. This corrects the display text.