### PR TITLE
feat(explorer): add middleware to enforce lowercase IDs across relevant routes

### DIFF
--- a/.changeset/brave-boats-burn.md
+++ b/.changeset/brave-boats-burn.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The explorer now redirects requests with uppercase IDs to their lowercase equivalents.

--- a/apps/explorer/middleware.ts
+++ b/apps/explorer/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export const config = {
+  matcher: ['/:entity(address|block|contract|host|tx)/:path*'],
+}
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // If the caught path contains uppercase characters, lowercase the URL.
+  if (/[A-Z]/.test(pathname)) {
+    const lowercasePath = pathname.toLowerCase()
+    const url = request.nextUrl.clone()
+    url.pathname = lowercasePath
+
+    return NextResponse.redirect(url, 308)
+  }
+
+  return NextResponse.next()
+}


### PR DESCRIPTION
This PR adds middleware to the Explorer that enforces lowercased IDs across the `address`, `block`, `contract`, `host`, and `tx` routes.

For example, if a user navigates to `https://zen.siascan.com/address/E254b0e6500cbe7eba250e0f60f90fb46eade419554b7a5eda6e83ef38554dda0486af517d0b` or enters that same uppercase "E" ID in the search bar, they will be redirected to `https://zen.siascan.com/address/e254b0e6500cbe7eba250e0f60f90fb46eade419554b7a5eda6e83ef38554dda0486af517d0b`.

I did a `308 - Permanent Redirect` here over `301 - Permanently Moved`. I'm open to either, but the former seems more semantic to our intentions.

I think it's important for me to recognize that middleware introduces at least a bit of complexity. It does things away from the components/processes that we may be trying to improve or fix. We may not know about this code and then go forth with false assumptions. Here, though, it feels warranted and solves more problems that I think it has the potential to cause. We're creating a tighter connection between the URLs we ultimately render against and the database `explored` is querying. The alternatives I can think of are not as desirable, to me: sprinkling the codebase with `.toLowercase()` or creating indirection to avoid that repetition. 