### PR TITLE
fix(renterd): file uploads wrong directory on chrome

### DIFF
--- a/.changeset/bitter-impalas-slide.md
+++ b/.changeset/bitter-impalas-slide.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where files uploaded without a containing directory in Chrome would be uploaded inside a directory named "./".

--- a/apps/renterd/contexts/uploadsManager/index.tsx
+++ b/apps/renterd/contexts/uploadsManager/index.tsx
@@ -261,6 +261,14 @@ function useUploadsManagerMain() {
   const uploadFiles = useCallback(
     (files: File[]) => {
       files.forEach((file) => {
+        // When uploading a file vs directory File.path is:
+        // File:
+        // - chrome eg: `./test.txt`
+        // - firefox eg: `/test.txt`
+        // File in a directory:
+        // - chrome eg: `/dir/test.txt`
+        // - firefox eg: `/dir/test.txt`
+
         // @ts-expect-error: https://developer.mozilla.org/en-US/docs/Web/API/File
         // Documentation does not include `path` but all browsers populate it
         // with the relative path of the file. Whereas webkitRelativePath is

--- a/apps/renterd/lib/paths.spec.ts
+++ b/apps/renterd/lib/paths.spec.ts
@@ -16,8 +16,21 @@ describe('paths', () => {
     it('b', () => {
       expect(join('bucket/dir/', '')).toEqual('bucket/dir/')
     })
-    it('b', () => {
+    it('c', () => {
       expect(join('bucket/dir/', '/')).toEqual('bucket/dir/')
+    })
+    it('d', () => {
+      expect(join('bucket/dir/', './path/to/file.txt')).toEqual(
+        'bucket/dir/path/to/file.txt'
+      )
+    })
+    it('e', () => {
+      expect(join('/bucket/dir/', './path/to/file.txt')).toEqual(
+        '/bucket/dir/path/to/file.txt'
+      )
+    })
+    it('f', () => {
+      expect(join('', '/path/to/file.txt')).toEqual('/path/to/file.txt')
     })
   })
 

--- a/apps/renterd/lib/paths.ts
+++ b/apps/renterd/lib/paths.ts
@@ -6,7 +6,11 @@ export type KeyPath = string
 
 export function join(a: string, b: string): FullPath {
   const _a = a.endsWith('/') ? a.slice(0, -1) : a
-  const _b = b.startsWith('/') ? b.slice(1) : b
+  const _b = b.startsWith('/')
+    ? b.slice(1)
+    : b.startsWith('./')
+    ? b.slice(2)
+    : b
   return `${_a}/${_b}`
 }
 


### PR DESCRIPTION
- Fixed an issue where files uploaded without a directory in Chrome would be uploaded inside a directory named "./".