### PR TITLE
fix(explorer): improve host ranking accuracy and consistency

### DIFF
--- a/.changeset/khaki-walls-cough.md
+++ b/.changeset/khaki-walls-cough.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Fixed errors in top hosts ranking.


### PR DESCRIPTION
I've seen some results in this top hosts list that have surprised me, and so I looked into this more and realized there were likely a couple of errors in this calculation around knownSince and sectors vs bytes v2 vs. v1. 

While here, I also created a confidence weighting that considers hosts with less than 10 scans to be weaker and also tried to clarify error messages, in case they crop up.

Before:

![Screenshot 2025-06-25 at 12.51.42 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/48e80e81-1f44-4f8a-b621-44049693d6d2.png)

After:

![Screenshot 2025-06-25 at 12.51.55 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/uN70g1DQ5YQEeblFjgZt/519f9f6d-5f59-42a3-92bd-e7e7b93d52c3.png)

