### PR TITLE
fix(explorer): align active contract status

### DIFF
--- a/.changeset/serious-brooms-add.md
+++ b/.changeset/serious-brooms-add.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The 'in progress' contract status is now 'active' which is consistent with hostd and renterd.

--- a/apps/explorer-e2e/src/helpers/findTestContract.ts
+++ b/apps/explorer-e2e/src/helpers/findTestContract.ts
@@ -40,9 +40,9 @@ export async function findV2TestContractWithResolutionType(
   )
 }
 
-export async function findV1TestContractWithResolutionType(
+export async function findV1TestContractWithStatus(
   cluster: Cluster,
-  resolutionType: 'complete' | 'failed' | 'in progress' | 'invalid'
+  status: 'complete' | 'failed' | 'active' | 'invalid'
 ) {
   const foundContracts: ExplorerFileContract[] = []
 
@@ -69,7 +69,7 @@ export async function findV1TestContractWithResolutionType(
     }
   }
 
-  switch (resolutionType) {
+  switch (status) {
     case 'complete':
       return foundContracts.find(
         (contract) => contract.valid && contract.resolved
@@ -78,7 +78,7 @@ export async function findV1TestContractWithResolutionType(
       return foundContracts.find(
         (contract) => !contract.valid && contract.resolved
       )
-    case 'in progress':
+    case 'active':
       return foundContracts.find((contract) => !contract.resolved)
   }
 }

--- a/apps/explorer-e2e/src/specs/contract.spec.ts
+++ b/apps/explorer-e2e/src/specs/contract.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '@siafoundation/clusterd'
 import { exploredStabilization } from '../helpers/exploredStabilization'
 import {
-  findV1TestContractWithResolutionType,
+  findV1TestContractWithStatus,
   findV2TestContractWithResolutionType,
 } from '../helpers/findTestContract'
 import { RENEWED_FROM_BUTTON, RENEWED_TO_BUTTON } from '../fixtures/constants'
@@ -90,7 +90,7 @@ test.describe('v2', () => {
       'renewal'
     )
     await explorerApp.goTo('/contract/' + renewedContract?.renewedTo)
-    await expect(page.getByText('in progress')).toBeVisible()
+    await expect(page.getByText('active')).toBeVisible()
   })
 
   test('contract navigate to and from a renewed contract', async ({ page }) => {
@@ -172,7 +172,7 @@ test.describe('v1', () => {
   })
 
   test('contract correctly displays a completed contract', async ({ page }) => {
-    const completedContract = await findV1TestContractWithResolutionType(
+    const completedContract = await findV1TestContractWithStatus(
       cluster,
       'complete'
     )
@@ -182,27 +182,19 @@ test.describe('v1', () => {
   })
 
   test('contract correctly displays a failed contract', async ({ page }) => {
-    const failedContract = await findV1TestContractWithResolutionType(
-      cluster,
-      'failed'
-    )
+    const failedContract = await findV1TestContractWithStatus(cluster, 'failed')
 
     await explorerApp.goTo('/contract/' + failedContract?.id)
 
     await expect(page.getByText('failed')).toBeVisible()
   })
 
-  test('contract correctly displays a contract in progress', async ({
-    page,
-  }) => {
-    const inProgressContract = await findV1TestContractWithResolutionType(
-      cluster,
-      'in progress'
-    )
+  test('contract correctly displays an active contract', async ({ page }) => {
+    const activeContract = await findV1TestContractWithStatus(cluster, 'active')
 
-    await explorerApp.goTo('/contract/' + inProgressContract?.id)
+    await explorerApp.goTo('/contract/' + activeContract?.id)
 
-    await expect(page.getByText('in progress')).toBeVisible()
+    await expect(page.getByText('active')).toBeVisible()
   })
 
   test('contract displays the correct version', async ({ page }) => {

--- a/apps/explorer/lib/contracts.ts
+++ b/apps/explorer/lib/contracts.ts
@@ -7,17 +7,7 @@ import {
 } from '@siafoundation/explored-types'
 import BigNumber from 'bignumber.js'
 
-export const CONTRACT_STATUS = {
-  IN_PROGRESS: 'in progress',
-  COMPLETE: 'complete',
-  FAILED: 'failed',
-  RENEWED: 'renewed',
-  INVALID: 'invalid',
-} as const
-
-type ObjectValues<T> = T[keyof T]
-
-type ContractStatus = ObjectValues<typeof CONTRACT_STATUS>
+type ContractStatus = 'active' | 'complete' | 'failed' | 'renewed' | 'invalid'
 
 export function determineV1ContractStatus({
   resolved,
@@ -25,7 +15,7 @@ export function determineV1ContractStatus({
   validProofOutputs,
   missedProofOutputs,
 }: ExplorerFileContract): ContractStatus {
-  if (!resolved) return 'in progress'
+  if (!resolved) return 'active'
 
   const successful =
     valid || validProofOutputs?.[1].value === missedProofOutputs?.[1].value
@@ -48,7 +38,7 @@ export function determineV2ContractStatus(
     case 'renewal':
       return 'renewed'
     default:
-      if (expirationHeight > currentHeight) return 'in progress'
+      if (expirationHeight > currentHeight) return 'active'
       return hostOutput.value === missedHostValue ? 'complete' : 'failed'
   }
 }
@@ -57,7 +47,7 @@ export function determineContractStatusColor(status: ContractStatus) {
   switch (status) {
     case 'complete':
     case 'renewed':
-    case 'in progress':
+    case 'active':
       return 'green'
     case 'failed':
     case 'invalid':


### PR DESCRIPTION
- The 'in progress' contract status is now 'active' which is consistent with hostd and renterd.