### PR TITLE
feat(explorer): add dropdown for JSON, add to block and tx pages

### DIFF
--- a/.changeset/early-dancers-tickle.md
+++ b/.changeset/early-dancers-tickle.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added a dropdown to view the JSON for transaction and block pages.

--- a/apps/explorer/components/Block/index.tsx
+++ b/apps/explorer/components/Block/index.tsx
@@ -13,6 +13,8 @@ import { EntityHeading } from '../EntityHeading'
 import { ContentLayout } from '../ContentLayout'
 import { ExplorerBlock } from '@siafoundation/explored-types'
 import { ArrowLeft16, ArrowRight16 } from '@siafoundation/react-icons'
+import { ExplorerAccordion } from '../ExplorerAccordion'
+import { ExplorerTextarea } from '../ExplorerTextarea'
 
 type Props = {
   block: ExplorerBlock
@@ -154,6 +156,11 @@ export function Block({ block, blockID, currentHeight }: Props) {
             })}
           />
         )}
+        <ExplorerAccordion title="JSON">
+          <div className="p-2">
+            <ExplorerTextarea value={JSON.stringify(block, null, 2)} />
+          </div>
+        </ExplorerAccordion>
       </div>
     </ContentLayout>
   )

--- a/apps/explorer/components/ExplorerAccordion.tsx
+++ b/apps/explorer/components/ExplorerAccordion.tsx
@@ -1,0 +1,29 @@
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  Heading,
+} from '@siafoundation/design-system'
+
+type ExplorerAccordionProps = {
+  title: string
+  children: React.ReactNode
+}
+
+export function ExplorerAccordion({ title, children }: ExplorerAccordionProps) {
+  return (
+    <Accordion type="single">
+      <AccordionItem value="steps" variant="ghost">
+        <div className="transition-shadow ease-in-out duration-300 shadow-sm hover:shadow rounded border border-gray-400 dark:border-graydark-400 bg-white dark:bg-graydark-200 overflow-hidden">
+          <AccordionTrigger className="flex items-center p-4 border-b border-gray-200 dark:border-graydark-300 w-full focus:outline-none focus:ring-2 focus:ring-gray-400 dark:focus:ring-graydark-400">
+            <Heading size="20" font="mono" ellipsis>
+              {title}
+            </Heading>
+          </AccordionTrigger>
+          <AccordionContent>{children}</AccordionContent>
+        </div>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/apps/explorer/components/ExplorerTextarea.tsx
+++ b/apps/explorer/components/ExplorerTextarea.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Button } from '@siafoundation/design-system'
+import { useEffect, useRef, useState } from 'react'
+
+type ExplorerTextareaProps = {
+  value: string
+}
+
+export function ExplorerTextarea({ value }: ExplorerTextareaProps) {
+  const ref = useRef<HTMLTextAreaElement>(null)
+  const [copied, setCopied] = useState(false)
+
+  // Render the textarea at the height of the dynamic content within it.
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.style.height = 'auto'
+      ref.current.style.height = `${ref.current.scrollHeight}px`
+    }
+  }, [value])
+
+  function handleCopy() {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className="relative">
+      <textarea
+        readOnly
+        ref={ref}
+        value={value}
+        className="w-full p-4 text-sm bg-gray-100 dark:bg-graydark-50 text-gray-1000 dark:text-graydark-1000 border border-gray-300 dark:border-gray-700 rounded font-mono whitespace-pre"
+      />
+      <Button
+        onClick={handleCopy}
+        variant="gray"
+        className="absolute top-3 right-6"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    </div>
+  )
+}

--- a/apps/explorer/components/Transaction/index.tsx
+++ b/apps/explorer/components/Transaction/index.tsx
@@ -17,6 +17,8 @@ import {
 } from '@siafoundation/explored-types'
 import { getTransactionSummary } from '../../lib/tx'
 import { EntityType } from '@siafoundation/units'
+import { ExplorerAccordion } from '../ExplorerAccordion'
+import { ExplorerTextarea } from '../ExplorerTextarea'
 
 type Props = {
   transactionHeaderData: TransactionHeaderData
@@ -194,6 +196,14 @@ export function Transaction({
     return [...sfItems, ...scItems]
   }, [transaction])
 
+  const JSONAccordion = (
+    <ExplorerAccordion title="JSON">
+      <div className="p-2">
+        <ExplorerTextarea value={JSON.stringify(transaction, null, 2)} />
+      </div>
+    </ExplorerAccordion>
+  )
+
   // An "empty" transaction.
   if (!inputs.length && !outputs.length && !operations.length) {
     return (
@@ -207,13 +217,14 @@ export function Transaction({
           </div>
         }
       >
-        <Panel>
-          <div className="p-4 flex justify-center">
+        <div className="flex flex-col gap-5">
+          <Panel className="p-4 flex justify-center">
             <Text size="16" color="subtle">
               No activity
             </Text>
-          </div>
-        </Panel>
+          </Panel>
+          {JSONAccordion}
+        </div>
       </ContentLayout>
     )
   }
@@ -257,6 +268,7 @@ export function Transaction({
             dataset={operations}
           />
         )}
+        {JSONAccordion}
       </div>
     </ContentLayout>
   )


### PR DESCRIPTION
![Screenshot 2025-06-06 at 11.20.37 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/6e9869ed-5305-44d8-a9d1-80e11123f95c.png)

Adds a dropdown to the block and transaction pages (and therefore also the contract page) to allow people to view the request response from `explored` without curling or postman'ing or whatever. I've seen it used in other explorers and I do find it to be useful, even though you can directly request this stuff. We don't display everything in these objects, but people may appreciate a browser-based method to examine it.