### PR TITLE
fix(explorer): restore host roi calculator

### DIFF
--- a/.changeset/healthy-grapes-sort.md
+++ b/.changeset/healthy-grapes-sort.md
@@ -1,0 +1,5 @@
+---
+'explorer': minor
+---
+
+The host revenue calculator has been restored.

--- a/apps/explorer/app/(main)/host-revenue-calculator/page.tsx
+++ b/apps/explorer/app/(main)/host-revenue-calculator/page.tsx
@@ -21,7 +21,7 @@ export default function Page() {
       <div className="flex flex-col gap-3">
         <Heading>Host Revenue Calculator</Heading>
         <iframe
-          src="https://bafybeiguvt6gevjdyxmruhetnbryyqqdnvwqnwuu3bobjuh35vg4trgvwm.ipfs.fsd.link"
+          src="https://host-roi-calculator.sia.tools"
           width="100%"
           height="1000px"
         />

--- a/apps/explorer/components/Layout/NavDropdownMenu.tsx
+++ b/apps/explorer/components/Layout/NavDropdownMenu.tsx
@@ -55,6 +55,11 @@ export function NavDropdownMenu({ trigger, children, ...props }: Props) {
             Host Map
           </Link>
         </DropdownMenuItem>
+        <DropdownMenuItem className="p-2">
+          <Link href={routes.hostRevenueCalculator.index} underline="none">
+            Host Revenue Calculator
+          </Link>
+        </DropdownMenuItem>
       </DropdownMenuGroup>
       <DropdownMenuGroup className="py-1 px-1">
         <DropdownMenuLabel className="px-1">Settings</DropdownMenuLabel>


### PR DESCRIPTION
- The host revenue calculator has been restored.

![Screenshot 2025-07-02 at 8.51.18 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/7bde6e8d-1a41-4bf8-8e1c-29faa53b719f.png)

![Screenshot 2025-07-02 at 8.51.14 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/8f7e6d92-2506-4907-b5b3-70067468e3a2.png)

