### PR TITLE
refactor(explorer): typescript strict mode

### DIFF
--- a/.changeset/green-spiders-behave.md
+++ b/.changeset/green-spiders-behave.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Improved top host ranking.

--- a/apps/explorer/app/address/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/address/[id]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { humanSiacoin, humanSiafund } from '@siafoundation/units'
 import { getOGImage } from '../../../components/OGImageEntity'
 import { truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
 export const revalidate = 0
 
@@ -13,7 +14,7 @@ export const size = {
 
 export const contentType = 'image/png'
 
-export default async function Image({ params }) {
+export default async function Image({ params }: ExplorerPageProps) {
   const address = params?.id as string
 
   try {

--- a/apps/explorer/app/address/[id]/page.tsx
+++ b/apps/explorer/app/address/[id]/page.tsx
@@ -6,8 +6,9 @@ import { truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../lib/explored'
 import { to } from '@siafoundation/request'
 import { notFound } from 'next/navigation'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
-export function generateMetadata({ params }): Metadata {
+export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
   const title = `Address ${truncate(id, 30)}`
   const description = 'View details for Sia address.'
@@ -21,8 +22,8 @@ export function generateMetadata({ params }): Metadata {
 
 export const revalidate = 0
 
-export default async function Page({ params }) {
-  const address = params?.id as string
+export default async function Page({ params }: ExplorerPageProps) {
+  const address = params.id
 
   const [
     [balance, balanceError, balanceResponse],

--- a/apps/explorer/app/block/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/block/[id]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { humanDate } from '@siafoundation/units'
 import { getOGImage } from '../../../components/OGImageEntity'
 import { truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
 export const revalidate = 0
 
@@ -25,15 +26,15 @@ const formatOGImage = (id: string) => {
   )
 }
 
-export default async function Image({ params }) {
+export default async function Image({ params }: ExplorerPageProps) {
   let id: string
 
   // Check if the incoming id is referencing height.
-  if (!isNaN(Number(params?.id))) {
+  if (!isNaN(Number(params.id))) {
     // If it is, we need the block ID at that height.
-    const { data: tipAtHeight } = await getExplored().consensusTipByHeight(
-      params?.id
-    )
+    const { data: tipAtHeight } = await getExplored().consensusTipByHeight({
+      params: { height: Number(params.id) },
+    })
     id = tipAtHeight.id
   } else {
     // If it is not the height, assume we're referencing ID. No call necessary.

--- a/apps/explorer/app/block/[id]/page.tsx
+++ b/apps/explorer/app/block/[id]/page.tsx
@@ -6,8 +6,9 @@ import { buildMetadata } from '../../../lib/utils'
 import { getExplored } from '../../../lib/explored'
 import { to } from '@siafoundation/request'
 import { notFound } from 'next/navigation'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
-export function generateMetadata({ params }): Metadata {
+export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
   const height = Number(id || 0) as number
   if (isNaN(height)) {
@@ -32,14 +33,14 @@ export function generateMetadata({ params }): Metadata {
 
 export const revalidate = 0
 
-export default async function Page({ params }) {
+export default async function Page({ params }: ExplorerPageProps) {
   let id: string
 
   // Check if the incoming id is referencing height.
   if (!isNaN(Number(params?.id))) {
     // If it is, we need the block ID at that height.
     const { data: tipAtHeight } = await getExplored().consensusTipByHeight({
-      params: { height: params?.id },
+      params: { height: Number(params?.id) },
     })
     id = tipAtHeight.id
   } else {

--- a/apps/explorer/app/contract/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/contract/[id]/opengraph-image.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../lib/contracts'
 import BigNumber from 'bignumber.js'
 import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
 export const revalidate = 0
 
@@ -25,7 +26,7 @@ const currencyOpt = currencyOptions.find(
   (c) => c.id === 'usd'
 ) as CurrencyOption
 
-export default async function Image({ params }) {
+export default async function Image({ params }: ExplorerPageProps) {
   const id = params?.id as string
 
   const { data: contractType } = await getExplored().searchResultType({

--- a/apps/explorer/app/contract/[id]/page.tsx
+++ b/apps/explorer/app/contract/[id]/page.tsx
@@ -7,8 +7,9 @@ import { stripPrefix, truncate } from '@siafoundation/design-system'
 import { normalizeContract } from '../../../lib/contracts'
 import { getExplored } from '../../../lib/explored'
 import { to } from '@siafoundation/request'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
-export function generateMetadata({ params }): Metadata {
+export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
   const title = `Contract ${truncate(id, 30)}`
   const description = `View details for Sia contract.`
@@ -22,7 +23,7 @@ export function generateMetadata({ params }): Metadata {
 
 export const revalidate = 0
 
-export default async function Page({ params }) {
+export default async function Page({ params }: ExplorerPageProps) {
   const id = params?.id
 
   const { data: searchResultType } = await getExplored().searchResultType({

--- a/apps/explorer/app/host/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/host/[id]/opengraph-image.tsx
@@ -8,6 +8,7 @@ import { truncate } from '@siafoundation/design-system'
 import { CurrencyOption, currencyOptions } from '@siafoundation/react-core'
 import { getHostNetAddress } from '../../../lib/hostType'
 import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
 export const revalidate = 0
 
@@ -21,7 +22,7 @@ const currency = currencyOptions.find((c) => c.id === 'usd') as CurrencyOption
 
 export const contentType = 'image/png'
 
-export default async function Image({ params }) {
+export default async function Image({ params }: ExplorerPageProps) {
   const id = params?.id as string
 
   try {

--- a/apps/explorer/app/host/[id]/page.tsx
+++ b/apps/explorer/app/host/[id]/page.tsx
@@ -6,8 +6,9 @@ import { truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../lib/explored'
 import { to } from '@siafoundation/request'
 import { notFound } from 'next/navigation'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
-export function generateMetadata({ params }): Metadata {
+export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
   const title = `Host ${truncate(id, 30)}`
   const description = `View details for Sia host.`
@@ -21,7 +22,7 @@ export function generateMetadata({ params }): Metadata {
 
 export const revalidate = 0
 
-export default async function Page({ params }) {
+export default async function Page({ params }: ExplorerPageProps) {
   const id = params?.id
   const [host, hostError, hostResponse] = await to(
     getExplored().hostByPubkey({ params: { id } })

--- a/apps/explorer/app/tx/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/tx/[id]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { humanDate } from '@siafoundation/units'
 import { getOGImage } from '../../../components/OGImageEntity'
 import { stripPrefix, truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
 export const revalidate = 0
 
@@ -24,7 +25,7 @@ const NotFoundImage = (id: string) =>
     size
   )
 
-export default async function Image({ params }) {
+export default async function Image({ params }: ExplorerPageProps) {
   const id = params?.id as string
 
   try {

--- a/apps/explorer/app/tx/[id]/page.tsx
+++ b/apps/explorer/app/tx/[id]/page.tsx
@@ -6,8 +6,9 @@ import { notFound } from 'next/navigation'
 import { stripPrefix, truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../lib/explored'
 import { to } from '@siafoundation/request'
+import { ExplorerPageProps } from '../../../lib/pageProps'
 
-export function generateMetadata({ params }): Metadata {
+export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
   const title = `Transaction ${truncate(id, 30)}`
   const description = `View details for Sia transaction.`
@@ -21,7 +22,7 @@ export function generateMetadata({ params }): Metadata {
 
 export const revalidate = 0
 
-export default async function Page({ params }) {
+export default async function Page({ params }: ExplorerPageProps) {
   const id = params?.id as string
 
   // Do we have a v1 or v2 transaction?

--- a/apps/explorer/components/Transaction/index.tsx
+++ b/apps/explorer/components/Transaction/index.tsx
@@ -46,11 +46,15 @@ export function Transaction({
         label: 'siacoin input',
         addressHref: routes.address.view.replace(
           ':id',
-          stripPrefix(o.address || o.parent.siacoinOutput.address)
+          stripPrefix(
+            'parent' in o ? o.parent.siacoinOutput.address : o.address
+          )
         ),
-        address: o.address || o.parent.siacoinOutput.address,
-        sc: new BigNumber(o.value || o.parent.siacoinOutput.value),
-        outputId: o.parentID || o.parent.id,
+        address: 'parent' in o ? o.parent.siacoinOutput.address : o.address,
+        sc: new BigNumber(
+          'parent' in o ? o.parent.siacoinOutput.value : o.value
+        ),
+        outputId: 'parent' in o ? o.parent.id : o.parentID,
       })
     })
     transaction.siafundInputs?.forEach((o) => {
@@ -58,11 +62,15 @@ export function Transaction({
         label: 'siafund input',
         addressHref: routes.address.view.replace(
           ':id',
-          stripPrefix(o.address || o.parent.siafundOutput.address)
+          stripPrefix(
+            'parent' in o ? o.parent.siafundOutput.address : o.address
+          )
         ),
-        address: o.address || o.parent.siafundOutput.address,
-        sc: new BigNumber(o.value || o.parent.siafundOutput.value),
-        outputId: o.parentID || o.parent.id,
+        address: 'parent' in o ? o.parent.siafundOutput.address : o.address,
+        sc: new BigNumber(
+          'parent' in o ? o.parent.siafundOutput.value : o.value
+        ),
+        outputId: 'parent' in o ? o.parent.id : o.parentID,
       })
     })
     return list
@@ -76,16 +84,22 @@ export function Transaction({
     transaction.siacoinOutputs?.forEach((o) => {
       list.push({
         label:
-          o.source === 'transaction'
-            ? 'siacoin output'
-            : o.source.replace(/_/g, ' '),
+          'source' in o
+            ? o.source === 'transaction'
+              ? 'siacoin output'
+              : o.source.replace(/_/g, ' ')
+            : 'siacoin output',
         addressHref: routes.address.view.replace(
           ':id',
-          stripPrefix(o.siacoinOutput.address)
+          stripPrefix(
+            'siacoinOutput' in o ? o.siacoinOutput.address : o.address
+          )
         ),
-        address: o.siacoinOutput.address,
-        sc: new BigNumber(o.siacoinOutput.value),
-        outputId: o.id,
+        address: 'siacoinOutput' in o ? o.siacoinOutput.address : o.address,
+        sc: new BigNumber(
+          'siacoinOutput' in o ? o.siacoinOutput.value : o.value
+        ),
+        outputId: 'id' in o && o.id ? o.id : '',
       })
     })
     transaction.siafundOutputs?.forEach((o) => {
@@ -93,11 +107,13 @@ export function Transaction({
         label: 'siafund output',
         addressHref: routes.address.view.replace(
           ':id',
-          stripPrefix(o.siafundOutput.address)
+          stripPrefix(
+            'siafundOutput' in o ? o.siafundOutput.address : o.address
+          )
         ),
-        address: o.siafundOutput.address,
-        sf: Number(o.siafundOutput.value),
-        outputId: o.id,
+        address: 'siafundOutput' in o ? o.siafundOutput.address : o.address,
+        sf: Number('siafundOutput' in o ? o.siafundOutput.value : o.value),
+        outputId: 'id' in o && o.id ? o.id : '',
       })
     })
     return list
@@ -109,12 +125,14 @@ export function Transaction({
     }
     const operations: EntityListItemProps[] = []
     transaction.fileContracts?.forEach((contract) => {
-      return operations.push({
-        label: 'contract formation',
-        type: 'contract',
-        href: routes.contract.view.replace(':id', stripPrefix(contract.id)),
-        hash: contract.id,
-      })
+      if ('id' in contract) {
+        return operations.push({
+          label: 'contract formation',
+          type: 'contract',
+          href: routes.contract.view.replace(':id', stripPrefix(contract.id)),
+          hash: contract.id,
+        })
+      }
     })
     transaction.fileContractRevisions?.forEach(
       (contract: ExplorerFileContractRevision | V2FileContractRevision) => {
@@ -141,7 +159,12 @@ export function Transaction({
       operations.push({
         label: 'host announcement',
         // type: 'host',
-        hash: host.netAddress,
+        hash:
+          'netAddress' in host
+            ? host.netAddress
+            : host.V2HostAnnouncement.filter(
+                (ha) => ha.protocol === 'siamux'
+              )[0].address,
       })
     })
     {

--- a/apps/explorer/lib/identicon.d.ts
+++ b/apps/explorer/lib/identicon.d.ts
@@ -1,0 +1,15 @@
+declare module 'identicon.js' {
+  export default class Identicon {
+    constructor(hash: string, options?: IdenticonOptions)
+
+    toString(): string
+  }
+
+  interface IdenticonOptions {
+    foreground?: number[]
+    background?: number[]
+    margin?: number
+    size?: number
+    format?: string
+  }
+}

--- a/apps/explorer/lib/pageProps.ts
+++ b/apps/explorer/lib/pageProps.ts
@@ -1,0 +1,5 @@
+export type ExplorerPageProps<
+  T extends Record<string, string | number | object> = { id: string }
+> = {
+  params: T
+}

--- a/apps/explorer/lib/utils.ts
+++ b/apps/explorer/lib/utils.ts
@@ -4,9 +4,21 @@ import { siteName } from '../config'
 import { EntityType } from '@siafoundation/units'
 
 export function getHref(type: EntityType, value: string) {
-  // block accepts blockhash as a value.
+  // Block accepts blockhash as a value.
   const coercedType = type === 'blockHash' ? 'block' : type
-  return routes[coercedType].view.replace(':id', value)
+
+  switch (coercedType) {
+    case 'output':
+    case 'ip':
+    case 'hostIp':
+      return routes['home'].index
+
+    case 'hostPublicKey':
+      return routes['host'].view.replace(':id', value)
+
+    default:
+      return routes[coercedType]?.view.replace(':id', value) || ''
+  }
 }
 
 export function buildMetadata({

--- a/apps/explorer/tsconfig.json
+++ b/apps/explorer/tsconfig.json
@@ -5,7 +5,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
This refactor for typescript strict mode was fairly straightforward. Biggest change by number of files touched was simply typing out `params: { id: string }`. I unified that prop type and made it extensible, just in case it ever needs to be. Beyond that:

* The rankHosts function needed a decent rewrite, and I suspect that, previous to this, it was at least somewhat broken. I believe we were referencing keys that didn't exist, and I'm guessing that was skewing the final result. Should I throw a changeset on that, since the resultant list is now an entirely different group of hosts?

* Satisfying strict mode for the Transaction slice was fairly verbose. Lots of novel `'key' in object ? ... : ...`. It does probably need consolidating earlier. There is some decision-making to do there about what a consolidated type should care about, due to all the custom types used (and the available keys/types therein), so I've resolved to leave that for another day.

* The `identicon.js` import in `/lib/avatar.ts` has no official typings. It does have an `@types`, but that didn't seem to be the correct typing. Could be a versioning issue, but the end result is that I `ts-expect-error`'d this import. We could alternatively declare a module in a `*.d.ts` file in libs.