### PR TITLE
fix(explorer): move outputs into main route group

### DIFF
--- a/apps/explorer/app/(main)/output/[id]/error.tsx
+++ b/apps/explorer/app/(main)/output/[id]/error.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { StateError } from '../../../components/StateError'
+import { StateError } from '../../../../components/StateError'
 
 export default function Page({ error }: { error: Error }) {
   console.error(error)

--- a/apps/explorer/app/(main)/output/[id]/loading.tsx
+++ b/apps/explorer/app/(main)/output/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { OutputSkeleton } from '../../../../components/OutputSkeleton'
+
+export default function Loading() {
+  return <OutputSkeleton />
+}

--- a/apps/explorer/app/(main)/output/[id]/not-found.tsx
+++ b/apps/explorer/app/(main)/output/[id]/not-found.tsx
@@ -1,4 +1,4 @@
-import { StateError } from '../../../components/StateError'
+import { StateError } from '../../../../components/StateError'
 
 export default function Page() {
   return (

--- a/apps/explorer/app/(main)/output/[id]/opengraph-image.tsx
+++ b/apps/explorer/app/(main)/output/[id]/opengraph-image.tsx
@@ -2,9 +2,9 @@ import { truncate } from '@siafoundation/design-system'
 import { to } from '@siafoundation/request'
 import { humanSiacoin } from '@siafoundation/units'
 
-import { getOGImage } from '../../../components/OGImageEntity'
-import { getExplored } from '../../../lib/explored'
-import { ExplorerPageProps } from '../../../lib/pageProps'
+import { getOGImage } from '../../../../components/OGImageEntity'
+import { getExplored } from '../../../../lib/explored'
+import { ExplorerPageProps } from '../../../../lib/pageProps'
 
 export const revalidate = 0
 

--- a/apps/explorer/app/(main)/output/[id]/page.tsx
+++ b/apps/explorer/app/(main)/output/[id]/page.tsx
@@ -3,11 +3,11 @@ import { notFound } from 'next/navigation'
 
 import { to } from '@siafoundation/request'
 
-import { Output } from '../../../components/Output'
-import { routes } from '../../../config/routes'
-import { getExplored } from '../../../lib/explored'
-import { ExplorerPageProps } from '../../../lib/pageProps'
-import { buildMetadata } from '../../../lib/utils'
+import { Output } from '../../../../components/Output'
+import { routes } from '../../../../config/routes'
+import { getExplored } from '../../../../lib/explored'
+import { ExplorerPageProps } from '../../../../lib/pageProps'
+import { buildMetadata } from '../../../../lib/utils'
 
 export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')

--- a/apps/explorer/app/output/[id]/loading.tsx
+++ b/apps/explorer/app/output/[id]/loading.tsx
@@ -1,5 +1,0 @@
-import { OutputSkeleton } from '../../../components/OutputSkeleton'
-
-export default function Loading() {
-  return <OutputSkeleton />
-}


### PR DESCRIPTION
- Missed output when adding the two layout route groups.