### PR TITLE
fix: scroll area width display issue

### DIFF
--- a/.changeset/fruity-tools-hope.md
+++ b/.changeset/fruity-tools-hope.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Fixed a width display issue in ScrollArea.

--- a/libs/design-system/src/core/ScrollArea.tsx
+++ b/libs/design-system/src/core/ScrollArea.tsx
@@ -28,7 +28,7 @@ export const ScrollArea = React.forwardRef<
       // Part 2: After updating radix there was an issues where the scroll area
       // would adopt its contents width. The following fixed that:
       // https://github.com/radix-ui/primitives/issues/3129
-      className="w-full h-full [&>div]:!min-w-0 [&>div]:!h-full"
+      className="w-full h-full [&>div]:!min-w-0 [&>div]:!block [&>div]:!h-full"
     >
       {children}
     </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
Not sure how this broken but there is an issue with ScrollArea display width in certain contexts, eg: `min-w-fit`.

### Before
![Screenshot 2025-06-10 at 2.28.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/b245122c-b8b6-4b63-a790-36138a627086.png)

### After
![Screenshot 2025-06-10 at 2.27.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/2b2c1972-36fd-4ec6-a50d-49ed197582cb.png)

