### PR TITLE
feat(explorer): add expandable option for EntityListItems

### DIFF
--- a/.changeset/green-berries-share.md
+++ b/.changeset/green-berries-share.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/units': minor
+---
+
+Added undefined maxLength passthrough for defaultValue and formatEntityValue.

--- a/.changeset/plenty-lizards-allow.md
+++ b/.changeset/plenty-lizards-allow.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Added expandable option to ValueCopyable component.

--- a/.changeset/quiet-tomatoes-change.md
+++ b/.changeset/quiet-tomatoes-change.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added ability for users to expand IDs across the app. Closes https://github.com/SiaFoundation/web/issues/1008

--- a/apps/explorer/components/Address/index.tsx
+++ b/apps/explorer/components/Address/index.tsx
@@ -203,6 +203,7 @@ function formatV1TransactionEntity(
     href: routes.transaction.view.replace(':id', transaction.id),
     height: v1Transaction.index.height,
     timestamp: new Date(v1Transaction.timestamp).getTime(),
+    type: 'transaction',
   }
 }
 
@@ -231,6 +232,7 @@ function formatV2TransactionEntity(
     href: routes.transaction.view.replace(':id', transaction.id),
     height: v2Transaction.index.height,
     timestamp: new Date(v2Transaction.timestamp).getTime(),
+    type: 'transaction',
   }
 }
 
@@ -246,6 +248,7 @@ function formatV1ContractResolutionEntity(
     href: routes.contract.view.replace(':id', parent.id),
     sc: new BigNumber(siacoinElement.siacoinOutput.value),
     timestamp: new Date(v1ContractResolution.timestamp).getTime(),
+    type: 'contract',
   }
 }
 
@@ -261,6 +264,7 @@ function formatV2ContractResolutionEntity(
     href: routes.contract.view.replace(':id', resolution.parent.id),
     sc: new BigNumber(siacoinElement.siacoinOutput.value),
     timestamp: new Date(v1ContractResolution.timestamp).getTime(),
+    type: 'contract',
   }
 }
 
@@ -276,6 +280,7 @@ function formatPayoutEntity(payout: ExplorerEvent): EntityListItemProps {
     height: payout.index.height,
     sc: new BigNumber(siacoinElement.siacoinOutput.value),
     timestamp: new Date(payout.timestamp).getTime(),
+    type: 'output',
   }
 }
 
@@ -288,6 +293,7 @@ function formatUnspentSiacoinOutputEntity(
     label: 'siacoin output',
     initials: 'SO',
     scVariant: 'value' as const,
+    type: 'output',
   }
 }
 

--- a/apps/explorer/components/Entity/EntityListItem.tsx
+++ b/apps/explorer/components/Entity/EntityListItem.tsx
@@ -54,6 +54,7 @@ export function EntityListItem(entity: EntityListItemProps) {
       siascanUrl={entity.siascanUrl}
       href={entity.href}
       color="subtle"
+      expandable
     />
   )
   const label =

--- a/libs/units/src/entityTypes.ts
+++ b/libs/units/src/entityTypes.ts
@@ -79,7 +79,8 @@ export function getEntitySiascanUrl(
   }
 }
 
-export function defaultFormatValue(text: string, maxLength: number) {
+export function defaultFormatValue(text: string, maxLength?: number) {
+  if (!maxLength) return text
   return `${text?.slice(0, maxLength)}${
     (text?.length || 0) > maxLength ? '...' : ''
   }`
@@ -88,8 +89,9 @@ export function defaultFormatValue(text: string, maxLength: number) {
 export function formatEntityValue(
   type: EntityType,
   text: string,
-  maxLength: number
+  maxLength?: number
 ) {
+  if (!maxLength) return text
   switch (type) {
     case 'blockHash': {
       const halfMax = maxLength / 2


### PR DESCRIPTION
[Screen Recording 2025-05-13 at 12.54.43 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/uN70g1DQ5YQEeblFjgZt/08eb6d8e-21d8-498b-8deb-0f6cf6c01ebd.mov" />](https://app.graphite.dev/media/video/uN70g1DQ5YQEeblFjgZt/08eb6d8e-21d8-498b-8deb-0f6cf6c01ebd.mov)

Adds the ability to optionally expand ID/hashes through `ValueCopyable` and implements this by default mostly everywhere in the explorer.