### PR TITLE
feat(explorer): add maturity height indicator to address page events

### DIFF
--- a/.changeset/ten-maps-film.md
+++ b/.changeset/ten-maps-film.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Added maturity height indicator to address page events.

--- a/apps/explorer/app/address/[id]/page.tsx
+++ b/apps/explorer/app/address/[id]/page.tsx
@@ -29,10 +29,12 @@ export default async function Page({ params }: ExplorerPageProps) {
     [balance, balanceError, balanceResponse],
     { data: unconfirmedEvents },
     { data: unspentOutputs },
+    { data: explorerTip },
   ] = await Promise.all([
     to(getExplored().addressBalance({ params: { address } })),
     getExplored().addressUnconfirmedEvents({ params: { address } }),
     getExplored().addressSiacoinUTXOs({ params: { address } }),
+    getExplored().explorerTip(),
   ])
 
   if (balanceError) {
@@ -43,6 +45,7 @@ export default async function Page({ params }: ExplorerPageProps) {
   return (
     <Address
       id={address}
+      networkHeight={explorerTip.height}
       addressInfo={{
         balance,
         unconfirmedEvents,

--- a/apps/explorer/components/Entity/EntityListItem.tsx
+++ b/apps/explorer/components/Entity/EntityListItem.tsx
@@ -11,7 +11,13 @@ import {
   ValueScFiat,
   ValueSf,
 } from '@siafoundation/design-system'
-import { DotMark16 } from '@siafoundation/react-icons'
+import {
+  ExplorerTransaction,
+  ExplorerV2Transaction,
+  Transaction,
+  V2Transaction,
+} from '@siafoundation/explored-types'
+import { DotMark16, Locked16, Unlocked16 } from '@siafoundation/react-icons'
 import {
   EntityType,
   getEntityTypeLabel,
@@ -23,14 +29,7 @@ import {
 } from '@siafoundation/units'
 
 import LoadingTimestamp from '../LoadingTimestamp'
-
 import { EntityListItemLayout } from './EntityListItemLayout'
-import {
-  ExplorerTransaction,
-  ExplorerV2Transaction,
-  Transaction,
-  V2Transaction,
-} from '@siafoundation/explored-types'
 
 export type EntityListItemProps = {
   label?: string
@@ -45,18 +44,25 @@ export type EntityListItemProps = {
   sf?: number
   scVariant?: 'value' | 'change'
   sfVariant?: 'value' | 'change'
-  height?: number
+  entityHeight?: number
   timestamp?: number
   unconfirmed?: boolean
   siascanUrl?: string
   avatarShape?: 'square' | 'circle'
   avatar?: string
   txPreviewBadge?: React.ReactNode
+  maturityHeight?: number
+  networkHeight?: number
 }
 
 export function EntityListItem(entity: EntityListItemProps) {
   const sc = entity.sc
   const sf = entity.sf
+  const maturityHeight = entity.maturityHeight ?? 0
+  const entityHeight = entity.entityHeight ?? 0
+  const networkHeight = entity.networkHeight ?? 0
+  const isMature = maturityHeight <= networkHeight
+
   const truncHashEl = entity.hash && (
     <ValueCopyable
       value={entity.hash}
@@ -67,6 +73,7 @@ export function EntityListItem(entity: EntityListItemProps) {
       color="subtle"
     />
   )
+
   const label =
     entity.label ||
     (entity.type === 'transaction' &&
@@ -75,75 +82,102 @@ export function EntityListItem(entity: EntityListItemProps) {
     getEntityTypeLabel(entity.type)
 
   const title = isValidUrl(label) ? label : upperFirst(label)
+
   return (
     <EntityListItemLayout {...entity}>
-      <div className="flex flex-col items-center gap-1 w-full min-w-0">
-        <div className="flex gap-2 items-center w-full">
-          <div className="flex gap-2 items-center min-w-0">
-            {entity.height && entity.blockHref && (
-              <Text color="subtle" weight="semibold">
-                <Link href={entity.blockHref} underline="none">
-                  {humanNumber(entity.height)}
-                </Link>
-              </Text>
-            )}
-            {title ? (
-              entity.href ? (
-                <Tooltip content={title}>
-                  <Link
-                    ellipsis
-                    weight="medium"
-                    underline="none"
-                    href={entity.href}
-                  >
-                    {title}
-                  </Link>
-                </Tooltip>
-              ) : (
-                <Tooltip content={title}>
-                  <Text ellipsis weight="medium">
-                    {title}
-                  </Text>
-                </Tooltip>
-              )
-            ) : (
-              <Text ellipsis weight="medium">
-                {truncHashEl}
-              </Text>
-            )}
-          </div>
-          <div className="flex-1" />
-          <div className="flex gap-1">{entity.txPreviewBadge}</div>
-          {(sc || sf) && (
-            <div className="flex items-center">
-              {!!sc && <ValueScFiat variant={entity.scVariant} value={sc} />}
-              {!!sf && <ValueSf variant={entity.sfVariant} value={sf} />}
-            </div>
+      <div className="flex justify-between w-full items-start gap-4 flex-1 min-w-0">
+        <div className="flex flex-col gap-2 min-w-0">
+          {entity.entityHeight && entity.blockHref && (
+            <Text color="subtle" weight="semibold">
+              <Link href={entity.blockHref} underline="none">
+                {humanNumber(entity.entityHeight)}
+              </Link>
+            </Text>
           )}
-        </div>
-        <div className="flex justify-between w-full">
-          <div className="flex gap-1">{!!title && truncHashEl}</div>
-          <div className="flex gap-1 items-center">
-            {entity.unconfirmed ? (
-              <>
-                <Text color="verySubtle">unconfirmed</Text>
-                {entity.timestamp ? (
-                  <Text color="verySubtle">
-                    <DotMark16 className="scale-50" />
-                  </Text>
-                ) : null}
-              </>
-            ) : null}
-            {entity.timestamp && (
-              <LoadingTimestamp className="w-[130px]">
-                <Text color="subtle">
-                  {formatDistance(new Date(entity.timestamp), new Date(), {
-                    addSuffix: true,
-                  })}
+          {title &&
+            (entity.href ? (
+              <Tooltip content={title}>
+                <Link
+                  ellipsis
+                  weight="medium"
+                  underline="none"
+                  href={entity.href}
+                >
+                  {title}
+                </Link>
+              </Tooltip>
+            ) : (
+              <Tooltip content={title}>
+                <Text ellipsis weight="medium">
+                  {title}
                 </Text>
-              </LoadingTimestamp>
+              </Tooltip>
+            ))}
+          {truncHashEl}
+        </div>
+        <div className="flex flex-row gap-4 items-center">
+          <div className="flex flex-col gap-2 items-end">
+            {(sc || sf || entity.txPreviewBadge) && (
+              <div className="flex items-center gap-2">
+                {entity.txPreviewBadge}
+                {!!sc && <ValueScFiat variant={entity.scVariant} value={sc} />}
+                {!!sf && <ValueSf variant={entity.sfVariant} value={sf} />}
+              </div>
             )}
+            <div className="flex gap-1 items-center">
+              {entity.unconfirmed && (
+                <>
+                  <Text color="verySubtle">unconfirmed</Text>
+                  {entity.timestamp && (
+                    <Text color="verySubtle">
+                      <DotMark16 className="scale-50" />
+                    </Text>
+                  )}
+                </>
+              )}
+              {entity.timestamp && (
+                <LoadingTimestamp className="w-[130px]">
+                  <Text color="subtle">
+                    {formatDistance(new Date(entity.timestamp), new Date(), {
+                      addSuffix: true,
+                    })}
+                  </Text>
+                </LoadingTimestamp>
+              )}
+            </div>
           </div>
+          {maturityHeight && entityHeight && networkHeight ? (
+            <Tooltip
+              content={
+                isMature
+                  ? 'The maturity height has been reached.'
+                  : 'The maturity height has not been reached, therefore the output is still locked.'
+              }
+            >
+              <div className="hidden sm:flex flex-col gap-[5px] pl-2 border-l border-gray-600 dark:border-graydark-600 cursor-pointer">
+                <div className="flex justify-end">
+                  <Text
+                    size="12"
+                    font="mono"
+                    ellipsis
+                    color={isMature ? 'green' : 'red'}
+                    className="flex gap-1 items-center"
+                  >
+                    {isMature ? <Unlocked16 /> : <Locked16 />}
+                    {maturityHeight.toLocaleString()}
+                  </Text>
+                </div>
+                <div className="flex justify-between items-end gap-1">
+                  <div className="pl-[8px] pb-[6px]">
+                    <div className="border-l border-b border-gray-800 dark:border-graydark-800 h-[20px] w-[7px]" />
+                  </div>
+                  <Text size="12" font="mono" color="subtle" ellipsis>
+                    {entityHeight.toLocaleString()}
+                  </Text>
+                </div>
+              </div>
+            </Tooltip>
+          ) : null}
         </div>
       </div>
     </EntityListItemLayout>


### PR DESCRIPTION
This one was a bit tricky in terms of placement. I ended up re-writing the flex containers in EntityListItem (before, two rows in flex-col. now, one flex-row row with flex-col containers). Beyond that flex strategy getting rewritten, I decided to place this at the end but with a small border to the left. It disappears at the `sm` breakpoint.

![Screenshot 2025-06-17 at 9.51.24 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/f6149d63-a06b-43ff-9d45-130eaeeb90c0.png)

