### PR TITLE
refactor(explored-types): rewrite ExplorerV2Transaction to match explored

### DIFF
--- a/.changeset/silver-ghosts-develop.md
+++ b/.changeset/silver-ghosts-develop.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/explored-types': minor
+---
+
+Refactored ExplorerV2Transaction to match explored implementation.

--- a/apps/explorer/components/Address/index.tsx
+++ b/apps/explorer/components/Address/index.tsx
@@ -216,7 +216,7 @@ function formatV2TransactionEntity(
     sc: getTotal({
       address: id,
       inputs: transaction.siacoinInputs?.map((o) => o.parent.siacoinOutput),
-      outputs: transaction.siacoinOutputs,
+      outputs: transaction.siacoinOutputs?.map((o) => o.siacoinOutput),
     }),
     sf: getTotal({
       address: id,
@@ -224,7 +224,10 @@ function formatV2TransactionEntity(
         address: o.parent.siafundOutput.address,
         value: String(o.parent.siafundOutput.value),
       })),
-      outputs: transaction.siafundOutputs,
+      outputs: transaction.siafundOutputs?.map((o) => ({
+        address: o.siafundOutput.address,
+        value: String(o.siafundOutput.value),
+      })),
     }).toNumber(),
     label: 'Transaction',
     initials: 'TX',

--- a/apps/explorer/components/Transaction/index.tsx
+++ b/apps/explorer/components/Transaction/index.tsx
@@ -91,14 +91,11 @@ export function Transaction({
             : 'siacoin output',
         addressHref: routes.address.view.replace(
           ':id',
-          stripPrefix(
-            'siacoinOutput' in o ? o.siacoinOutput.address : o.address
-          )
+
+          o.siacoinOutput.address
         ),
-        address: 'siacoinOutput' in o ? o.siacoinOutput.address : o.address,
-        sc: new BigNumber(
-          'siacoinOutput' in o ? o.siacoinOutput.value : o.value
-        ),
+        address: o.siacoinOutput.address,
+        sc: new BigNumber(o.siacoinOutput.value),
         outputId: 'id' in o && o.id ? o.id : '',
       })
     })
@@ -107,12 +104,10 @@ export function Transaction({
         label: 'siafund output',
         addressHref: routes.address.view.replace(
           ':id',
-          stripPrefix(
-            'siafundOutput' in o ? o.siafundOutput.address : o.address
-          )
+          stripPrefix(o.siafundOutput.address)
         ),
-        address: 'siafundOutput' in o ? o.siafundOutput.address : o.address,
-        sf: Number('siafundOutput' in o ? o.siafundOutput.value : o.value),
+        address: o.siafundOutput.address,
+        sf: Number(o.siafundOutput.value),
         outputId: 'id' in o && o.id ? o.id : '',
       })
     })

--- a/libs/explored-types/src/types.ts
+++ b/libs/explored-types/src/types.ts
@@ -29,6 +29,10 @@ import type {
   V2FileContractElement,
   V2FileContractResolution,
   V2FileContractRevision,
+  V2SiacoinInput,
+  V2SiafundInput,
+  Attestation,
+  MerkleProof,
 } from '@siafoundation/types'
 
 // Unchanged Types - Re-exported for a more straight-forward DX like:
@@ -405,8 +409,68 @@ export type ExplorerV2HostAnnouncement = {
   V2HostAnnouncement: NetAddress[]
 }
 
-export type ExplorerV2Transaction = V2Transaction & {
-  id: string
+export type ExplorerV2FileContractResolutionType =
+  | 'invalid'
+  | 'expiration'
+  | 'renewal'
+  | 'storage_proof'
+
+type ExplorerV2FileContractResolutionBase = {
+  parent: ExplorerV2FileContract
+}
+
+export type ExplorerV2FileContractResolutionExpiration =
+  ExplorerV2FileContractResolutionBase & {
+    type: 'expiration'
+    resolution: Record<string, never>
+  }
+
+export type ExplorerV2FileContractResolutionRenewal =
+  ExplorerV2FileContractResolutionBase & {
+    type: 'renewal'
+    resolution: {
+      finalRevision: ExplorerV2FileContract
+      newContract: ExplorerV2FileContract
+      renterRollover: Currency
+      hostRollover: Currency
+      renterSignature: Signature
+      hostSignature: Signature
+    }
+  }
+
+export type ExplorerV2FileContractResolutionStorageProof =
+  ExplorerV2FileContractResolutionBase & {
+    type: 'storage_proof'
+    resolution: {
+      proofIndex: ChainIndex
+      leaf: string
+      proof: MerkleProof
+    }
+  }
+
+export type ExplorerV2FileContractResolution =
+  | ExplorerV2FileContractResolutionExpiration
+  | ExplorerV2FileContractResolutionRenewal
+  | ExplorerV2FileContractResolutionStorageProof
+
+export type ExplorerV2Transaction = {
+  id: TransactionID
+
+  siacoinInputs?: V2SiacoinInput[]
+  siacoinOutputs?: ExplorerSiacoinOutput[]
+  siafundInputs?: V2SiafundInput[]
+  siafundOutputs?: ExplorerSiafundOutput[]
+
+  fileContracts?: ExplorerV2FileContract[]
+  fileContractRevisions?: V2FileContractRevision[]
+  fileContractResolutions?: ExplorerV2FileContractResolution[]
+
+  attestations?: Attestation[]
+  arbitraryData?: Uint8Array
+
+  newFoundationAddress?: Address
+  minerFee: Currency
+
   hostAnnouncements?: ExplorerV2HostAnnouncement[]
 }
 
@@ -415,11 +479,6 @@ export type V2BlockData = {
   commitment: Hash256
   transactions: ExplorerV2Transaction[]
 }
-
-export type ExplorerV2FileContractResolutionType =
-  | 'renewal'
-  | 'storage_proof'
-  | 'expiration'
 
 export type ExplorerV2FileContract = V2FileContractElement & {
   transactionID: TransactionID


### PR DESCRIPTION
In writing the contract status testing up stack, I realized that `ExplorerV2Transaction` was incorrect, particularly around resolution states. This was using web core `V2Transaction`, which matched enough for the `explorer`'s purposes, but there are differences. While it's unfortunate we break out from core a bit more, many of the values are still core imports.