### PR TITLE
fix: toast notification z-index

### DIFF
--- a/.changeset/famous-needles-smile.md
+++ b/.changeset/famous-needles-smile.md
@@ -1,0 +1,9 @@
+---
+'@siafoundation/design-system': patch
+'explorer': patch
+'hostd': patch
+'renterd': patch
+'walletd': patch
+---
+
+Fixed an issue where toast notifications would appear behind dialogs.

--- a/libs/design-system/src/lib/toast.tsx
+++ b/libs/design-system/src/lib/toast.tsx
@@ -119,7 +119,6 @@ export function buildToastOptions({
       '!max-w-[800px]',
       '[&>div]:overflow-hidden',
       '!p-0',
-      'z-50',
       className
     ),
     success: {
@@ -145,7 +144,7 @@ export function Toaster() {
     <RToaster
       toastOptions={buildToastOptions()}
       containerStyle={{
-        zIndex: 20,
+        zIndex: 30,
       }}
     />
   )


### PR DESCRIPTION
- Fixed an issue where toast notifications would appear behind dialogs.

### before

![Screenshot 2025-07-01 at 9.39.31 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/5ec9c67b-b75d-4201-93d7-451143f1fc55.png)

### after

![Screenshot 2025-07-01 at 9.39.07 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/46414851-97df-409a-a5be-1002d4e29f7c.png)

