### PR TITLE
chore: configure nx implicit go deps

### DIFF
--- a/apps/explorer-e2e/project.json
+++ b/apps/explorer-e2e/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/explorer-e2e/src",
   "projectType": "application",
-  "implicitDependencies": ["explorer"],
+  "implicitDependencies": ["explorer", "cluster"],
   "targets": {
     "build-cluster": {
       "executor": "nx:run-commands",

--- a/apps/hostd-e2e/project.json
+++ b/apps/hostd-e2e/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/hostd-e2e/src",
   "projectType": "application",
-  "implicitDependencies": ["hostd"],
+  "implicitDependencies": ["hostd", "cluster"],
   "targets": {
     "build-cluster": {
       "executor": "nx:run-commands",

--- a/apps/renterd-e2e/project.json
+++ b/apps/renterd-e2e/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/renterd-e2e/src",
   "projectType": "application",
-  "implicitDependencies": ["renterd"],
+  "implicitDependencies": ["renterd", "cluster"],
   "targets": {
     "build-cluster": {
       "executor": "nx:run-commands",

--- a/apps/walletd-e2e/project.json
+++ b/apps/walletd-e2e/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/walletd-e2e/src",
   "projectType": "application",
-  "implicitDependencies": ["walletd"],
+  "implicitDependencies": ["walletd", "cluster"],
   "targets": {
     "build-cluster": {
       "executor": "nx:run-commands",

--- a/internal/cluster/README.md
+++ b/internal/cluster/README.md
@@ -26,47 +26,49 @@ Each node has a unique api address to interact with its respective daemon.
 
 CTRL-C or SIGINT will shut down the cluster and cleanup the resources
 
-### `[GET] /nodes` 
+### `[GET] /nodes`
+
 Lists all running nodes in the cluster
 
 **Response Body**
+
 ```json
 [
-        {
-                "id": "facaba60da2e71bb",
-                "type": "renterd",
-                "apiAddress": "http://[::]:53873/api",
-                "password": "sia is cool",
-                "walletAddress": "addr:1ca3bfe60a50fe3e700a67fae7c9670446849a0177b0da0378399c6d6ca9cb13dfcb3d084c2d"
-        },
-        {
-                "id": "eabf85c452cf4bca",
-                "type": "walletd",
-                "apiAddress": "http://[::]:53874/api",
-                "password": "sia is cool",
-                "walletAddress": "addr:000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"
-        },
-        {
-                "id": "1c01bc97b794c8d7",
-                "type": "hostd",
-                "apiAddress": "http://[::]:53864/api",
-                "password": "sia is cool",
-                "walletAddress": "addr:862b5ca325b4c77ffe861a892e65f48bbcb43f2287b2dfe8d7c70459659f7367a2ffbcf62de9"
-        },
-        {
-                "id": "31b3a65f8a1842d2",
-                "type": "hostd",
-                "apiAddress": "http://[::]:53867/api",
-                "password": "sia is cool",
-                "walletAddress": "addr:b906d603430c7e814a107910d8029f931da96a6f2afef6e6dfa93b488e9b337ae29d9f195d23"
-        },
-        {
-                "id": "712e5c22050c0700",
-                "type": "hostd",
-                "apiAddress": "http://[::]:53870/api",
-                "password": "sia is cool",
-                "walletAddress": "addr:42fd84ddb08a96105c41b31414913a1a3e09a94046d8444f65398e9b96a814a7708027a323f7"
-        }
+  {
+    "id": "facaba60da2e71bb",
+    "type": "renterd",
+    "apiAddress": "http://[::]:53873/api",
+    "password": "sia is cool",
+    "walletAddress": "addr:1ca3bfe60a50fe3e700a67fae7c9670446849a0177b0da0378399c6d6ca9cb13dfcb3d084c2d"
+  },
+  {
+    "id": "eabf85c452cf4bca",
+    "type": "walletd",
+    "apiAddress": "http://[::]:53874/api",
+    "password": "sia is cool",
+    "walletAddress": "addr:000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"
+  },
+  {
+    "id": "1c01bc97b794c8d7",
+    "type": "hostd",
+    "apiAddress": "http://[::]:53864/api",
+    "password": "sia is cool",
+    "walletAddress": "addr:862b5ca325b4c77ffe861a892e65f48bbcb43f2287b2dfe8d7c70459659f7367a2ffbcf62de9"
+  },
+  {
+    "id": "31b3a65f8a1842d2",
+    "type": "hostd",
+    "apiAddress": "http://[::]:53867/api",
+    "password": "sia is cool",
+    "walletAddress": "addr:b906d603430c7e814a107910d8029f931da96a6f2afef6e6dfa93b488e9b337ae29d9f195d23"
+  },
+  {
+    "id": "712e5c22050c0700",
+    "type": "hostd",
+    "apiAddress": "http://[::]:53870/api",
+    "password": "sia is cool",
+    "walletAddress": "addr:42fd84ddb08a96105c41b31414913a1a3e09a94046d8444f65398e9b96a814a7708027a323f7"
+  }
 ]
 ```
 
@@ -77,6 +79,7 @@ Any API request may be proxied through the cluster to all nodes matching the fil
 For example, to get the tip of all `hostd` nodes in the cluster you can make a request to `[GET] /nodes/proxy/hostd/api/consensus/tip`. Auth is handled automatically and the response from every node is returned.
 
 **Response:**
+
 ```json
 [
   {
@@ -130,13 +133,14 @@ For example, to get the tip of all `hostd` nodes in the cluster you can make a r
 ]
 ```
 
-### `POST /mine` 
+### `POST /mine`
 
 Mines a preset number of blocks on the testnet
 
 **Request Body**
+
 ```json
 {
-	"blocks": 10
+  "blocks": 10
 }
 ```

--- a/internal/cluster/project.json
+++ b/internal/cluster/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "cluster",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "internal/cluster",
+  "projectType": "library",
+  "targets": {}
+}


### PR DESCRIPTION
- Adds internal/cluster as an nx project named "cluster" by adding project.json.
- Adds "cluster" as an implicit dependency of all e2e projects. This makes all e2e projects `affected` when cluster source files are modified.