### PR TITLE
Fix v2 contract status logic again

### DIFF
--- a/.changeset/clean-jars-run.md
+++ b/.changeset/clean-jars-run.md
@@ -1,0 +1,5 @@
+---
+'explorer': patch
+---
+
+Fix V2 contract status logic.

--- a/apps/explorer/lib/contracts.ts
+++ b/apps/explorer/lib/contracts.ts
@@ -42,14 +42,13 @@ export function determineV2ContractStatus(
     v2FileContract: { expirationHeight, hostOutput, missedHostValue },
   } = contract
 
-  if (expirationHeight > currentHeight) return 'in progress'
-
   switch (resolutionType) {
     case 'storage_proof':
       return 'complete'
     case 'renewal':
       return 'renewed'
     default:
+      if (expirationHeight > currentHeight) return 'in progress'
       return hostOutput.value === missedHostValue ? 'complete' : 'failed'
   }
 }


### PR DESCRIPTION
Last time (I promise)

https://siascan.com/contract/891a8b50e1a2e6b8fcf6d6c5887fef6a3f6e35444ce8ac83e90daa85bcfe9366

Should be "complete" because it has a storage proof. It is currently "in progress"