### PR TITLE
chore: add cjs builds

### DIFF
--- a/.changeset/pretty-insects-rhyme.md
+++ b/.changeset/pretty-insects-rhyme.md
@@ -1,0 +1,28 @@
+---
+'@siafoundation/clusterd': patch
+'@siafoundation/data-sources': patch
+'@siafoundation/design-system': patch
+'@siafoundation/e2e': patch
+'@siafoundation/explored-js': patch
+'@siafoundation/explored-react': patch
+'@siafoundation/explored-types': patch
+'@siafoundation/fonts': patch
+'@siafoundation/hostd-js': patch
+'@siafoundation/hostd-react': patch
+'@siafoundation/hostd-types': patch
+'@siafoundation/next': patch
+'@siafoundation/react-core': patch
+'@siafoundation/react-icons': patch
+'@siafoundation/renterd-js': patch
+'@siafoundation/renterd-react': patch
+'@siafoundation/renterd-types': patch
+'@siafoundation/request': patch
+'@siafoundation/sdk': patch
+'@siafoundation/types': patch
+'@siafoundation/units': patch
+'@siafoundation/walletd-js': patch
+'@siafoundation/walletd-react': patch
+'@siafoundation/walletd-types': patch
+---
+
+The library is now published in both ESM and CJS.

--- a/libs/clusterd/project.json
+++ b/libs/clusterd/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/clusterd/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/clusterd/*.md",

--- a/libs/clusterd/rollup.config.js
+++ b/libs/clusterd/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/data-sources/project.json
+++ b/libs/data-sources/project.json
@@ -16,6 +16,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/data-sources/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/data-sources/*.md",

--- a/libs/data-sources/rollup.config.js
+++ b/libs/data-sources/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/design-system/project.json
+++ b/libs/design-system/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/design-system/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/design-system/*.md",

--- a/libs/design-system/rollup.config.js
+++ b/libs/design-system/rollup.config.js
@@ -9,7 +9,6 @@ function getRollupOptions(config) {
     output: {
       ...c.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: c.plugins.concat(preserveDirectives.default()),

--- a/libs/e2e/project.json
+++ b/libs/e2e/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/e2e/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/e2e/*.md",

--- a/libs/e2e/rollup.config.js
+++ b/libs/e2e/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/explored-js/project.json
+++ b/libs/explored-js/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/explored-js/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/explored-js/*.md",

--- a/libs/explored-js/rollup.config.js
+++ b/libs/explored-js/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/explored-react/project.json
+++ b/libs/explored-react/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/explored-react/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/explored-react/*.md",

--- a/libs/explored-react/rollup.config.js
+++ b/libs/explored-react/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/explored-types/project.json
+++ b/libs/explored-types/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/explored-types/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/explored-types/*.md",

--- a/libs/explored-types/rollup.config.js
+++ b/libs/explored-types/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/fonts/project.json
+++ b/libs/fonts/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/fonts/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/fonts/*.md",

--- a/libs/fonts/rollup.config.js
+++ b/libs/fonts/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/hostd-js/project.json
+++ b/libs/hostd-js/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/hostd-js/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/hostd-js/*.md",

--- a/libs/hostd-js/rollup.config.js
+++ b/libs/hostd-js/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/hostd-react/project.json
+++ b/libs/hostd-react/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/hostd-react/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/hostd-react/*.md",

--- a/libs/hostd-react/rollup.config.js
+++ b/libs/hostd-react/rollup.config.js
@@ -8,7 +8,7 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
+
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/hostd-types/project.json
+++ b/libs/hostd-types/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/hostd-types/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/hostd-types/*.md",

--- a/libs/hostd-types/rollup.config.js
+++ b/libs/hostd-types/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/next/project.json
+++ b/libs/next/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/next/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/next/*.md",

--- a/libs/next/rollup.config.js
+++ b/libs/next/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/react-core/project.json
+++ b/libs/react-core/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/react-core/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/react-core/*.md",

--- a/libs/react-core/rollup.config.js
+++ b/libs/react-core/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/react-icons/project.json
+++ b/libs/react-icons/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/react-icons/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/react-icons/*.md",

--- a/libs/react-icons/rollup.config.js
+++ b/libs/react-icons/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/renterd-js/project.json
+++ b/libs/renterd-js/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/renterd-js/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/renterd-js/*.md",

--- a/libs/renterd-js/rollup.config.js
+++ b/libs/renterd-js/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/renterd-react/project.json
+++ b/libs/renterd-react/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/renterd-react/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/renterd-react/*.md",

--- a/libs/renterd-react/rollup.config.js
+++ b/libs/renterd-react/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/renterd-types/project.json
+++ b/libs/renterd-types/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/renterd-types/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/renterd-types/*.md",

--- a/libs/renterd-types/rollup.config.js
+++ b/libs/renterd-types/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/request/project.json
+++ b/libs/request/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/request/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/request/*.md",

--- a/libs/request/rollup.config.js
+++ b/libs/request/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/sdk/project.json
+++ b/libs/sdk/project.json
@@ -32,6 +32,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/sdk/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/sdk/*.md",
@@ -42,6 +43,7 @@
       },
       "configurations": {}
     },
+
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]

--- a/libs/sdk/rollup.config.js
+++ b/libs/sdk/rollup.config.js
@@ -9,7 +9,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins

--- a/libs/types/project.json
+++ b/libs/types/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/types/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/types/*.md",

--- a/libs/types/rollup.config.js
+++ b/libs/types/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/units/project.json
+++ b/libs/units/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/units/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/units/*.md",

--- a/libs/units/rollup.config.js
+++ b/libs/units/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/walletd-js/project.json
+++ b/libs/walletd-js/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/walletd-js/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/walletd-js/*.md",

--- a/libs/walletd-js/rollup.config.js
+++ b/libs/walletd-js/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/walletd-react/project.json
+++ b/libs/walletd-react/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/walletd-react/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/walletd-react/*.md",

--- a/libs/walletd-react/rollup.config.js
+++ b/libs/walletd-react/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),

--- a/libs/walletd-types/project.json
+++ b/libs/walletd-types/project.json
@@ -17,6 +17,7 @@
         "compiler": "tsc",
         "outputFileName": "index.js",
         "rollupConfig": "libs/walletd-types/rollup.config.js",
+        "format": ["esm", "cjs"],
         "assets": [
           {
             "glob": "libs/walletd-types/*.md",

--- a/libs/walletd-types/rollup.config.js
+++ b/libs/walletd-types/rollup.config.js
@@ -8,7 +8,6 @@ function getRollupOptions(options) {
     output: {
       ...options.output,
       preserveModules: true,
-      format: 'esm',
       sourcemap: true,
     },
     plugins: options.plugins.concat(preserveDirectives.default()),


### PR DESCRIPTION
- Adds commonjs builds for all our packages.
- In the past the specific way this was set up caused some bundling issues in the electron desktop apps, so will not merge this PR until this has been tested via the beta channel.
