### PR TITLE
feat(explorer): add output route, display, and search

### DIFF
--- a/.changeset/eighty-pumas-explode.md
+++ b/.changeset/eighty-pumas-explode.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added support for output search and display.

--- a/apps/explorer-e2e/src/helpers/findTestOutput.ts
+++ b/apps/explorer-e2e/src/helpers/findTestOutput.ts
@@ -1,0 +1,49 @@
+import { ExplorerSiacoinOutput } from '@siafoundation/explored-types'
+import { Cluster } from '../fixtures/cluster'
+
+export async function findTestOutput(cluster: Cluster, version: 'v1' | 'v2') {
+  let foundOutput: ExplorerSiacoinOutput | undefined
+  const tip = await cluster.daemons.explored.api.consensusTip()
+  let currentHeight = tip.data.height
+
+  // Hopefully, 50 blocks should be enough. We stop on find.
+  for (let i = 0; i < 50; i++) {
+    const { data: blockIndex } =
+      await cluster.daemons.explored.api.consensusTipByHeight({
+        params: { height: currentHeight },
+      })
+
+    const { data: block } = await cluster.daemons.explored.api.blockByID({
+      params: { id: blockIndex.id },
+    })
+
+    if (version === 'v2') {
+      block.v2?.transactions?.forEach((tx) =>
+        tx.siacoinOutputs?.forEach((output) => {
+          if (!foundOutput) {
+            foundOutput = output
+          }
+        })
+      )
+    }
+
+    if (version === 'v1') {
+      block.transactions?.forEach((tx) =>
+        tx.siacoinOutputs?.forEach((output) => {
+          if (!foundOutput) {
+            foundOutput = output
+          }
+        })
+      )
+    }
+
+    if (foundOutput) break
+    currentHeight--
+  }
+
+  if (!foundOutput) {
+    throw new Error('Output ID not found in 50 blocks')
+  }
+
+  return foundOutput
+}

--- a/apps/explorer-e2e/src/specs/output.spec.ts
+++ b/apps/explorer-e2e/src/specs/output.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test'
+import { ExplorerApp } from '../fixtures/ExplorerApp'
+import { Cluster, startCluster } from '../fixtures/cluster'
+import {
+  renterdWaitForContracts,
+  teardownCluster,
+} from '@siafoundation/clusterd'
+import { exploredStabilization } from '../helpers/exploredStabilization'
+import { findTestOutput } from '../helpers/findTestOutput'
+import { humanSiacoin } from '@siafoundation/units'
+
+let explorerApp: ExplorerApp
+let cluster: Cluster
+
+// V2
+test.describe('v2', () => {
+  test.beforeEach(async ({ page, context }) => {
+    cluster = await startCluster({ context, networkVersion: 'v2' })
+    await renterdWaitForContracts({
+      renterdNode: cluster.daemons.renterds[0].node,
+      hostdCount: cluster.daemons.hostds.length,
+    })
+    await exploredStabilization(cluster)
+    explorerApp = new ExplorerApp(page)
+  })
+
+  test.afterEach(async () => {
+    await teardownCluster()
+  })
+
+  test('output can be searched by id', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v2')
+
+    await explorerApp.goTo('/')
+    await explorerApp.navigateBySearchBar(output.id)
+
+    await expect(
+      page
+        .getByTestId('entity-heading')
+        .getByText('Output ' + output.id.slice(0, 6))
+    ).toBeVisible()
+  })
+
+  test('output can be directly navigated to by id', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v2')
+
+    await explorerApp.goTo('/output/' + output.id)
+
+    await expect(
+      page
+        .getByTestId('entity-heading')
+        .getByText('Output ' + output.id.slice(0, 6))
+    ).toBeVisible()
+  })
+
+  test('output displays the correct data', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v2')
+
+    await explorerApp.goTo('/output/' + output.id)
+
+    await expect(
+      page.getByText(output.siacoinOutput.address.slice(0, 6))
+    ).toBeVisible()
+    await expect(
+      page.getByText(humanSiacoin(output.siacoinOutput.value))
+    ).toBeVisible()
+  })
+
+  test('output can navigate through to an address', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v2')
+
+    await explorerApp.goTo('/output/' + output.id)
+
+    await page.getByText(output.siacoinOutput.address.slice(0, 6)).click()
+
+    await expect(
+      page
+        .getByTestId('entity-heading')
+        .getByText(`Address ${output.siacoinOutput.address.slice(0, 6)}`)
+    ).toBeVisible()
+  })
+})
+
+// V1
+test.describe('v1', () => {
+  test.beforeEach(async ({ page, context }) => {
+    cluster = await startCluster({ context, networkVersion: 'v1' })
+    await renterdWaitForContracts({
+      renterdNode: cluster.daemons.renterds[0].node,
+      hostdCount: cluster.daemons.hostds.length,
+    })
+    await exploredStabilization(cluster)
+    explorerApp = new ExplorerApp(page)
+  })
+
+  test.afterEach(async () => {
+    await teardownCluster()
+  })
+
+  test('output can be searched by id', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v1')
+
+    await explorerApp.goTo('/')
+    await explorerApp.navigateBySearchBar(output.id)
+
+    await expect(
+      page
+        .getByTestId('entity-heading')
+        .getByText('Output ' + output.id.slice(0, 6))
+    ).toBeVisible()
+  })
+
+  test('output can be directly navigated to by id', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v1')
+
+    await explorerApp.goTo('/output/' + output.id)
+
+    await expect(
+      page
+        .getByTestId('entity-heading')
+        .getByText('Output ' + output.id.slice(0, 6))
+    ).toBeVisible()
+  })
+
+  test('output displays the correct data', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v1')
+
+    await explorerApp.goTo('/output/' + output.id)
+
+    await expect(
+      page.getByText(output.siacoinOutput.address.slice(0, 6))
+    ).toBeVisible()
+    await expect(
+      page.getByText(humanSiacoin(output.siacoinOutput.value))
+    ).toBeVisible()
+  })
+
+  test('output can navigate through to an address', async ({ page }) => {
+    const output = await findTestOutput(cluster, 'v1')
+
+    await explorerApp.goTo('/output/' + output.id)
+
+    await page.getByText(output.siacoinOutput.address.slice(0, 6)).click()
+
+    await expect(
+      page
+        .getByTestId('entity-heading')
+        .getByText(`Address ${output.siacoinOutput.address.slice(0, 6)}`)
+    ).toBeVisible()
+  })
+})

--- a/apps/explorer-e2e/src/specs/tx.spec.ts
+++ b/apps/explorer-e2e/src/specs/tx.spec.ts
@@ -78,10 +78,24 @@ test.describe('v2', () => {
     const transactionID = events.data[0].id
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByRole('link', { name: 'SO', exact: true }).first().click()
+    await page.getByText('Address').first().click()
 
     await expect(
       page.getByTestId('entity-heading').getByText('Address')
+    ).toBeVisible()
+  })
+
+  test('transaction can click through to an output', async ({ page }) => {
+    const events = await cluster.daemons.renterds[0].api.walletEvents({
+      params: { limit: 1, offset: 0 },
+    })
+    const transactionID = events.data[0].id
+
+    await explorerApp.goTo('/tx/' + transactionID)
+    await page.getByRole('link', { name: 'SO', exact: true }).first().click()
+
+    await expect(
+      page.getByTestId('entity-heading').getByText('Output')
     ).toBeVisible()
   })
 
@@ -167,10 +181,24 @@ test.describe('v1', () => {
     const transactionID = events.data[0].id
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByRole('link', { name: 'SO', exact: true }).first().click()
+    await page.getByText('Address').first().click()
 
     await expect(
       page.getByTestId('entity-heading').getByText('Address')
+    ).toBeVisible()
+  })
+
+  test('transaction can click through to an output', async ({ page }) => {
+    const events = await cluster.daemons.renterds[0].api.walletEvents({
+      params: { limit: 1, offset: 0 },
+    })
+    const transactionID = events.data[0].id
+
+    await explorerApp.goTo('/tx/' + transactionID)
+    await page.getByRole('link', { name: 'SO', exact: true }).first().click()
+
+    await expect(
+      page.getByTestId('entity-heading').getByText('Output')
     ).toBeVisible()
   })
 

--- a/apps/explorer/app/output/[id]/error.tsx
+++ b/apps/explorer/app/output/[id]/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { StateError } from '../../../components/StateError'
+
+export default function Page({ error }: { error: Error }) {
+  console.error(error)
+  return (
+    <StateError
+      code={500}
+      message="Error, double check the output id and try again."
+    />
+  )
+}

--- a/apps/explorer/app/output/[id]/loading.tsx
+++ b/apps/explorer/app/output/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { OutputSkeleton } from '../../../components/OutputSkeleton'
+
+export default function Loading() {
+  return <OutputSkeleton />
+}

--- a/apps/explorer/app/output/[id]/not-found.tsx
+++ b/apps/explorer/app/output/[id]/not-found.tsx
@@ -1,0 +1,7 @@
+import { StateError } from '../../../components/StateError'
+
+export default function Page() {
+  return (
+    <StateError message="Not found, double check the output id and try again." />
+  )
+}

--- a/apps/explorer/app/output/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/output/[id]/opengraph-image.tsx
@@ -1,0 +1,93 @@
+import { truncate } from '@siafoundation/design-system'
+import { to } from '@siafoundation/request'
+import { humanSiacoin } from '@siafoundation/units'
+
+import { getOGImage } from '../../../components/OGImageEntity'
+import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
+
+export const revalidate = 0
+
+export const alt = 'Output'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+const formatOGImage = (id: string) => {
+  return getOGImage(
+    {
+      id,
+      title: truncate(id, 30),
+      subtitle: 'Output',
+      initials: 'O',
+    },
+    size
+  )
+}
+
+export default async function Image({ params }: ExplorerPageProps) {
+  const id = params.id
+
+  try {
+    const { data: searchResultType } = await getExplored().searchResultType({
+      params: { id },
+    })
+
+    if (!searchResultType) return formatOGImage(id)
+
+    if (searchResultType === 'siacoinElement') {
+      const [output] = await to(getExplored().outputSiacoin({ params: { id } }))
+
+      if (!output) return formatOGImage(id)
+
+      const values = [
+        { label: 'address', value: truncate(output.siacoinOutput.address, 10) },
+        {
+          label: 'sc',
+          value: humanSiacoin(output.siacoinOutput.value),
+        },
+      ]
+
+      return getOGImage(
+        {
+          id,
+          title: truncate(id, 30),
+          subtitle: 'Output',
+          initials: 'O',
+          values,
+        },
+        size
+      )
+    } else if (searchResultType === 'siafundElement') {
+      const [output] = await to(getExplored().outputSiafund({ params: { id } }))
+
+      if (!output) return formatOGImage(id)
+
+      const values = [
+        { label: 'address', value: truncate(output.siafundOutput.address, 10) },
+        {
+          label: 'sf',
+          value: String(output.siafundOutput.value),
+        },
+      ]
+
+      return getOGImage(
+        {
+          id,
+          title: truncate(id, 30),
+          subtitle: 'Output',
+          initials: 'O',
+          values,
+        },
+        size
+      )
+    } else {
+      return formatOGImage(id)
+    }
+  } catch (e) {
+    return formatOGImage(id)
+  }
+}

--- a/apps/explorer/app/output/[id]/page.tsx
+++ b/apps/explorer/app/output/[id]/page.tsx
@@ -1,0 +1,58 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { to } from '@siafoundation/request'
+
+import { Output } from '../../../components/Output'
+import { routes } from '../../../config/routes'
+import { getExplored } from '../../../lib/explored'
+import { ExplorerPageProps } from '../../../lib/pageProps'
+import { buildMetadata } from '../../../lib/utils'
+
+export function generateMetadata({ params }: ExplorerPageProps): Metadata {
+  const id = decodeURIComponent((params?.id as string) || '')
+  const title = `Output ${id}`
+  const description = 'View details for Sia output'
+  const url = routes.output.view.replace(':id', id)
+  return buildMetadata({
+    title,
+    description,
+    url,
+  })
+}
+
+export const revalidate = 0
+
+export default async function Page({ params }: ExplorerPageProps) {
+  const id = params?.id as string
+
+  const { data: searchResultType } = await getExplored().searchResultType({
+    params: { id },
+  })
+
+  if (searchResultType === 'siacoinElement') {
+    const [output, outputError, outputResponse] = await to(
+      getExplored().outputSiacoin({ params: { id } })
+    )
+
+    if (outputError) {
+      if (outputResponse?.status === 404) return notFound()
+      throw outputError
+    }
+
+    return <Output outputElement={output} />
+  } else if (searchResultType === 'siafundElement') {
+    const [output, outputError, outputResponse] = await to(
+      getExplored().outputSiafund({ params: { id } })
+    )
+
+    if (outputError) {
+      if (outputResponse?.status === 404) return notFound()
+      throw outputError
+    }
+
+    return <Output outputElement={output} />
+  } else {
+    return notFound()
+  }
+}

--- a/apps/explorer/components/Layout/Search.tsx
+++ b/apps/explorer/components/Layout/Search.tsx
@@ -1,5 +1,10 @@
 'use client'
 
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+
+import { useForm } from 'react-hook-form'
+
 import {
   Button,
   ConfigFields,
@@ -8,11 +13,9 @@ import {
   triggerErrorToast,
 } from '@siafoundation/design-system'
 import { Search16 } from '@siafoundation/react-icons'
-import React, { useCallback } from 'react'
-import { useRouter } from 'next/navigation'
-import { useForm } from 'react-hook-form'
-import { routes } from '../../config/routes'
 import { to } from '@siafoundation/request'
+
+import { routes } from '../../config/routes'
 import { useExplored } from '../../hooks/useExplored'
 
 const defaultValues = {
@@ -127,6 +130,10 @@ export function Search() {
         case 'transaction':
         case 'v2Transaction':
           router.push(routes.transaction.view.replace(':id', values.query))
+          break
+        case 'siacoinElement':
+        case 'siafundElement':
+          router.push(routes.output.view.replace(':id', values.query))
           break
         case 'invalid':
           form.setError('query', {

--- a/apps/explorer/components/Output/index.tsx
+++ b/apps/explorer/components/Output/index.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useMemo } from 'react'
+import BigNumber from 'bignumber.js'
+
+import {
+  ExplorerSiacoinOutput,
+  ExplorerSiafundOutput,
+} from '@siafoundation/explored-types'
+import { Text } from '@siafoundation/design-system'
+
+import { routes } from '../../config/routes'
+
+import { ContentLayout } from '../ContentLayout'
+import { EntityHeading } from '../EntityHeading'
+import { DatumProps, ExplorerDatum } from '../ExplorerDatum'
+import { ExplorerAccordion } from '../ExplorerAccordion'
+import { ExplorerTextarea } from '../ExplorerTextarea'
+
+type Props = {
+  outputElement: ExplorerSiacoinOutput | ExplorerSiafundOutput
+}
+
+export function Output({ outputElement: output }: Props) {
+  const outputDatums: DatumProps[] = useMemo(() => {
+    if ('siacoinOutput' in output) {
+      return [
+        {
+          label: 'Address',
+          entityType: 'address',
+          entityValue: output.siacoinOutput.address,
+        },
+        { label: 'Value', sc: new BigNumber(output.siacoinOutput.value) },
+        output.spentIndex
+          ? {
+              label: 'Spent block',
+              entityType: 'block',
+              entityValue: output.spentIndex.id,
+              copyable: true,
+            }
+          : {
+              label: 'Spent Block',
+              value: '-',
+              copyable: false,
+            },
+        {
+          label: 'Source',
+          value: <Text>{output.source}</Text>,
+          copyable: false,
+        },
+      ]
+    } else {
+      return [
+        {
+          label: 'Address',
+          entityType: 'address',
+          entityValue: output.siafundOutput.address,
+        },
+        { label: 'Value', sc: new BigNumber(output.siafundOutput.value) },
+        output.spentIndex
+          ? {
+              label: 'Spent block',
+              entityType: 'block',
+              entityValue: output.spentIndex.id,
+              copyable: true,
+            }
+          : {
+              label: 'Spent Block',
+              value: '-',
+              copyable: false,
+            },
+      ]
+    }
+  }, [output])
+
+  return (
+    <ContentLayout
+      panel={
+        <div className="flex flex-col gap-5">
+          <EntityHeading
+            label="output"
+            type="output"
+            value={output.id}
+            href={routes.block.view.replace(':id', output.id)}
+          />
+          <div className="flex flex-col gap-y-2 md:gap-y-4">
+            {outputDatums.map((item) => (
+              <ExplorerDatum key={item.label} {...item} />
+            ))}
+          </div>
+        </div>
+      }
+    >
+      <ExplorerAccordion title="State">
+        <div className="p-2">
+          <ExplorerTextarea
+            value={JSON.stringify(output.stateElement, null, 2)}
+          />
+        </div>
+      </ExplorerAccordion>
+    </ContentLayout>
+  )
+}

--- a/apps/explorer/components/OutputSkeleton/index.tsx
+++ b/apps/explorer/components/OutputSkeleton/index.tsx
@@ -1,0 +1,24 @@
+import { Skeleton, DatumSkeleton, Panel } from '@siafoundation/design-system'
+
+import { ContentLayout } from '../ContentLayout'
+
+export function OutputSkeleton() {
+  return (
+    <ContentLayout
+      panel={
+        <div className="flex flex-col gap-5">
+          <Skeleton className="h-10 w-[300px] text-base/6" />
+          <div className="flex flex-col gap-y-2 md:gap-y-4">
+            {Array.from({ length: 4 }, (_, i) => (
+              <DatumSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      }
+    >
+      <Panel className="p-2">
+        <Skeleton className="h-10 w-[100px] text-base/6" />
+      </Panel>
+    </ContentLayout>
+  )
+}

--- a/apps/explorer/components/Transaction/OutputListItem.tsx
+++ b/apps/explorer/components/Transaction/OutputListItem.tsx
@@ -1,13 +1,18 @@
 'use client'
 
+import BigNumber from 'bignumber.js'
+
 import {
   Link,
+  Text,
   ValueCopyable,
   ValueSc,
   ValueSf,
 } from '@siafoundation/design-system'
+
+import { routes } from '../../config/routes'
+
 import { EntityListItemLayout } from '../Entity/EntityListItemLayout'
-import BigNumber from 'bignumber.js'
 
 type Props = {
   label: string
@@ -20,31 +25,40 @@ type Props = {
 
 export function OutputListItem(props: Props) {
   const { label, outputId, address, addressHref, sc, sf } = props
+  const outputHref = routes.output.view.replace(':id', outputId)
   return (
-    <EntityListItemLayout label={label} href={addressHref}>
+    <EntityListItemLayout label={label} href={outputHref}>
       <div className="flex flex-col items-center gap-1 w-full">
         <div className="flex gap-2 items-center w-full">
-          <Link href={addressHref} weight="medium" underline="hover" ellipsis>
+          <Link href={outputHref} weight="medium" underline="hover" ellipsis>
             {label}
           </Link>
           <div className="flex-1" />
           {sc && <ValueSc variant="value" value={sc} />}
           {sf && <ValueSf variant="value" value={sf} />}
         </div>
-        <div className="flex gap-2 justify-between w-full @container">
-          <ValueCopyable
-            value={outputId}
-            type="output"
-            label={label}
-            color="subtle"
-          />
-          <ValueCopyable
-            value={address}
-            type="address"
-            color="subtle"
-            href={addressHref}
-            className="hidden @sm:flex"
-          />
+        <div className="flex gap-2 justify-between w-full flex-col lg:flex-row">
+          <div className="flex gap-1">
+            <Text>ID:</Text>
+            <ValueCopyable
+              value={outputId}
+              type="output"
+              label={label}
+              color="subtle"
+              href={routes.output.view.replace(':id', outputId)}
+              maxLength={10}
+            />
+          </div>
+          <div className="flex gap-1">
+            <Text>Addr:</Text>
+            <ValueCopyable
+              value={address}
+              type="address"
+              color="subtle"
+              href={addressHref}
+              maxLength={10}
+            />
+          </div>
         </div>
       </div>
     </EntityListItemLayout>

--- a/apps/explorer/components/Transaction/index.tsx
+++ b/apps/explorer/components/Transaction/index.tsx
@@ -52,7 +52,7 @@ export function Transaction({
     const list: OutputItem[] = []
     transaction.siacoinInputs?.forEach((o) => {
       list.push({
-        label: 'siacoin input',
+        label: 'siacoin output',
         addressHref: routes.address.view.replace(
           ':id',
           stripPrefix(
@@ -68,7 +68,7 @@ export function Transaction({
     })
     transaction.siafundInputs?.forEach((o) => {
       list.push({
-        label: 'siafund input',
+        label: 'siafund output',
         addressHref: routes.address.view.replace(
           ':id',
           stripPrefix(

--- a/apps/explorer/config/routes.ts
+++ b/apps/explorer/config/routes.ts
@@ -1,26 +1,29 @@
 export const routes = {
-  home: {
-    index: '/',
-  },
-  contract: {
-    view: '/contract/:id',
-  },
-  transaction: {
-    view: '/tx/:id',
+  address: {
+    view: '/address/:id',
   },
   block: {
     view: '/block/:id',
   },
-  address: {
-    view: '/address/:id',
-  },
-  host: {
-    view: '/host/:id',
+  contract: {
+    view: '/contract/:id',
   },
   faucet: {
     index: '/faucet',
   },
+  home: {
+    index: '/',
+  },
   hostRevenueCalculator: {
     index: '/host-revenue-calculator',
+  },
+  host: {
+    view: '/host/:id',
+  },
+  output: {
+    view: '/output/:id',
+  },
+  transaction: {
+    view: '/tx/:id',
   },
 }


### PR DESCRIPTION
Fairly straightforward. Tests included. There were some minor cascading visual tweaks to the outputs list on the transaction page. Since both the ID and address are now clickable (previously only the output title or icon linked to the address), I added title beside these, for clarity. Those extra characters put some strain on the responsiveness of the ID/hash flex container, so I brought down the number of characters displayed in those copyables and adjusted the layout to stack the ID and address more aggressively at smaller viewport widths, rather than hiding the address entirely.