### PR TITLE
fix(walletd): switch auth connectivity route

### DIFF
--- a/.changeset/plenty-moles-hug.md
+++ b/.changeset/plenty-moles-hug.md
@@ -1,0 +1,5 @@
+---
+'walletd': patch
+---
+
+Move the auth and connectivity route to /wallets so that consensus and syncer routes can be made public without affecting the UI.

--- a/apps/walletd/config/routes.ts
+++ b/apps/walletd/config/routes.ts
@@ -1,4 +1,4 @@
-import { syncerPeersRoute } from '@siafoundation/walletd-types'
+import { walletsRoute } from '@siafoundation/walletd-types'
 
 export const routes = {
   home: '/',
@@ -15,4 +15,4 @@ export const routes = {
   login: '/login',
 }
 
-export const connectivityRoute = syncerPeersRoute
+export const connectivityRoute = walletsRoute


### PR DESCRIPTION
- Move the auth and connectivity route to /wallets so that consensus and syncer routes can be made public without affecting the UI.

