### PR TITLE
fix(renterd): improve uploads experience

### DIFF
--- a/.changeset/rude-sites-attack.md
+++ b/.changeset/rude-sites-attack.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The app is now more stable and responsive when uploading files especially on localhost or http/1.1 and Firefox-based browsers.


### PR DESCRIPTION
- The app is now more stable and responsive when uploading files especially on localhost or http/1.1 and Firefox-based browsers.

## Issues
- Users were experiencing very wonky app behaviour during uploads, the main issue was that multipart uploads were saturating the browsers limit of 6 requests in http/1.1 and this meant other requests such as navigating pages or between directories were being blocked from going through. With bad host contracts this could block further requests almost indefinitely as renterd kept reattempted to upload stalled parts.
- In addition the multipart slot logic appeared to somehow have had slightly different behaviour on Firefox, that was causing additional erroneous requests.

## Fix
- The app now limits the number of concurrent multipart requests based on http version, with a max of 5 on http/1.1.
- The multipart uploader has been refactored with a much clearer loop which has removed the Firefox edge cases.
- The multipart uploader slot/concurrency system is now global spanning all multipart uploads. Previously each upload had its own slots so one upload stalled out on its final part would block all its slots.
- Refactored and added to the tests.

## Manual test

### renterd with lousy contracts
```
2025-06-19T10:43:11-04:00       DEBUG   worker.worker.uploadmanager     sector upload failure was penalised     {"uploadError": "sector upload already finished; failed to upload sector to contract 9eb01e5d51e3411897be0816f33549be086508f77a13f072c571e30c078142bc; failed to write sector: failed to calculate root: stream was gracefully closed", "uploadDuration": "0s", "totalDuration": "8.547291458s", "overdrive": false, "penalty": 85470, "hk": "ed25519:de13e12e37bb3662caeb3a78e7159281aa5c8cf1f160c88792cea393cd4410fc"}
2025-06-19T10:43:17-04:00       DEBUG   worker.worker.uploadmanager     sector upload failure was penalised     {"uploadError": "sector upload already finished; failed to upload sector to contract e617ad43a1d9e121221d820ac5a68d18b0c6ab59b1926e69aec49020e7f956e9; failed to write sector: failed to read response: stream was gracefully closed", "uploadDuration": "0s", "totalDuration": "37.592916625s", "overdrive": false, "penalty": 375920, "hk": "ed25519:91bf3019f428f3affe45dcb10b904e5f4f3f33da368d9316d32b4fe0e4bec223"}
```

### chrome http2
![Screenshot 2025-06-19 at 10.32.43 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/f3d8be1b-82a2-41ce-993b-bc2feeeb25c9.png)

### chrome http1
![Screenshot 2025-06-19 at 10.31.19 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/c4ed4290-d8ed-4d7c-8eb2-2107e1de04ba.png)

### firefox http2
![Screenshot 2025-06-19 at 10.34.15 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/27981287-0bb5-4a65-b128-8939c24e6cd4.png)

### firefox http1
![Screenshot 2025-06-19 at 10.33.33 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/b8e2b86d-0562-4f42-b462-98728bbb0ca3.png)


