### PR TITLE
fix(renterd): contract timeline current block height

### DIFF
--- a/.changeset/tricky-pillows-smoke.md
+++ b/.changeset/tricky-pillows-smoke.md
@@ -1,0 +1,5 @@
+---
+'renterd': patch
+---
+
+Fixed an issue where the contract timeline would show the current block height indicator at the incorrect height.

--- a/apps/renterd/contexts/contracts/index.tsx
+++ b/apps/renterd/contexts/contracts/index.tsx
@@ -126,7 +126,7 @@ function useContractsMain() {
 
   const cellContext = useMemo(() => {
     const context: ContractTableContext = {
-      currentHeight: syncStatus.estimatedBlockHeight,
+      currentHeight,
       contractsTimeRange,
       siascanUrl,
       hasFetchedAllPrunableSize,
@@ -137,7 +137,7 @@ function useContractsMain() {
     }
     return context
   }, [
-    syncStatus.estimatedBlockHeight,
+    currentHeight,
     contractsTimeRange,
     siascanUrl,
     hasFetchedAllPrunableSize,


### PR DESCRIPTION
- Fixed an issue where the contract timeline would show the current block height indicator at the incorrect height.
  - It was showing the estimated height rather than the currentHeight variable which uses node block height unless it is still syncing.


![Screenshot 2025-07-16 at 9.58.59 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/3a654f4f-24fa-40d0-857c-0e0c8e5cdde5.png)

