### PR TITLE
fix(explorer-e2e): only use test contracts with v1 network

### DIFF
--- a/apps/explorer-e2e/playwright.config.ts
+++ b/apps/explorer-e2e/playwright.config.ts
@@ -11,6 +11,8 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:3005'
  */
 // require('dotenv').config();
 
+const operationTimeout = 60_000
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -23,13 +25,14 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     video: 'on-first-retry',
+    actionTimeout: operationTimeout,
   },
   // Timeout per test. The cluster takes up to 30 seconds to start and form contracts.
   timeout: 180_000,
   expect: {
     // Raise the timeout because it is running against next dev mode
     // which requires compilation the first to a page is visited.
-    timeout: 25_000,
+    timeout: operationTimeout,
   },
   outputDir: 'output',
   /* Run your local dev server before starting the tests */

--- a/apps/explorer-e2e/src/fixtures/cluster.ts
+++ b/apps/explorer-e2e/src/fixtures/cluster.ts
@@ -6,7 +6,7 @@ export type Cluster = Awaited<ReturnType<typeof startCluster>>
 export async function startCluster({
   renterdCount = 1,
   walletdCount = 1,
-  hostdCount = 3,
+  hostdCount = 1,
   context,
   networkVersion,
 }: {

--- a/apps/explorer-e2e/src/helpers/findTestOutput.ts
+++ b/apps/explorer-e2e/src/helpers/findTestOutput.ts
@@ -6,8 +6,7 @@ export async function findTestOutput(cluster: Cluster, version: 'v1' | 'v2') {
   const tip = await cluster.daemons.explored.api.consensusTip()
   let currentHeight = tip.data.height
 
-  // Hopefully, 50 blocks should be enough. We stop on find.
-  for (let i = 0; i < 50; i++) {
+  while (currentHeight > 0) {
     const { data: blockIndex } =
       await cluster.daemons.explored.api.consensusTipByHeight({
         params: { height: currentHeight },

--- a/apps/explorer-e2e/src/specs/address.spec.ts
+++ b/apps/explorer-e2e/src/specs/address.spec.ts
@@ -1,14 +1,11 @@
 import { test, expect } from '@playwright/test'
 import { ExplorerApp } from '../fixtures/ExplorerApp'
 import { startCluster, Cluster } from '../fixtures/cluster'
-import {
-  mine,
-  renterdWaitForContracts,
-  teardownCluster,
-} from '@siafoundation/clusterd'
+import { mine, teardownCluster } from '@siafoundation/clusterd'
 import { addWalletToWalletd, sendSiacoinFromRenterd } from '../fixtures/walletd'
 import { toHastings } from '@siafoundation/units'
 import { exploredStabilization } from '../helpers/exploredStabilization'
+import { expectThenClick } from '@siafoundation/e2e'
 
 let explorerApp: ExplorerApp
 let cluster: Cluster
@@ -17,10 +14,6 @@ let cluster: Cluster
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v2' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -73,7 +66,7 @@ test.describe('v2', () => {
     await expect(page.getByTestId('entity-link')).toHaveCount(
       events.data.length
     )
-    await page.getByRole('tab').getByText('Unspent outputs').click()
+    await expectThenClick(page.getByRole('tab').getByText('Unspent outputs'))
     await expect(page.getByText('Siacoin output').first()).toBeVisible()
     await expect(
       page.getByText(outputs.data.outputs[0].id.slice(0, 5))
@@ -85,10 +78,6 @@ test.describe('v2', () => {
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v1' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -141,7 +130,7 @@ test.describe('v1', () => {
     await expect(page.getByTestId('entity-link')).toHaveCount(
       events.data.length
     )
-    await page.getByRole('tab').getByText('Unspent outputs').click()
+    await expectThenClick(page.getByRole('tab').getByText('Unspent outputs'))
     await expect(page.getByText('Siacoin output').first()).toBeVisible()
     await expect(
       page.getByText(outputs.data.outputs[0].id.slice(0, 5))

--- a/apps/explorer-e2e/src/specs/block.spec.ts
+++ b/apps/explorer-e2e/src/specs/block.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test'
 import { ExplorerApp } from '../fixtures/ExplorerApp'
 import { Cluster, startCluster } from '../fixtures/cluster'
-import {
-  renterdWaitForContracts,
-  teardownCluster,
-} from '@siafoundation/clusterd'
+import { teardownCluster } from '@siafoundation/clusterd'
 import { exploredStabilization } from '../helpers/exploredStabilization'
+import { expectThenClick } from '@siafoundation/e2e'
 
 let explorerApp: ExplorerApp
 let cluster: Cluster
@@ -14,10 +12,6 @@ let cluster: Cluster
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v2' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -85,7 +79,7 @@ test.describe('v2', () => {
     const height = String(data.height - 1)
 
     await explorerApp.goTo('/block/' + height)
-    await page.getByTestId('explorer-block-prevBlock').click()
+    await expectThenClick(page.getByTestId('explorer-block-prevBlock'))
 
     await expect(
       page
@@ -99,7 +93,7 @@ test.describe('v2', () => {
     const height = String(data.height - 1)
 
     await explorerApp.goTo('/block/' + height)
-    await page.getByTestId('explorer-block-nextBlock').click()
+    await expectThenClick(page.getByTestId('explorer-block-nextBlock'))
 
     await expect(
       page
@@ -115,9 +109,9 @@ test.describe('v2', () => {
     const transaction = events.data[0]
 
     await explorerApp.goTo('/block/' + transaction.maturityHeight)
-    await page
-      .locator(`a[data-testid="entity-link"][href*="${transaction.id}"]`)
-      .click()
+    await expectThenClick(
+      page.locator(`a[data-testid="entity-link"][href*="${transaction.id}"]`)
+    )
 
     await expect(
       page.getByTestId('entity-heading').getByText(transaction.id.slice(0, 5))
@@ -140,10 +134,6 @@ test.describe('v2', () => {
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v1' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -211,7 +201,7 @@ test.describe('v1', () => {
     const height = String(data.height - 1)
 
     await explorerApp.goTo('/block/' + height)
-    await page.getByTestId('explorer-block-prevBlock').click()
+    await expectThenClick(page.getByTestId('explorer-block-prevBlock'))
 
     await expect(
       page
@@ -225,7 +215,7 @@ test.describe('v1', () => {
     const height = String(data.height - 1)
 
     await explorerApp.goTo('/block/' + height)
-    await page.getByTestId('explorer-block-nextBlock').click()
+    await expectThenClick(page.getByTestId('explorer-block-nextBlock'))
 
     await expect(
       page
@@ -241,9 +231,9 @@ test.describe('v1', () => {
     const transaction = events.data[0]
 
     await explorerApp.goTo('/block/' + transaction.maturityHeight)
-    await page
-      .locator(`a[data-testid="entity-link"][href*="${transaction.id}"]`)
-      .click()
+    await expectThenClick(
+      page.locator(`a[data-testid="entity-link"][href*="${transaction.id}"]`)
+    )
 
     await expect(
       page.getByTestId('entity-heading').getByText(transaction.id.slice(0, 5))

--- a/apps/explorer-e2e/src/specs/output.spec.ts
+++ b/apps/explorer-e2e/src/specs/output.spec.ts
@@ -1,13 +1,11 @@
 import { test, expect } from '@playwright/test'
 import { ExplorerApp } from '../fixtures/ExplorerApp'
 import { Cluster, startCluster } from '../fixtures/cluster'
-import {
-  renterdWaitForContracts,
-  teardownCluster,
-} from '@siafoundation/clusterd'
+import { teardownCluster } from '@siafoundation/clusterd'
 import { exploredStabilization } from '../helpers/exploredStabilization'
 import { findTestOutput } from '../helpers/findTestOutput'
 import { humanSiacoin } from '@siafoundation/units'
+import { expectThenClick } from '@siafoundation/e2e'
 
 let explorerApp: ExplorerApp
 let cluster: Cluster
@@ -16,10 +14,6 @@ let cluster: Cluster
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v2' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -71,7 +65,9 @@ test.describe('v2', () => {
 
     await explorerApp.goTo('/output/' + output.id)
 
-    await page.getByText(output.siacoinOutput.address.slice(0, 6)).click()
+    await expectThenClick(
+      page.getByText(output.siacoinOutput.address.slice(0, 6))
+    )
 
     await expect(
       page
@@ -85,10 +81,6 @@ test.describe('v2', () => {
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v1' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -140,7 +132,9 @@ test.describe('v1', () => {
 
     await explorerApp.goTo('/output/' + output.id)
 
-    await page.getByText(output.siacoinOutput.address.slice(0, 6)).click()
+    await expectThenClick(
+      page.getByText(output.siacoinOutput.address.slice(0, 6))
+    )
 
     await expect(
       page

--- a/apps/explorer-e2e/src/specs/tx.spec.ts
+++ b/apps/explorer-e2e/src/specs/tx.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect } from '@playwright/test'
 import { ExplorerApp } from '../fixtures/ExplorerApp'
 import { Cluster, startCluster } from '../fixtures/cluster'
-import {
-  renterdWaitForContracts,
-  teardownCluster,
-} from '@siafoundation/clusterd'
+import { teardownCluster } from '@siafoundation/clusterd'
 import { exploredStabilization } from '../helpers/exploredStabilization'
+import { findV1TestContractWithStatus } from '../helpers/findTestContract'
+import { expectThenClick } from '@siafoundation/e2e'
 
 let explorerApp: ExplorerApp
 let cluster: Cluster
@@ -14,10 +13,6 @@ let cluster: Cluster
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v2' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -64,7 +59,7 @@ test.describe('v2', () => {
     const transactionID = events.data[0].id
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByRole('link', { name: 'C', exact: true }).click()
+    await expectThenClick(page.getByRole('link', { name: 'C', exact: true }))
 
     await expect(
       page.getByTestId('entity-heading').getByText('Contract')
@@ -78,7 +73,7 @@ test.describe('v2', () => {
     const transactionID = events.data[0].id
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByText('Address').first().click()
+    await expectThenClick(page.getByText('Address').first())
 
     await expect(
       page.getByTestId('entity-heading').getByText('Address')
@@ -92,7 +87,7 @@ test.describe('v2', () => {
     const transactionID = events.data[0].id
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByRole('link', { name: 'SO', exact: true }).first().click()
+    await expectThenClick(page.getByRole('link', { name: 'SO', exact: true }))
 
     await expect(
       page.getByTestId('entity-heading').getByText('Output')
@@ -117,10 +112,6 @@ test.describe('v2', () => {
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
     cluster = await startCluster({ context, networkVersion: 'v1' })
-    await renterdWaitForContracts({
-      renterdNode: cluster.daemons.renterds[0].node,
-      hostdCount: cluster.daemons.hostds.length,
-    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -130,10 +121,10 @@ test.describe('v1', () => {
   })
 
   test('transaction can be searched by id', async ({ page }) => {
-    const events = await cluster.daemons.renterds[0].api.walletEvents({
-      params: { limit: 1, offset: 0 },
-    })
-    const transactionID = events.data[0].id
+    const testContract = await findV1TestContractWithStatus(cluster, 'active')
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    const transactionID = testContract?.confirmationTransactionID || 'invalid'
 
     await explorerApp.goTo('/')
     await explorerApp.navigateBySearchBar(transactionID)
@@ -146,10 +137,10 @@ test.describe('v1', () => {
   })
 
   test('transaction can be navigated to by id', async ({ page }) => {
-    const events = await cluster.daemons.renterds[0].api.walletEvents({
-      params: { limit: 1, offset: 0 },
-    })
-    const transactionID = events.data[0].id
+    const testContract = await findV1TestContractWithStatus(cluster, 'active')
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    const transactionID = testContract?.confirmationTransactionID || 'invalid'
 
     await explorerApp.goTo('/tx/' + transactionID)
 
@@ -161,13 +152,13 @@ test.describe('v1', () => {
   })
 
   test('transaction can click through to a contract', async ({ page }) => {
-    const events = await cluster.daemons.renterds[0].api.walletEvents({
-      params: { limit: 1, offset: 0 },
-    })
-    const transactionID = events.data[0].id
+    const testContract = await findV1TestContractWithStatus(cluster, 'active')
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    const transactionID = testContract?.confirmationTransactionID || 'invalid'
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByRole('link', { name: 'C', exact: true }).click()
+    await expectThenClick(page.getByRole('link', { name: 'C', exact: true }))
 
     await expect(
       page.getByTestId('entity-heading').getByText('Contract')
@@ -175,13 +166,13 @@ test.describe('v1', () => {
   })
 
   test('transaction can click through to an address', async ({ page }) => {
-    const events = await cluster.daemons.renterds[0].api.walletEvents({
-      params: { limit: 1, offset: 0 },
-    })
-    const transactionID = events.data[0].id
+    const testContract = await findV1TestContractWithStatus(cluster, 'active')
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    const transactionID = testContract?.confirmationTransactionID || 'invalid'
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByText('Address').first().click()
+    await expectThenClick(page.getByText('Address').first())
 
     await expect(
       page.getByTestId('entity-heading').getByText('Address')
@@ -189,13 +180,13 @@ test.describe('v1', () => {
   })
 
   test('transaction can click through to an output', async ({ page }) => {
-    const events = await cluster.daemons.renterds[0].api.walletEvents({
-      params: { limit: 1, offset: 0 },
-    })
-    const transactionID = events.data[0].id
+    const testContract = await findV1TestContractWithStatus(cluster, 'active')
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    const transactionID = testContract?.confirmationTransactionID || 'invalid'
 
     await explorerApp.goTo('/tx/' + transactionID)
-    await page.getByRole('link', { name: 'SO', exact: true }).first().click()
+    await expectThenClick(page.getByRole('link', { name: 'SO', exact: true }))
 
     await expect(
       page.getByTestId('entity-heading').getByText('Output')
@@ -203,10 +194,10 @@ test.describe('v1', () => {
   })
 
   test('transaction displays the correct version', async ({ page }) => {
-    const events = await cluster.daemons.renterds[0].api.walletEvents({
-      params: { limit: 1, offset: 0 },
-    })
-    const transactionID = events.data[0].id
+    const testContract = await findV1TestContractWithStatus(cluster, 'active')
+
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    const transactionID = testContract?.confirmationTransactionID || 'invalid'
 
     await explorerApp.goTo('/tx/' + transactionID)
 


### PR DESCRIPTION
- explorer-e2e tests only use test contracts for v1 tests instead of waiting for contracts to form between renterd and hostd nodes.
- explorer-e2e only runs 1 instead of 3 hostd nodes.
- Adjust actionTimeout and also use expectThenClick for clearer expect errors, clicking a missing locator was using full 180s test timeout.
