### PR TITLE
fix(walletd): dynamic hardfork heights

### DIFF
--- a/.changeset/large-gorillas-protect.md
+++ b/.changeset/large-gorillas-protect.md
@@ -1,0 +1,5 @@
+---
+'walletd': patch
+---
+
+The wallet send features now use hardfork heights from the consensus network data instead of hardcoded heights.

--- a/apps/walletd/dialogs/WalletSendLedgerDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletSendLedgerDialog/index.tsx
@@ -1,10 +1,6 @@
-import {
-  useConsensusNetwork,
-  useConsensusTip,
-} from '@siafoundation/walletd-react'
 import { WalletSendLedgerDialogV2 } from './WalletSendLedgerDialogV2'
 import { WalletSendLedgerDialogV1 } from './WalletSendLedgerDialogV1'
-import { isPastV2RequireHeight } from '../_sharedWalletSend/hardforkV2'
+import { useIsPastV2RequireHeight } from '../_sharedWalletSend/hardforkV2'
 
 export type WalletSendLedgerDialogParams = {
   walletId: string
@@ -23,13 +19,7 @@ export function WalletSendLedgerDialog({
   open,
   onOpenChange,
 }: Props) {
-  const n = useConsensusNetwork()
-  const ct = useConsensusTip()
-
-  const isV2Required = isPastV2RequireHeight({
-    network: n.data?.name || 'mainnet',
-    height: ct.data?.height || 0,
-  })
+  const isV2Required = useIsPastV2RequireHeight()
 
   if (isV2Required) {
     return (

--- a/apps/walletd/dialogs/WalletSendSeedDialog/index.tsx
+++ b/apps/walletd/dialogs/WalletSendSeedDialog/index.tsx
@@ -1,10 +1,6 @@
-import {
-  useConsensusNetwork,
-  useConsensusTip,
-} from '@siafoundation/walletd-react'
 import { WalletSendSeedDialogV2 } from './WalletSendSeedDialogV2'
 import { WalletSendSeedDialogV1 } from './WalletSendSeedDialogV1'
-import { isPastV2AllowHeight } from '../_sharedWalletSend/hardforkV2'
+import { useIsPastV2AllowHeight } from '../_sharedWalletSend/hardforkV2'
 
 export type WalletSendSeedDialogParams = {
   walletId: string
@@ -23,13 +19,7 @@ export function WalletSendSeedDialog({
   open,
   onOpenChange,
 }: Props) {
-  const n = useConsensusNetwork()
-  const ct = useConsensusTip()
-
-  const isV2Allowed = isPastV2AllowHeight({
-    network: n.data?.name || 'mainnet',
-    height: ct.data?.height || 0,
-  })
+  const isV2Allowed = useIsPastV2AllowHeight()
 
   if (isV2Allowed) {
     return (

--- a/apps/walletd/dialogs/_sharedWalletSend/TransactionVersionIndicator.tsx
+++ b/apps/walletd/dialogs/_sharedWalletSend/TransactionVersionIndicator.tsx
@@ -1,15 +1,6 @@
 import { Text } from '@siafoundation/design-system'
-import {
-  useConsensusNetwork,
-  useConsensusTip,
-} from '@siafoundation/walletd-react'
-import {
-  isPastV2AllowHeight,
-  isPastV2RequireHeight,
-  getHardforkV2RequireHeight,
-  getHardforkV2AllowHeight,
-  getNetwork,
-} from './hardforkV2'
+import { useConsensusNetwork } from '@siafoundation/walletd-react'
+import { useIsPastV2AllowHeight, useIsPastV2RequireHeight } from './hardforkV2'
 
 export function TransactionVersionIndicator({
   type,
@@ -17,22 +8,11 @@ export function TransactionVersionIndicator({
   type: 'seed' | 'ledger'
 }) {
   const n = useConsensusNetwork()
-  const ct = useConsensusTip()
-  const height = ct.data?.height || 0
-  const network = getNetwork(n.data?.name)
-
-  const requireHeight = getHardforkV2RequireHeight(network).toLocaleString()
-  const allowHeight = getHardforkV2AllowHeight(network).toLocaleString()
-
-  const isV2Allowed = isPastV2AllowHeight({
-    network,
-    height,
-  })
-
-  const isV2Required = isPastV2RequireHeight({
-    network,
-    height,
-  })
+  const network = n.data?.name
+  const requireHeight = n.data?.hardforkV2.requireHeight.toLocaleString()
+  const allowHeight = n.data?.hardforkV2.allowHeight.toLocaleString()
+  const isV2Allowed = useIsPastV2AllowHeight()
+  const isV2Required = useIsPastV2RequireHeight()
 
   if (type === 'ledger') {
     let text = ''

--- a/apps/walletd/dialogs/_sharedWalletSend/hardforkV2.ts
+++ b/apps/walletd/dialogs/_sharedWalletSend/hardforkV2.ts
@@ -1,65 +1,24 @@
-// mainnet: https://github.com/SiaFoundation/coreutils/blob/master/chain/network.go#L50-L51
-// n.HardforkV2.AllowHeight = 526000   // June 6th, 2025 @ 6:00am UTC
-// n.HardforkV2.RequireHeight = 530000 // July 4th, 2025 @ 2:00am UTC
+import {
+  useConsensusNetwork,
+  useConsensusTip,
+} from '@siafoundation/walletd-react'
 
-// zen: https://github.com/SiaFoundation/coreutils/blob/master/chain/network.go#L144-L145
-// n.HardforkV2.AllowHeight = 112000   // March 1, 2025 @ 7:00:00 UTC
-// n.HardforkV2.RequireHeight = 114000 // ~ 2 weeks later
+export function useIsPastV2AllowHeight() {
+  const n = useConsensusNetwork()
+  const ct = useConsensusTip()
 
-// anagami: https://github.com/SiaFoundation/coreutils/blob/master/chain/network.go#L172-L173
-// n.HardforkV2.AllowHeight = 2016         // ~2 weeks in
-// n.HardforkV2.RequireHeight = 2016 + 288 // ~2 days later
-
-// test cluster: internal/cluster/cmd/clusterd/main.go#L131-L132
-// n.HardforkV2.AllowHeight = 400
-// n.HardforkV2.RequireHeight = 500
-
-export const hardforkV2AllowHeights = {
-  mainnet: 526_000,
-  zen: 112_000,
-  anagami: 2_016,
-  testCluster: 400,
+  if (!n.data?.hardforkV2.allowHeight || !ct.data?.height) {
+    return false
+  }
+  return ct.data.height > n.data.hardforkV2.allowHeight
 }
 
-export const hardforkV2RequireHeights = {
-  mainnet: 530_000,
-  zen: 114_000,
-  anagami: 2_016 + 288,
-  testCluster: 500,
-}
+export function useIsPastV2RequireHeight() {
+  const n = useConsensusNetwork()
+  const ct = useConsensusTip()
 
-export function getNetwork(network?: string) {
-  return process.env.NEXT_PUBLIC_TEST_CLUSTER === 'true'
-    ? 'testCluster'
-    : network || 'mainnet'
-}
-
-export function getHardforkV2AllowHeight(network: string) {
-  return hardforkV2AllowHeights[getNetwork(network)]
-}
-
-export function getHardforkV2RequireHeight(network: string) {
-  return hardforkV2RequireHeights[getNetwork(network)]
-}
-
-export function isPastV2AllowHeight({
-  network,
-  height,
-}: {
-  network: string
-  height: number
-}) {
-  const hardforkV2AllowHeight = getHardforkV2AllowHeight(network)
-  return height > hardforkV2AllowHeight
-}
-
-export function isPastV2RequireHeight({
-  network,
-  height,
-}: {
-  network: string
-  height: number
-}) {
-  const hardforkV2RequireHeight = getHardforkV2RequireHeight(network)
-  return height > hardforkV2RequireHeight
+  if (!n.data?.hardforkV2.requireHeight || !ct.data?.height) {
+    return false
+  }
+  return ct.data.height > n.data.hardforkV2.requireHeight
 }

--- a/internal/cluster/cmd/clusterd/main.go
+++ b/internal/cluster/cmd/clusterd/main.go
@@ -97,6 +97,7 @@ func main() {
 
 	// use modified Zen testnet
 	n, genesis := chain.TestnetZen()
+	n.Name = "testCluster"
 	n.InitialTarget = types.BlockID{0xFF}
 	n.HardforkDevAddr.Height = 1
 	n.HardforkTax.Height = 1


### PR DESCRIPTION
- The wallet send features now use hardfork heights from the consensus network data instead of hardcoded heights. Closes https://github.com/SiaFoundation/web/issues/990

