### PR TITLE
refactor(explorer): refine empty transaction ui

### DIFF
--- a/.changeset/clean-news-suffer.md
+++ b/.changeset/clean-news-suffer.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Refined transaction page display when there are no inputs, outputs, and contract operations.

--- a/apps/explorer/components/Transaction/index.tsx
+++ b/apps/explorer/components/Transaction/index.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react'
 import BigNumber from 'bignumber.js'
-import { stripPrefix } from '@siafoundation/design-system'
+import { Panel, stripPrefix, Text } from '@siafoundation/design-system'
 import { EntityList } from '../Entity/EntityList'
 import { EntityListItemProps } from '../Entity/EntityListItem'
 import { routes } from '../../config/routes'
@@ -193,6 +193,30 @@ export function Transaction({
 
     return [...sfItems, ...scItems]
   }, [transaction])
+
+  // An "empty" transaction.
+  if (!inputs.length && !outputs.length && !operations.length) {
+    return (
+      <ContentLayout
+        panel={
+          <div className="flex flex-col gap-16">
+            <TransactionHeader
+              title={title}
+              transactionHeaderData={transactionHeaderData}
+            />
+          </div>
+        }
+      >
+        <Panel>
+          <div className="p-4 flex justify-center">
+            <Text size="16" color="subtle">
+              No activity
+            </Text>
+          </div>
+        </Panel>
+      </ContentLayout>
+    )
+  }
 
   return (
     <ContentLayout


### PR DESCRIPTION
Instead of displaying blank summary and empty input/output list:

![Screenshot 2025-06-06 at 11.05.47 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/1a00889d-9803-4707-8e27-6db3b722e018.png)

Upstream PR adds a dropdown with the transaction dropdown to this page, which will allow people to look at the arbitrary data, which is often the only thing of import happening here.