### PR TITLE
fix(walletd): zen testnet warning text

### DIFF
--- a/.changeset/hungry-starfishes-march.md
+++ b/.changeset/hungry-starfishes-march.md
@@ -1,0 +1,6 @@
+---
+'walletd': patch
+---
+
+Fixed an issue where the testnet warning banner said 'testnet' twice. Closes https://github.com/SiaFoundation/walletd/issues/323
+

--- a/.changeset/light-maps-clean.md
+++ b/.changeset/light-maps-clean.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/types': minor
+---
+
+Added anagami to ConsensusNetwork name.

--- a/apps/walletd/components/WalletdTestnetWarningBanner.tsx
+++ b/apps/walletd/components/WalletdTestnetWarningBanner.tsx
@@ -14,8 +14,5 @@ export function WalletdTestnetWarningBanner() {
     return null
   }
 
-  const testnetName =
-    network.data.name === 'zen' ? 'Zen Testnet' : network.data.name
-
-  return <TestnetWarningBanner testnetName={testnetName} />
+  return <TestnetWarningBanner testnetName={network.data.name} />
 }

--- a/libs/types/src/core.ts
+++ b/libs/types/src/core.ts
@@ -167,7 +167,7 @@ export type ChainIndex = {
 }
 
 export type ConsensusNetwork = {
-  name: 'mainnet' | 'zen'
+  name: 'mainnet' | 'zen' | 'anagami'
   initialCoinbase: Currency
   minimumCoinbase: Currency
   initialTarget: string


### PR DESCRIPTION
### walletd
- Fixed an issue where the testnet warning banner said 'testnet' twice. https://github.com/SiaFoundation/walletd/issues/323
### types
- Added anagami to ConsensusNetwork name.

