### PR TITLE
fix(renterd): transfers bar issues and improvements

### DIFF
--- a/.changeset/sharp-snails-raise.md
+++ b/.changeset/sharp-snails-raise.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the transfers bar active uploads button did not always work.

--- a/.changeset/soft-papayas-hang.md
+++ b/.changeset/soft-papayas-hang.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The transfers bar now lists all buckets with active uploads.

--- a/.changeset/tiny-bobcats-fail.md
+++ b/.changeset/tiny-bobcats-fail.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+The transfers bar now shows the total count across all buckets.

--- a/apps/renterd-e2e/src/specs/uploads.spec.ts
+++ b/apps/renterd-e2e/src/specs/uploads.spec.ts
@@ -34,7 +34,10 @@ test('uploads are shown in the local and all uploads lists', async ({
     'file6.txt': 10,
   })
   await expect(
-    page.getByRole('button', { name: 'Active uploads' })
+    page.getByTestId('docked-controls').getByText('Active uploads')
+  ).toBeVisible()
+  await expect(
+    page.getByTestId('docked-controls').getByText('bucket1')
   ).toBeVisible()
   await changeExplorerMode(page, 'uploads')
   await expect(getUploadRows(page)).toHaveCount(6)

--- a/apps/renterd/components/DockedControls.tsx
+++ b/apps/renterd/components/DockedControls.tsx
@@ -5,7 +5,7 @@ import { EnabledBar } from './EnabledBar'
 
 export function DockedControls({ children }: { children?: React.ReactNode }) {
   return (
-    <div className="flex flex-col gap-2">
+    <div data-testid="docked-controls" className="flex flex-col gap-2">
       {children}
       <TransfersBar />
       <OnboardingBar />

--- a/apps/renterd/components/Files/FilesExplorerModeContextMenu.tsx
+++ b/apps/renterd/components/Files/FilesExplorerModeContextMenu.tsx
@@ -13,7 +13,7 @@ export function FilesExplorerModeContextMenu() {
     setExplorerModeDirectory,
     setExplorerModeFlat,
     isViewingUploads,
-    navigateToUploads,
+    navigateToActiveBucketUploads,
   } = useFilesManager()
 
   return (
@@ -57,7 +57,7 @@ export function FilesExplorerModeContextMenu() {
         </DropdownMenuLeftSlot>
         All files
       </DropdownMenuItem>
-      <DropdownMenuItem onSelect={navigateToUploads}>
+      <DropdownMenuItem onSelect={navigateToActiveBucketUploads}>
         <DropdownMenuLeftSlot>
           <CloudUpload16 />
         </DropdownMenuLeftSlot>

--- a/apps/renterd/components/TransfersBar.tsx
+++ b/apps/renterd/components/TransfersBar.tsx
@@ -1,43 +1,61 @@
-import { Button, AppDockedControl } from '@siafoundation/design-system'
-import { Upload16 } from '@siafoundation/react-icons'
+import {
+  AppDockedControl,
+  Panel,
+  Text,
+  Separator,
+} from '@siafoundation/design-system'
+import { BucketIcon } from '@siafoundation/react-icons'
 import { useFilesManager } from '../contexts/filesManager'
 import { useAppSettings } from '@siafoundation/react-core'
-import { useUploads } from '../contexts/uploads'
+import { routes } from '../config/routes'
+import { Link } from '@siafoundation/next'
+import { useUploadsManager } from '../contexts/uploadsManager'
 
 export function TransfersBar() {
   const { isUnlockedAndAuthedRoute } = useAppSettings()
-  const { isViewingUploads, navigateToUploads } = useFilesManager()
+  const { isViewingUploads, activeBucketName } = useFilesManager()
+  const { bucketsWithUploads, uploadsList } = useUploadsManager()
 
-  const {
-    localUploads: { datasetTotal: uploadsTotal },
-  } = useUploads()
-
-  const isActiveUploads = !!uploadsTotal
+  const activeAndQueuedUploadsCount = uploadsList.length
 
   if (!isUnlockedAndAuthedRoute) {
     return <AppDockedControl />
   }
 
-  if (!isActiveUploads) {
+  if (!activeAndQueuedUploadsCount) {
     return <AppDockedControl />
   }
 
-  if (isViewingUploads) {
+  const bucketWithUploadsIsActiveBucket =
+    bucketsWithUploads.length === 1 &&
+    bucketsWithUploads[0].name === activeBucketName
+
+  if (isViewingUploads && bucketWithUploadsIsActiveBucket) {
     return <AppDockedControl />
   }
 
   return (
     <AppDockedControl>
-      <div className="flex gap-2 justify-center">
-        <Button
-          tip="Uploads list"
-          onClick={navigateToUploads}
-          className="flex gap-1"
-        >
-          <Upload16 className="opacity-50 scale-75 relative top-px" />
-          Active uploads ({uploadsTotal.toLocaleString()})
-        </Button>
-      </div>
+      <Panel className="py-2 px-3">
+        <Text weight="medium" className="flex gap-1 items-center">
+          Active uploads ({activeAndQueuedUploadsCount.toLocaleString()})
+        </Text>
+        <Separator className="my-2" />
+        <div className="flex flex-col gap-1">
+          {bucketsWithUploads.map((bucket) => (
+            <Text key={bucket.name} size="14">
+              <Link
+                key={bucket.name}
+                href={routes.buckets.uploads.replace('[bucket]', bucket.name)}
+                className="flex gap-1 items-center"
+              >
+                <BucketIcon size={14} />
+                {bucket.name}
+              </Link>
+            </Text>
+          ))}
+        </div>
+      </Panel>
     </AppDockedControl>
   )
 }

--- a/apps/renterd/contexts/filesManager/index.tsx
+++ b/apps/renterd/contexts/filesManager/index.tsx
@@ -122,20 +122,21 @@ function useFilesManagerMain() {
     ]
   )
 
-  const uploadsRoute = routes.buckets.uploads.replace(
+  const activeBucketUploadsRoute = routes.buckets.uploads.replace(
     '[bucket]',
     activeBucketName || ''
   )
 
-  const navigateToUploads = useCallback(() => {
+  const navigateToActiveBucketUploads = useCallback(() => {
     if (!activeBucket) {
       return
     }
-    router.push(uploadsRoute)
-  }, [activeBucket, uploadsRoute, router])
+    router.push(activeBucketUploadsRoute)
+  }, [activeBucket, activeBucketUploadsRoute, router])
 
   const pathname = usePathname()
-  const isViewingUploads = activeBucketName && pathname.startsWith(uploadsRoute)
+  const isViewingUploads =
+    activeBucketName && pathname.startsWith(activeBucketUploadsRoute)
 
   const setExplorerModeDirectory = useCallback(async () => {
     if (!isViewingUploads && activeExplorerMode === 'directory') {
@@ -184,7 +185,7 @@ function useFilesManagerMain() {
     activeBucket,
     activeBucketName,
     activeDirectory,
-    navigateToUploads,
+    navigateToActiveBucketUploads,
     setActiveDirectory,
     setActiveDirectoryAndFileNamePrefix,
     activeDirectoryPath,

--- a/apps/renterd/contexts/uploads/useLocalUploads.tsx
+++ b/apps/renterd/contexts/uploads/useLocalUploads.tsx
@@ -9,16 +9,20 @@ import { columns } from './columns'
 import { ObjectUploadData } from '../uploadsManager/types'
 import { Maybe } from '@siafoundation/types'
 import { useUploadsManager } from '../uploadsManager'
+import { useFilesManager } from '../filesManager'
 
 const defaultLimit = 50
 
 export function useLocalUploads() {
   const { uploadsList } = useUploadsManager()
   const { limit, offset } = usePaginationOffset(defaultLimit)
+  const { activeBucket } = useFilesManager()
 
   const datasetPage = useMemo<Maybe<ObjectUploadData[]>>(() => {
-    return uploadsList.slice(offset, offset + limit)
-  }, [uploadsList, offset, limit])
+    return uploadsList
+      .filter((upload) => upload.bucket.name === activeBucket?.name)
+      .slice(offset, offset + limit)
+  }, [uploadsList, offset, limit, activeBucket?.name])
 
   const datasetState = useDatasetState({
     datasetPage,

--- a/apps/renterd/contexts/uploadsManager/index.tsx
+++ b/apps/renterd/contexts/uploadsManager/index.tsx
@@ -409,10 +409,15 @@ function useUploadsManagerMain() {
   // Abort local uploads when the browser tab is closed.
   useWarnActiveUploadsOnClose({ uploadsList })
 
+  const bucketsWithUploads = useMemo(() => {
+    return [...new Set(uploadsList.map((upload) => upload.bucket))]
+  }, [uploadsList])
+
   return {
     uploadFiles,
     uploadsMap,
     uploadsList,
+    bucketsWithUploads,
   }
 }
 

--- a/apps/renterd/lib/multipartUpload.ts
+++ b/apps/renterd/lib/multipartUpload.ts
@@ -234,9 +234,7 @@ export class MultipartUpload {
     // Acquire a slot once for the lifetime of this worker. This guarantees that
     // slots stay with the earliest upload, giving it priority until its queue
     // of parts is empty.
-    console.log('runWorker', 'queue', workerId, this.#key)
     await MultipartUpload.acquireSlot()
-    console.log('runWorker', 'acquired', workerId, this.#key)
 
     try {
       while (!this.#aborted && !this.#completed) {


### PR DESCRIPTION
- Fixed an issue where the transfers bar active uploads button did not always work.
  - It always assumed a single bucket.
- The transfers bar now lists all buckets with active uploads.
- The transfers bar now shows the total count across all buckets.

![Screenshot 2025-06-20 at 12.20.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/8f030586-d963-40d4-8bce-ec2b5337acc5.png)

![Screenshot 2025-06-20 at 12.29.02 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/ce22f5dc-eb19-425a-8867-74a73ba7d3b7.png)

