### PR TITLE
feat(explorer): add link to entity list titles, when appropriate

### DIFF
--- a/.changeset/honest-poems-shake.md
+++ b/.changeset/honest-poems-shake.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added title links to entity lists, improving navigation.

--- a/apps/explorer/components/Entity/EntityListItem.tsx
+++ b/apps/explorer/components/Entity/EntityListItem.tsx
@@ -77,11 +77,24 @@ export function EntityListItem(entity: EntityListItemProps) {
               </Text>
             )}
             {title ? (
-              <Tooltip content={title}>
-                <Text ellipsis weight="medium">
-                  {title}
-                </Text>
-              </Tooltip>
+              entity.href ? (
+                <Tooltip content={title}>
+                  <Link
+                    ellipsis
+                    weight="medium"
+                    underline="none"
+                    href={entity.href}
+                  >
+                    {title}
+                  </Link>
+                </Tooltip>
+              ) : (
+                <Tooltip content={title}>
+                  <Text ellipsis weight="medium">
+                    {title}
+                  </Text>
+                </Tooltip>
+              )
             ) : (
               <Text ellipsis weight="medium">
                 {truncHashEl}


### PR DESCRIPTION
Pretty straightforward: on the block and transaction pages, transactions and contract entities had avatars and IDs that were clickable, but the title wasn't. That felt counter-intuitive.

