### PR TITLE
fix(apps): align txn types

### DIFF
--- a/.changeset/eighty-rocks-hide.md
+++ b/.changeset/eighty-rocks-hide.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/types': minor
+---
+
+Refined naming of V2FileContractResolution types.

--- a/.changeset/hot-items-divide.md
+++ b/.changeset/hot-items-divide.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/units': minor
+---
+
+Added support for the arbitrary data event type.

--- a/.changeset/old-gorillas-shout.md
+++ b/.changeset/old-gorillas-shout.md
@@ -1,0 +1,9 @@
+---
+'explorer': minor
+'@siafoundation/units': minor
+'hostd': minor
+'renterd': minor
+'walletd': minor
+---
+
+Added support for the contract refresh event type. Closes https://github.com/SiaFoundation/hostd/issues/759

--- a/.changeset/quick-avocados-accept.md
+++ b/.changeset/quick-avocados-accept.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/types': patch
+---
+
+Fixed an issue with the ContractResolution type.

--- a/.changeset/witty-coats-tickle.md
+++ b/.changeset/witty-coats-tickle.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/explored-types': patch
+---
+
+Fixed v1 ExplorerTransaction arbitraryData type.

--- a/.changeset/witty-peas-remember.md
+++ b/.changeset/witty-peas-remember.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+Transaction headers now show a badge with the specific type.

--- a/apps/explorer/app/(main)/tx/[id]/page.tsx
+++ b/apps/explorer/app/(main)/tx/[id]/page.tsx
@@ -7,6 +7,11 @@ import { stripPrefix, truncate } from '@siafoundation/design-system'
 import { getExplored } from '../../../../lib/explored'
 import { to } from '@siafoundation/request'
 import { ExplorerPageProps } from '../../../../lib/pageProps'
+import {
+  getV1TransactionType,
+  getV2TransactionType,
+} from '@siafoundation/units'
+import { explorerV2TransactionToGetV2TransactionTypeParam } from '../../../../lib/tx'
 
 export function generateMetadata({ params }: ExplorerPageProps): Metadata {
   const id = decodeURIComponent((params?.id as string) || '')
@@ -52,6 +57,7 @@ export default async function Page({ params }: ExplorerPageProps) {
     })
     return (
       <Transaction
+        txType={getV1TransactionType(transaction)}
         transaction={transaction}
         transactionHeaderData={{
           id: stripPrefix(transaction.id),
@@ -84,6 +90,9 @@ export default async function Page({ params }: ExplorerPageProps) {
     })
     return (
       <Transaction
+        txType={getV2TransactionType(
+          explorerV2TransactionToGetV2TransactionTypeParam(transaction)
+        )}
         transaction={transaction}
         transactionHeaderData={{
           id: stripPrefix(transaction.id),

--- a/apps/explorer/components/Block/index.tsx
+++ b/apps/explorer/components/Block/index.tsx
@@ -8,7 +8,12 @@ import {
   Text,
 } from '@siafoundation/design-system'
 import { ExplorerBlock } from '@siafoundation/explored-types'
-import { humanDate, humanNumber } from '@siafoundation/units'
+import {
+  getV1TransactionType,
+  getV2TransactionType,
+  humanDate,
+  humanNumber,
+} from '@siafoundation/units'
 import { ArrowLeft16, ArrowRight16 } from '@siafoundation/react-icons'
 
 import { routes } from '../../config/routes'
@@ -20,11 +25,8 @@ import { EntityHeading } from '../EntityHeading'
 import { ContentLayout } from '../ContentLayout'
 import { ExplorerAccordion } from '../ExplorerAccordion'
 import { ExplorerTextarea } from '../ExplorerTextarea'
-import {
-  getExplorerV1TxPreviewBadge,
-  getExplorerV2TxPreviewBadge,
-} from '../Entity/EntityListItem'
 import LoadingTimestamp from '../LoadingTimestamp'
+import { explorerV2TransactionToGetV2TransactionTypeParam } from '../../lib/tx'
 
 type Props = {
   block: ExplorerBlock
@@ -158,7 +160,9 @@ export function Block({ block, blockID, currentHeight }: Props) {
                 label: 'transaction',
                 initials: 'T',
                 href: routes.transaction.view.replace(':id', txID),
-                txPreviewBadge: getExplorerV2TxPreviewBadge(tx),
+                txType: getV2TransactionType(
+                  explorerV2TransactionToGetV2TransactionTypeParam(tx)
+                ),
               }
             })}
           />
@@ -179,7 +183,7 @@ export function Block({ block, blockID, currentHeight }: Props) {
                 label: 'transaction',
                 initials: 'T',
                 href: routes.transaction.view.replace(':id', txID),
-                txPreviewBadge: getExplorerV1TxPreviewBadge(tx),
+                txType: getV1TransactionType(tx),
               }
             })}
           />

--- a/apps/explorer/components/ContractView/index.tsx
+++ b/apps/explorer/components/ContractView/index.tsx
@@ -44,7 +44,7 @@ export function ContractView({
       </Container>
       {formationTransaction && formationTransactionHeaderData ? (
         <Transaction
-          title="Formation"
+          txType="contractFormation"
           transaction={formationTransaction}
           transactionHeaderData={formationTransactionHeaderData}
         />

--- a/apps/explorer/components/Entity/EntityListItem.tsx
+++ b/apps/explorer/components/Entity/EntityListItem.tsx
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { formatDistance } from 'date-fns'
 import { upperFirst } from '@technically/lodash'
-
 import {
   Badge,
   Link,
@@ -11,23 +10,14 @@ import {
   ValueScFiat,
   ValueSf,
 } from '@siafoundation/design-system'
-import {
-  ExplorerTransaction,
-  ExplorerV2Transaction,
-  Transaction,
-  V2Transaction,
-} from '@siafoundation/explored-types'
 import { DotMark16, Locked16, Unlocked16 } from '@siafoundation/react-icons'
 import {
   EntityType,
   getEntityTypeLabel,
-  getTransactionType,
   getTxTypeLabel,
-  getV2TransactionType,
   humanNumber,
   TxType,
 } from '@siafoundation/units'
-
 import LoadingTimestamp from '../LoadingTimestamp'
 import { EntityListItemLayout } from './EntityListItemLayout'
 
@@ -50,7 +40,6 @@ export type EntityListItemProps = {
   siascanUrl?: string
   avatarShape?: 'square' | 'circle'
   avatar?: string
-  txPreviewBadge?: React.ReactNode
   maturityHeight?: number
   networkHeight?: number
 }
@@ -117,9 +106,13 @@ export function EntityListItem(entity: EntityListItemProps) {
         </div>
         <div className="flex flex-row gap-4 items-center">
           <div className="flex flex-col gap-2 items-end">
-            {(sc || sf || entity.txPreviewBadge) && (
+            {(sc || sf || entity.txType) && (
               <div className="flex items-center gap-2">
-                {entity.txPreviewBadge}
+                {entity.txType && (
+                  <Badge variant={getExplorerTxTypeBadgeVariant(entity.txType)}>
+                    {getTxTypeLabel(entity.txType)}
+                  </Badge>
+                )}
                 {!!sc && <ValueScFiat variant={entity.scVariant} value={sc} />}
                 {!!sf && <ValueSf variant={entity.sfVariant} value={sf} />}
               </div>
@@ -196,55 +189,14 @@ function isValidUrl(url?: string) {
   }
 }
 
-export function getExplorerV2TxPreviewBadge(
-  tx: ExplorerV2Transaction
-): React.ReactNode {
-  // This won't work for resolution types, returning undefined.
-  let txType = getV2TransactionType(tx as V2Transaction)
-
-  // Handle the above comment.
-  if (!txType) {
-    if (tx.fileContractResolutions?.[0]) {
-      txType =
-        tx.fileContractResolutions?.[0].type === 'expiration'
-          ? 'contractExpiration'
-          : tx.fileContractResolutions?.[0].type === 'renewal'
-          ? 'contractRenewal'
-          : 'storageProof'
-    }
+export function getExplorerTxTypeBadgeVariant(txType: TxType) {
+  if (txType === 'arbitraryData') {
+    return 'simple'
   }
 
-  if (txType === 'unknown') {
-    if (tx.arbitraryData?.length)
-      return <Badge variant="simple">arbitrary data</Badge>
+  if (txType === 'siacoin' || txType === 'siafund') {
+    return 'gray'
   }
 
-  if (txType === 'siacoin' || txType === 'siafund')
-    return (
-      <Badge variant="gray">
-        <Text color="none">{getTxTypeLabel(txType)}</Text>
-      </Badge>
-    )
-
-  return <Badge variant="accent">{getTxTypeLabel(txType)}</Badge>
-}
-
-export function getExplorerV1TxPreviewBadge(
-  tx: ExplorerTransaction
-): React.ReactNode {
-  const txType = getTransactionType(tx as Transaction)
-
-  if (txType === 'unknown') {
-    if (tx.arbitraryData?.length)
-      return <Badge variant="simple">arbitrary data</Badge>
-  }
-
-  if (txType === 'siacoin' || txType === 'siafund')
-    return (
-      <Badge variant="gray">
-        <Text color="subtle">{getTxTypeLabel(txType)}</Text>
-      </Badge>
-    )
-
-  return <Badge variant="accent">{getTxTypeLabel(txType)}</Badge>
+  return 'accent'
 }

--- a/apps/explorer/components/Transaction/TransactionHeader.tsx
+++ b/apps/explorer/components/Transaction/TransactionHeader.tsx
@@ -1,5 +1,5 @@
 import { Badge, Text, Tooltip } from '@siafoundation/design-system'
-import { humanDate } from '@siafoundation/units'
+import { getTxTypeLabel, humanDate, TxType } from '@siafoundation/units'
 import { routes } from '../../config/routes'
 import { EntityHeading } from '../EntityHeading'
 import LoadingTimestamp from '../LoadingTimestamp'
@@ -15,24 +15,29 @@ export type TransactionHeaderData = {
 type Props = {
   title?: string
   transactionHeaderData: TransactionHeaderData
+  txType?: TxType
 }
 
-export function TransactionHeader({ title, transactionHeaderData }: Props) {
+export function TransactionHeader({
+  title,
+  transactionHeaderData,
+  txType,
+}: Props) {
   const { id, timestamp, blockHeight, confirmations, version } =
     transactionHeaderData
   return (
-    <div className="flex flex-wrap gap-y-4 items-center justify-between">
-      <EntityHeading
-        label={title || 'Transaction'}
-        type="transaction"
-        value={id}
-        href={routes.transaction.view.replace(':id', id)}
-      />
-      <div className="flex gap-4 items-center overflow-hidden">
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap gap-y-4 items-center justify-between">
+        <EntityHeading
+          label={title || 'Transaction'}
+          type="transaction"
+          value={id}
+          href={routes.transaction.view.replace(':id', id)}
+        />
         {!!timestamp && (
           <LoadingTimestamp>
             <Tooltip content={timestamp}>
-              <Text font="mono" color="subtle" ellipsis>
+              <Text size="18" font="mono" color="subtle" ellipsis>
                 {humanDate(timestamp, {
                   dateStyle: 'medium',
                   timeStyle: 'short',
@@ -41,24 +46,31 @@ export function TransactionHeader({ title, transactionHeaderData }: Props) {
             </Tooltip>
           </LoadingTimestamp>
         )}
-        {!!blockHeight && (
-          <Badge variant="accent">
-            <div className="flex gap-2">
-              <Tooltip content="Block height">
-                <div className="">{blockHeight.toLocaleString()}</div>
-              </Tooltip>
-              <div className="">|</div>
-              <div className="">
-                {confirmations >= 72 ? '72+' : confirmations} confirmations
+      </div>
+      <div className="flex flex-wrap justify-between gap-2">
+        <div className="flex flex-wrap gap-2">
+          {txType && <Badge variant="accent">{getTxTypeLabel(txType)}</Badge>}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {!!blockHeight && (
+            <Badge variant="accent">
+              <div className="flex gap-2">
+                <Tooltip content="Block height">
+                  <div className="">{blockHeight.toLocaleString()}</div>
+                </Tooltip>
+                <div className="">|</div>
+                <div className="">
+                  {confirmations >= 72 ? '72+' : confirmations} confirmations
+                </div>
               </div>
-            </div>
-          </Badge>
-        )}
-        <Tooltip content={'transaction version'}>
-          <Badge variant="simple" data-testid="explorer-transaction-version">
-            {version}
-          </Badge>
-        </Tooltip>
+            </Badge>
+          )}
+          <Tooltip content={'transaction version'}>
+            <Badge variant="simple" data-testid="explorer-transaction-version">
+              {version}
+            </Badge>
+          </Tooltip>
+        </div>
       </div>
     </div>
   )

--- a/apps/explorer/components/Transaction/index.tsx
+++ b/apps/explorer/components/Transaction/index.tsx
@@ -10,7 +10,7 @@ import {
   ExplorerV2Transaction,
   V2FileContractRevision,
 } from '@siafoundation/explored-types'
-import { EntityType } from '@siafoundation/units'
+import { EntityType, TxType } from '@siafoundation/units'
 
 import { routes } from '../../config/routes'
 import { contractResolutionLabels } from '../../lib/contracts'
@@ -28,7 +28,7 @@ import { OutputListItem } from './OutputListItem'
 type Props = {
   transactionHeaderData: TransactionHeaderData
   transaction: ExplorerTransaction | ExplorerV2Transaction
-  title?: string
+  txType?: TxType
 }
 
 type OutputItem = {
@@ -41,8 +41,8 @@ type OutputItem = {
 }
 
 export function Transaction({
-  title,
   transaction,
+  txType,
   transactionHeaderData,
 }: Props) {
   const inputs = useMemo(() => {
@@ -229,10 +229,7 @@ export function Transaction({
       <ContentLayout
         panel={
           <div className="flex flex-col gap-16">
-            <TransactionHeader
-              title={title}
-              transactionHeaderData={transactionHeaderData}
-            />
+            <TransactionHeader transactionHeaderData={transactionHeaderData} />
           </div>
         }
       >
@@ -253,7 +250,7 @@ export function Transaction({
       panel={
         <div className="flex flex-col gap-16">
           <TransactionHeader
-            title={title}
+            txType={txType}
             transactionHeaderData={transactionHeaderData}
           />
         </div>

--- a/libs/explored-types/src/types.ts
+++ b/libs/explored-types/src/types.ts
@@ -333,7 +333,7 @@ export type ExplorerTransaction = {
   fileContractRevisions?: ExplorerFileContractRevision[]
   storageProofs?: StorageProof[]
   minerFees?: Currency
-  arbitraryData?: string[][]
+  arbitraryData?: string[]
   signatures?: TransactionSignature[]
   hostAnnouncements?: HostAnnouncement[]
 }

--- a/libs/types/src/events.ts
+++ b/libs/types/src/events.ts
@@ -7,7 +7,7 @@ import {
   Hash256,
   Address,
 } from './core'
-import { V2Transaction, V2FileContractResolutionType } from './v2'
+import { V2Transaction, V2FileContractResolution } from './v2'
 
 export type UnconfirmedChainIndex = {
   height: number
@@ -47,7 +47,7 @@ export type WalletEventContractResolutionV1 = WalletEventBase & {
 export type WalletEventContractResolutionV2 = WalletEventBase & {
   type: 'v2ContractResolution'
   data: {
-    resolution: V2FileContractResolutionType
+    resolution: V2FileContractResolution
     siacoinElement: SiacoinElement
     missed: boolean
   }

--- a/libs/types/src/v2.ts
+++ b/libs/types/src/v2.ts
@@ -58,11 +58,6 @@ export type V2FileContract = {
   hostSignature?: Signature
 }
 
-export type V2FileContractResolution = {
-  parent: V2FileContractElement
-  resolution: V2FileContractResolutionType
-}
-
 export type V2FileContractRenewal = {
   finalRevision: V2FileContract
   initialRevision: V2FileContract
@@ -118,37 +113,36 @@ export type ChainIndexElement = {
   chainIndex: ChainIndex
 }
 
-type V2FileContractResolutionTypeBase = {
+type V2FileContractResolutionBase = {
   parent: V2FileContractElement
 }
 
-export type V2FileContractResolutionTypeExpiration =
-  V2FileContractResolutionTypeBase & {
+export type V2FileContractResolutionExpiration =
+  V2FileContractResolutionBase & {
     type: 'expiration'
     resolution: Record<string, never> // is this always empty for expiration type?
   }
-export type V2FileContractResolutionTypeFinalization =
-  V2FileContractResolutionTypeBase & {
+export type V2FileContractResolutionFinalization =
+  V2FileContractResolutionBase & {
     type: 'finalization'
     resolution: V2FileContract
   }
 
-export type V2FileContractResolutionTypeRenewal =
-  V2FileContractResolutionTypeBase & {
-    type: 'renewal'
-    resolution: {
-      finalRevision: V2FileContract
-      newContract: V2FileContract
-      renterRollover: Currency
-      hostRollover: Currency
-      renterSignature: Signature
-      hostSignature: Signature
-    }
+export type V2FileContractResolutionRenewal = V2FileContractResolutionBase & {
+  type: 'renewal'
+  resolution: {
+    finalRevision: V2FileContract
+    newContract: V2FileContract
+    renterRollover: Currency
+    hostRollover: Currency
+    renterSignature: Signature
+    hostSignature: Signature
   }
+}
 
 export type V2FileContractResolutionDataStorageProof =
-  V2FileContractResolutionTypeBase & {
-    type: 'storage proof'
+  V2FileContractResolutionBase & {
+    type: 'storageProof'
     resolution: {
       proofIndex: ChainIndexElement
       leaf: string
@@ -156,8 +150,8 @@ export type V2FileContractResolutionDataStorageProof =
     }
   }
 
-export type V2FileContractResolutionType =
-  | V2FileContractResolutionTypeExpiration
-  | V2FileContractResolutionTypeFinalization
-  | V2FileContractResolutionTypeRenewal
+export type V2FileContractResolution =
+  | V2FileContractResolutionExpiration
+  | V2FileContractResolutionFinalization
+  | V2FileContractResolutionRenewal
   | V2FileContractResolutionDataStorageProof

--- a/libs/units/src/events.ts
+++ b/libs/units/src/events.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import { WalletEvent } from '@siafoundation/types'
 import {
   TxType,
-  getTransactionType,
+  getV1TransactionType,
   getV2TransactionType,
 } from './transactionTypes'
 
@@ -28,7 +28,7 @@ export function getEventContractId(e: WalletEvent) {
 export function getEventTxType(e: WalletEvent): TxType {
   const eventType = e.type
   if (eventType === 'v1Transaction') {
-    return getTransactionType(e.data.transaction)
+    return getV1TransactionType(e.data.transaction)
   }
   if (eventType === 'v2Transaction') {
     return getV2TransactionType(e.data)

--- a/libs/units/src/transactionTypes.ts
+++ b/libs/units/src/transactionTypes.ts
@@ -1,8 +1,4 @@
-import {
-  Transaction,
-  V2FileContractResolutionType,
-  V2Transaction,
-} from '@siafoundation/types'
+import { V2FileContractResolution } from '@siafoundation/types'
 
 export type TxType =
   | 'siacoin'
@@ -11,6 +7,7 @@ export type TxType =
   | 'contractFormation'
   | 'contractRevision'
   | 'contractRenewal'
+  | 'contractRefresh'
   | 'contractExpiration'
   | 'contractFinalization'
   | 'contractPayout'
@@ -18,9 +15,19 @@ export type TxType =
   | 'siafundClaim'
   | 'foundationSubsidy'
   | 'hostAnnouncement'
+  | 'arbitraryData'
   | 'unknown'
 
-export function getTransactionType(txn: Transaction): TxType {
+export function getV1TransactionType(txn: {
+  storageProofs?: unknown[]
+  fileContracts?: unknown[]
+  fileContractRevisions?: unknown[]
+  siacoinInputs?: unknown[]
+  siafundInputs?: unknown[]
+  siacoinOutputs?: unknown[]
+  siafundOutputs?: unknown[]
+  arbitraryData?: string[]
+}): TxType {
   if (txn.storageProofs && txn.storageProofs.length > 0) {
     return 'storageProof'
   }
@@ -55,15 +62,64 @@ export function getTransactionType(txn: Transaction): TxType {
   return 'unknown'
 }
 
-export function getV2TransactionType(txn: V2Transaction): TxType {
+export function getV2TransactionType(txn: {
+  siafundOutputs?: unknown[]
+  siacoinOutputs?: unknown[]
+  fileContracts?: unknown[]
+  arbitraryData?: Uint8Array
+  fileContractResolutions?:
+    | (
+        | {
+            type: 'renewal'
+            parent: {
+              v2FileContract: {
+                proofHeight: number
+                expirationHeight: number
+              }
+            }
+            resolution: {
+              newContract: {
+                proofHeight: number
+                expirationHeight: number
+              }
+            }
+          }
+        | {
+            type: 'expiration' | 'finalization' | 'storageProof'
+          }
+      )[]
+  fileContractRevisions?: {
+    parent: {
+      v2FileContract: {
+        proofHeight: number
+        expirationHeight: number
+      }
+    }
+    revision: {
+      proofHeight: number
+      expirationHeight: number
+    }
+  }[]
+  attestations?: {
+    key: string
+  }[]
+}): TxType {
   if (txn.fileContractResolutions && txn.fileContractResolutions.length > 0) {
-    const mapping: Record<V2FileContractResolutionType['type'], TxType> = {
+    const mapping: Record<V2FileContractResolution['type'], TxType> = {
       expiration: 'contractExpiration',
       finalization: 'contractFinalization',
       renewal: 'contractRenewal',
-      'storage proof': 'storageProof',
+      storageProof: 'storageProof',
     }
-    return mapping[txn.fileContractResolutions[0].resolution.type]
+    if (txn.fileContractResolutions[0].type === 'renewal') {
+      const oldContract = txn.fileContractResolutions[0].parent.v2FileContract
+      const newContract = txn.fileContractResolutions[0].resolution.newContract
+      return oldContract.proofHeight === newContract.proofHeight &&
+        oldContract.expirationHeight === newContract.expirationHeight
+        ? 'contractRefresh'
+        : 'contractRenewal'
+    }
+    return mapping[txn.fileContractResolutions[0].type]
   }
   if (txn.fileContractRevisions && txn.fileContractRevisions.length > 0) {
     return 'contractRevision'
@@ -81,6 +137,9 @@ export function getV2TransactionType(txn: V2Transaction): TxType {
   if (txn.siacoinOutputs && txn.siacoinOutputs.length > 0) {
     return 'siacoin'
   }
+  if (txn.arbitraryData && txn.arbitraryData.length > 0) {
+    return 'arbitraryData'
+  }
 
   return 'unknown'
 }
@@ -90,6 +149,7 @@ const txTypeMap: Record<TxType, string> = {
   siafund: 'siafund transfer',
   contractFormation: 'contract formation',
   contractRenewal: 'contract renewal',
+  contractRefresh: 'contract refresh',
   contractRevision: 'contract revision',
   contractExpiration: 'contract expiration',
   contractFinalization: 'contract finalization',
@@ -99,6 +159,7 @@ const txTypeMap: Record<TxType, string> = {
   siafundClaim: 'siafund claim',
   foundationSubsidy: 'foundation subsidy',
   hostAnnouncement: 'host announcement',
+  arbitraryData: 'arbitrary data',
   unknown: 'unknown transaction type',
 }
 export function getTxTypeLabel(type?: TxType): string | undefined {


### PR DESCRIPTION
- Transaction and contract and contract resolution types and labels are now fully aligned across all apps.

### Changes
- Added support for the contract refresh event type. https://github.com/SiaFoundation/hostd/issues/759
- Transaction headers in the explorer now show a badge with the specific type.
- Fixed an issue with the ContractResolution type.
- Fixed v1 ExplorerTransaction arbitraryData type.
- Added support for the arbitrary data event type.

#### renterd / hostd / walletd
![Screenshot 2025-06-26 at 2.44.22 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/75468def-c79f-4cff-80b2-e309d94b72d7.png)

#### explorer

![Screenshot 2025-06-26 at 3.44.47 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/94f677f7-b362-4f03-a330-fec31b28ac13.png)

![Screenshot 2025-06-26 at 3.44.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/a55c0b15-755b-4226-ae75-097022f3eae4.png)

