### PR TITLE
fix(explorer): round host uptime percentage to hundredths place

### DIFF
--- a/.changeset/kind-flowers-scream.md
+++ b/.changeset/kind-flowers-scream.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Rounded host uptime percentage to the hundredths place.

--- a/apps/explorer/components/Host/HostInfo.tsx
+++ b/apps/explorer/components/Host/HostInfo.tsx
@@ -21,10 +21,11 @@ type Props = {
 }
 
 export function HostInfo({ host }: Props) {
-  const estimatedUptime =
+  const estimatedUptime = (
     host.totalScans == 0
       ? 0
       : (host.successfulInteractions / host.totalScans) * 100
+  ).toFixed(2)
   return (
     <div className="flex flex-col">
       <ValueCopyable


### PR DESCRIPTION
![Screenshot 2025-05-23 at 1.36.53 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/ef307d77-e21c-41c4-8cac-b6fda30bde36.png)

![Screenshot 2025-05-23 at 1.37.38 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/a4744b2a-ce9b-42a4-a4be-af05fc4034fc.png)