### PR TITLE
fix(hostd): ignore rejected start height 0 in timeline range

### DIFF
--- a/.changeset/eighty-wolves-protect.md
+++ b/.changeset/eighty-wolves-protect.md
@@ -1,0 +1,6 @@
+---
+'hostd': patch
+'renterd': patch
+---
+
+Fixed an issue where contract timelines would start from 0 when the dataset included a rejected contract. Closes https://github.com/SiaFoundation/hostd/issues/717

--- a/.changeset/plenty-beers-cry.md
+++ b/.changeset/plenty-beers-cry.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+getContractsTimeRangeBlockHeight now ignores start heights of 0.

--- a/libs/design-system/src/lib/contracts.ts
+++ b/libs/design-system/src/lib/contracts.ts
@@ -15,9 +15,11 @@ export function getContractsTimeRangeBlockHeight(
     (acc, item) => {
       let accStartHeight = acc.startHeight
       let accEndHeight = acc.endHeight
-      // let end = acc.end
 
-      if (item.contractHeightStart < accStartHeight) {
+      if (
+        item.contractHeightStart > 0 &&
+        item.contractHeightStart < accStartHeight
+      ) {
         accStartHeight = item.contractHeightStart
       }
       if (item.contractHeightEnd > accEndHeight) {
@@ -34,11 +36,11 @@ export function getContractsTimeRangeBlockHeight(
     }
   )
 
-  // pad it out, also gives space for 1 day proof window
+  // Pad it out, also gives space for 1 day proof window.
   range.endHeight = Math.max(range.endHeight, currentHeight) + daysToBlocks(5)
   range.startHeight = range.startHeight - daysToBlocks(5)
 
-  // calculate points with timestamps for graphing
+  // Calculate points with timestamps for graphing.
   const allDates: number[] = []
 
   let current = range.startHeight


### PR DESCRIPTION
- Fixed an issue where contract timelines would start from 0 when the dataset included a rejected contract. https://github.com/SiaFoundation/hostd/issues/717
- getContractsTimeRangeBlockHeight now ignores start heights of 0.

### before

![Screenshot 2025-06-26 at 10.06.32 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/3eb8615d-0ccb-4714-aee5-b016dc4906bb.png)

### after

![Screenshot 2025-06-26 at 10.06.45 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/0569d971-2163-4620-867b-5a13ffcf93d8.png)

