### PR TITLE
feat(walletd-libs): unspent outputs now include confirmations

### DIFF
--- a/.changeset/late-needles-wonder.md
+++ b/.changeset/late-needles-wonder.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/walletd-types': minor
+'@siafoundation/walletd-js': minor
+'@siafoundation/walletd-react': minor
+---
+
+Elements returned by unspent outputs endpoints now include the number of confirmations.

--- a/apps/walletd/lib/mocks/mockSeedWallet.ts
+++ b/apps/walletd/lib/mocks/mockSeedWallet.ts
@@ -46,6 +46,7 @@ export function getMockScenarioSeedWallet() {
     },
     outputs: [
       {
+        confirmations: 8,
         id: 'aa3e781330c9b3991e0141807df1327fadf114ca6c37acb9e58004f942d91dfb',
         stateElement: {
           leafIndex: 304248,
@@ -71,6 +72,7 @@ export function getMockScenarioSeedWallet() {
         maturityHeight: 0,
       },
       {
+        confirmations: 8,
         id: '32e430158591b4073a6834e9f4c4b67162e348844f569f4e472896bb72efb724',
         stateElement: {
           leafIndex: 305723,

--- a/libs/walletd-types/src/api.ts
+++ b/libs/walletd-types/src/api.ts
@@ -6,8 +6,6 @@ import {
   ChainIndex,
   SiacoinOutputID,
   SiafundOutputID,
-  SiacoinElement,
-  SiafundElement,
   Transaction,
   V2Transaction,
   WalletEvent,
@@ -16,7 +14,14 @@ import {
   SiafundOutput,
   TransactionID,
 } from '@siafoundation/types'
-import { GatewayPeer, Wallet, WalletAddress, WalletMetadata } from './types'
+import {
+  GatewayPeer,
+  Wallet,
+  WalletAddress,
+  WalletMetadata,
+  SiacoinElementWithConfirmations,
+  SiafundElementWithConfirmations,
+} from './types'
 
 export const stateRoute = '/state'
 export const consensusTipRoute = '/consensus/tip'
@@ -183,14 +188,14 @@ export type WalletOutputsSiacoinParams = { id: string }
 export type WalletOutputsSiacoinPayload = void
 export type WalletOutputsSiacoinResponse = {
   basis: ChainIndex
-  outputs: SiacoinElement[]
+  outputs: SiacoinElementWithConfirmations[]
 }
 
 export type WalletOutputsSiafundParams = { id: string }
 export type WalletOutputsSiafundPayload = void
 export type WalletOutputsSiafundResponse = {
   basis: ChainIndex
-  outputs: SiafundElement[]
+  outputs: SiafundElementWithConfirmations[]
 }
 
 export type WalletFundSiacoinParams = {
@@ -251,7 +256,6 @@ export type WalletConstructV1TransactionPayload = {
   siafunds?: SiafundOutput[]
   changeAddress: Address
 }
-
 export type WalletConstructV1TransactionResponse = {
   basis: ChainIndex
   id: TransactionID

--- a/libs/walletd-types/src/types.ts
+++ b/libs/walletd-types/src/types.ts
@@ -1,4 +1,8 @@
-import { SpendPolicy } from '@siafoundation/types'
+import {
+  SiacoinElement,
+  SiafundElement,
+  SpendPolicy,
+} from '@siafoundation/types'
 
 export type GatewayPeer = {
   address: string
@@ -40,4 +44,12 @@ export type WalletAddress = {
   description: string
   spendPolicy?: SpendPolicy
   metadata: WalletAddressMetadata
+}
+
+export type SiacoinElementWithConfirmations = SiacoinElement & {
+  confirmations: number
+}
+
+export type SiafundElementWithConfirmations = SiafundElement & {
+  confirmations: number
 }


### PR DESCRIPTION
- Elements returned by unspent outputs endpoints now include the number of confirmations.