### PR TITLE
test(e2e): fix v1 explorer tests, flaky tests

### DIFF
--- a/apps/explorer-e2e/src/fixtures/cluster.ts
+++ b/apps/explorer-e2e/src/fixtures/cluster.ts
@@ -1,27 +1,27 @@
-import { clusterd, NetworkVersion, setupCluster } from '@siafoundation/clusterd'
+import { clusterd, setupCluster, TestContracts } from '@siafoundation/clusterd'
 import { BrowserContext } from 'playwright'
 
 export type Cluster = Awaited<ReturnType<typeof startCluster>>
 
 export async function startCluster({
+  testContracts = 'none',
   renterdCount = 1,
   walletdCount = 1,
   hostdCount = 1,
   context,
-  networkVersion,
 }: {
+  testContracts?: TestContracts
   renterdCount?: number
   walletdCount?: number
   hostdCount?: number
   context: BrowserContext
-  networkVersion?: NetworkVersion
 }) {
   const cluster = await setupCluster({
+    testContracts,
     exploredCount: 1,
     renterdCount,
     walletdCount,
     hostdCount,
-    networkVersion,
   })
   const daemons = {
     explored: cluster.daemons.exploreds[0],

--- a/apps/explorer-e2e/src/helpers/findTestContract.ts
+++ b/apps/explorer-e2e/src/helpers/findTestContract.ts
@@ -11,7 +11,7 @@ export async function findV2TestContractWithResolutionType(
 ) {
   const foundContracts: ExplorerV2FileContract[] = []
 
-  for (let i = 10; i <= 20; i++) {
+  for (let i = 1; i <= 30; i++) {
     // Get the block ID.
     const {
       data: { id: blockID },
@@ -46,7 +46,7 @@ export async function findV1TestContractWithStatus(
 ) {
   const foundContracts: ExplorerFileContract[] = []
 
-  for (let i = 10; i <= 20; i++) {
+  for (let i = 1; i <= 30; i++) {
     // Get the block ID.
     const {
       data: { id: blockID },

--- a/apps/explorer-e2e/src/specs/address.spec.ts
+++ b/apps/explorer-e2e/src/specs/address.spec.ts
@@ -12,7 +12,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -71,7 +71,10 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({
+      context,
+      testContracts: 'v1',
+    })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -81,23 +84,25 @@ test.describe('v1', () => {
   })
 
   test('address can be searched by id', async ({ page }) => {
-    const wallet = await cluster.daemons.renterds[0].api.wallet()
+    const { siacoinOutput } = await findTestOutput(cluster, 'v1')
+    const address = siacoinOutput.address
     await explorerApp.goTo('/')
-    await explorerApp.navigateBySearchBar(wallet.data.address)
+    await explorerApp.navigateBySearchBar(address)
     await expect(
       page
         .getByTestId('entity-heading')
-        .getByText(`Address ${wallet.data.address.slice(0, 5)}`)
+        .getByText(`Address ${address.slice(0, 5)}`)
     ).toBeVisible()
   })
 
   test('address can be directly navigated to by id', async ({ page }) => {
-    const wallet = await cluster.daemons.renterds[0].api.wallet()
-    await explorerApp.goTo('/address/' + wallet.data.address)
+    const { siacoinOutput } = await findTestOutput(cluster, 'v1')
+    const address = siacoinOutput.address
+    await explorerApp.goTo('/address/' + address)
     await expect(
       page
         .getByTestId('entity-heading')
-        .getByText(`Address ${wallet.data.address.slice(0, 5)}`)
+        .getByText(`Address ${address.slice(0, 5)}`)
     ).toBeVisible()
   })
 

--- a/apps/explorer-e2e/src/specs/block.spec.ts
+++ b/apps/explorer-e2e/src/specs/block.spec.ts
@@ -15,7 +15,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -142,7 +142,7 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({ context, testContracts: 'v1' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -251,10 +251,7 @@ test.describe('v1', () => {
   })
 
   test('block displays the correct version', async ({ page }) => {
-    const { data } = await cluster.daemons.explored.api.consensusTip()
-    const height = String(data.height - 1)
-
-    await explorerApp.goTo('/block/' + height)
+    await explorerApp.goTo('/block/1')
 
     await expect(
       page.getByTestId('explorer-block-version').getByText('v1')

--- a/apps/explorer-e2e/src/specs/contract.spec.ts
+++ b/apps/explorer-e2e/src/specs/contract.spec.ts
@@ -16,7 +16,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -128,7 +128,7 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({ context, testContracts: 'v1' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })

--- a/apps/explorer-e2e/src/specs/home.spec.ts
+++ b/apps/explorer-e2e/src/specs/home.spec.ts
@@ -19,7 +19,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
     await explorerApp.goTo('/')
@@ -62,7 +62,7 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({ context, testContracts: 'v1' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
     await explorerApp.goTo('/')

--- a/apps/explorer-e2e/src/specs/host.spec.ts
+++ b/apps/explorer-e2e/src/specs/host.spec.ts
@@ -16,7 +16,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -91,7 +91,7 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({ context, testContracts: 'v1' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })

--- a/apps/explorer-e2e/src/specs/output.spec.ts
+++ b/apps/explorer-e2e/src/specs/output.spec.ts
@@ -13,7 +13,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -80,7 +80,7 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({ context, testContracts: 'v1' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })

--- a/apps/explorer-e2e/src/specs/tx.spec.ts
+++ b/apps/explorer-e2e/src/specs/tx.spec.ts
@@ -15,7 +15,7 @@ let cluster: Cluster
 // V2
 test.describe('v2', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v2' })
+    cluster = await startCluster({ context, testContracts: 'v2' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })
@@ -136,7 +136,7 @@ test.describe('v2', () => {
 // V1
 test.describe('v1', () => {
   test.beforeEach(async ({ page, context }) => {
-    cluster = await startCluster({ context, networkVersion: 'v1' })
+    cluster = await startCluster({ context, testContracts: 'v1' })
     await exploredStabilization(cluster)
     explorerApp = new ExplorerApp(page)
   })

--- a/apps/hostd-e2e/src/fixtures/beforeTest.ts
+++ b/apps/hostd-e2e/src/fixtures/beforeTest.ts
@@ -3,8 +3,8 @@ import { Page } from 'playwright'
 import {
   clusterd,
   hostdWaitForContracts,
-  NetworkVersion,
   setupCluster,
+  TestContracts,
   teardownCluster,
 } from '@siafoundation/clusterd'
 import {
@@ -18,17 +18,17 @@ export async function beforeTest(
   page: Page,
   {
     renterdCount = 0,
-    networkVersion = 'v2',
+    testContracts = 'v2',
   }: {
     renterdCount?: number
-    networkVersion?: NetworkVersion
+    testContracts?: TestContracts
   } = {}
 ) {
   await mockApiSiaScanExchangeRates({ page })
   await mockApiSiaScanHostMetrics({ page })
-  await setupCluster({ hostdCount: 1, renterdCount, networkVersion })
+  await setupCluster({ hostdCount: 1, renterdCount, testContracts })
   const hostdNode = clusterd.nodes.find((n) => n.type === 'hostd')
-  await hostdWaitForContracts({ hostdNode, renterdCount, networkVersion })
+  await hostdWaitForContracts({ hostdNode, renterdCount })
   await login({
     page,
     address: hostdNode.apiAddress,

--- a/apps/renterd-e2e/src/specs/config.spec.ts
+++ b/apps/renterd-e2e/src/specs/config.spec.ts
@@ -56,7 +56,7 @@ test('field change and save behaviours', async ({ page }) => {
     page
       .getByTestId('spendingEstimate')
       .locator('input[name=estimatedSpendingPerMonth-fiat]')
-  ).toHaveValue('$902')
+  ).toHaveValue('$901.87')
 
   await fillSelectInputByName(page, 'spendingEstimateMode', 'tb')
 
@@ -69,7 +69,7 @@ test('field change and save behaviours', async ({ page }) => {
     page
       .getByTestId('spendingEstimate')
       .locator('input[name=estimatedSpendingPerTBPerMonth-fiat]')
-  ).toHaveValue('$129')
+  ).toHaveValue('$128.84')
 })
 
 test('set max prices to fit current spending estimate', async ({ page }) => {

--- a/apps/walletd-e2e/src/specs/seedSendSiacoin.spec.ts
+++ b/apps/walletd-e2e/src/specs/seedSendSiacoin.spec.ts
@@ -69,7 +69,7 @@ test('send siacoin between wallets', async ({ page, browserName }) => {
     expectedFee: 0.02,
     expectedVersion: 'v2',
     transactionVersionIndicator:
-      'testCluster - constructing v2 transaction - switched to v2 at allow height 2',
+      'testCluster - constructing v2 transaction - switched to v2 at allow height 1',
   })
 
   await mine(1)

--- a/apps/walletd-e2e/src/specs/seedSendSiafund.spec.ts
+++ b/apps/walletd-e2e/src/specs/seedSendSiafund.spec.ts
@@ -77,7 +77,7 @@ test('send siafund between wallets', async ({ page, browserName }) => {
     expectedFee: 0.02,
     expectedVersion: 'v2',
     transactionVersionIndicator:
-      'testCluster - constructing v2 transaction - switched to v2 at allow height 2',
+      'testCluster - constructing v2 transaction - switched to v2 at allow height 1',
   })
 
   await mine(1)

--- a/libs/design-system/src/core/SiacoinField.spec.tsx
+++ b/libs/design-system/src/core/SiacoinField.spec.tsx
@@ -42,8 +42,8 @@ describe('SiacoinField', () => {
     fireEvent.blur(scInput)
     expect(scInput.value).toBe('44')
     expect(fiatInput.value).toBe('$44')
-    expect(onChange.mock.calls.length).toBe(3)
-    expect(Number(onChange.mock.calls[2][0])).toBe(44)
+    expect(onChange.mock.calls.length).toBe(4)
+    expect(Number(onChange.mock.calls[3][0])).toBe(44)
     // for some reason after fireEvent.blur, user.click does not trigger a re-focus
     fireEvent.focus(scInput)
     await user.click(scInput)
@@ -51,9 +51,9 @@ describe('SiacoinField', () => {
     fireEvent.blur(scInput)
     expect(scInput.value).toBe('444')
     expect(fiatInput.value).toBe('$444')
-    expect(onChange.mock.calls.length).toBe(4)
-    expect(Number(onChange.mock.calls[3][0])).toBe(444)
-    expectOnChangeValues([undefined, '4', '44', '444'], onChange)
+    expect(onChange.mock.calls.length).toBe(5)
+    expect(Number(onChange.mock.calls[4][0])).toBe(444)
+    expectOnChangeValues(['33', undefined, '4', '44', '444'], onChange)
   })
 
   it('updates value starting with decimal', async () => {
@@ -117,7 +117,17 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('4.444,55')
     expect(fiatInput.value).toBe('$4.444,55')
     expectOnChangeValues(
-      [undefined, '4', '44', '444', '4444', '4444', '4444.5', '4444.55'],
+      [
+        '3333',
+        undefined,
+        '4',
+        '44',
+        '444',
+        '4444',
+        '4444',
+        '4444.5',
+        '4444.55',
+      ],
       onChange
     )
   })
@@ -145,7 +155,17 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('4.444,55')
     expect(fiatInput.value).toBe('₽4.444,55')
     expectOnChangeValues(
-      [undefined, '4', '44', '444', '4444', '4444', '4444.5', '4444.55'],
+      [
+        '3333',
+        undefined,
+        '4',
+        '44',
+        '444',
+        '4444',
+        '4444',
+        '4444.5',
+        '4444.55',
+      ],
       onChange
     )
   })
@@ -173,7 +193,17 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('4.444,55')
     expect(fiatInput.value).toBe('₽4.444,55')
     expectOnChangeValues(
-      [undefined, '4', '44', '444', '4444', '4444', '4444.5', '4444.55'],
+      [
+        '3333',
+        undefined,
+        '4',
+        '44',
+        '444',
+        '4444',
+        '4444',
+        '4444.5',
+        '4444.55',
+      ],
       onChange
     )
   })
@@ -197,10 +227,11 @@ describe('SiacoinField', () => {
     // Either way limits to 6 (not rounding)
     expect(scInput.value).toBe('0.123456')
     expect(fiatInput.value).toBe('$0.123456')
-    expect(onChange.mock.calls.length).toBe(9)
-    expect(Number(onChange.mock.calls[8][0])).toBe(0.123456)
+    expect(onChange.mock.calls.length).toBe(10)
+    expect(Number(onChange.mock.calls[9][0])).toBe(0.123456)
     expectOnChangeValues(
       [
+        '0.123457',
         undefined,
         '0',
         '0',
@@ -232,9 +263,10 @@ describe('SiacoinField', () => {
     fireEvent.blur(fiatInput)
     expect(scInput.value).toBe('0.123')
     expect(fiatInput.value).toBe('$0.123')
-    expect(onChange.mock.calls.length).toBe(11)
+    expect(onChange.mock.calls.length).toBe(12)
     expectOnChangeValues(
       [
+        '0.444',
         undefined,
         undefined,
         '0',
@@ -272,9 +304,10 @@ describe('SiacoinField', () => {
     fireEvent.blur(fiatInput)
     expect(fiatInput.value).toBe('$0.158')
     expect(scInput.value).toBe('45.208347')
-    expect(onChange.mock.calls.length).toBe(6)
+    expect(onChange.mock.calls.length).toBe(7)
     expectOnChangeValues(
       [
+        '45.47473',
         '45.474447',
         '45.474447',
         '45.465863',
@@ -304,9 +337,9 @@ describe('SiacoinField', () => {
     expect(scInput.value).toBe('0.123')
     expect(fiatInput.value).toBe('$0.000446')
     // Fires one more time because the currency inut component fires onValueChange on blur.
-    expect(onChange.mock.calls.length).toBe(6)
+    expect(onChange.mock.calls.length).toBe(7)
     expectOnChangeValues(
-      [undefined, '0', '0', '0.1', '0.12', '0.123'],
+      ['0.444', undefined, '0', '0', '0.1', '0.12', '0.123'],
       onChange
     )
   })
@@ -324,7 +357,8 @@ describe('SiacoinField', () => {
     fireEvent.focus(fiatInput)
     expect(scInput.value).toBe('0.444')
     expect(fiatInput.value).toBe('$0.001609')
-    expect(onChange.mock.calls.length).toBe(0)
+    expect(onChange.mock.calls.length).toBe(1)
+    expectOnChangeValues(['0.444'], onChange)
   })
 })
 

--- a/libs/design-system/src/core/SiacoinField.tsx
+++ b/libs/design-system/src/core/SiacoinField.tsx
@@ -83,11 +83,9 @@ export function SiacoinField({
   const onScChange = useCallback(
     (sc: string) => {
       setLocalSc(sc)
-      if (active) {
-        updateExternalSc(sc)
-      }
+      updateExternalSc(sc)
     },
-    [active, setLocalSc, updateExternalSc]
+    [setLocalSc, updateExternalSc]
   )
 
   const syncFiatToSc = useCallback(
@@ -160,8 +158,8 @@ export function SiacoinField({
         error
           ? 'border-red-500 dark:border-red-400'
           : changed
-          ? 'border-green-500 dark:border-green-400'
-          : 'border-gray-200 dark:border-graydark-200',
+            ? 'border-green-500 dark:border-green-400'
+            : 'border-gray-200 dark:border-graydark-200',
         'rounded'
       )}
     >
@@ -203,7 +201,7 @@ export function SiacoinField({
           focus="none"
           value={localFiat !== 'NaN' ? localFiat : ''}
           units={settings.currency.label + (unitsFiatPostfix || '')}
-          decimalScale={decimalsLimitSc}
+          decimalScale={decimalsLimitFiat}
           allowNegative={false}
           onValueChange={(value) => {
             setLocalFiat(value.value || '')

--- a/libs/design-system/src/form/FieldSiacoin.tsx
+++ b/libs/design-system/src/form/FieldSiacoin.tsx
@@ -11,7 +11,7 @@ import { useMemo } from 'react'
 
 export function FieldSiacoin<
   Values extends FieldValues,
-  Categories extends string
+  Categories extends string,
 >({
   name,
   form,
@@ -43,10 +43,10 @@ export function FieldSiacoin<
       _placeholder
         ? new BigNumber(_placeholder)
         : suggestion && typeof suggestion !== 'boolean'
-        ? new BigNumber(suggestion)
-        : median && typeof median !== 'boolean'
-        ? new BigNumber(median)
-        : undefined,
+          ? new BigNumber(suggestion)
+          : median && typeof median !== 'boolean'
+            ? new BigNumber(median)
+            : undefined,
     [_placeholder, suggestion, median]
   )
 
@@ -64,7 +64,6 @@ export function FieldSiacoin<
       changed={getFormStateFieldBoolean(form.formState.dirtyFields, name)}
       placeholder={placeholder}
       onChange={(val) => {
-        console.log('onChange', val?.toString())
         setValue(val as PathValue<Values, Path<Values>>, true)
       }}
       onBlur={onBlur}

--- a/libs/e2e/src/fixtures/preferences.ts
+++ b/libs/e2e/src/fixtures/preferences.ts
@@ -32,12 +32,12 @@ export const toggleColumnVisibility = step(
     if (visible) {
       await expect(columnToggle).toBeVisible()
       if (!(await columnToggle.isChecked())) {
-        await columnToggle.click()
+        await columnToggle.click({ force: true })
       }
     } else {
       await expect(columnToggle).toBeHidden()
       if (await columnToggle.isChecked()) {
-        await columnToggle.click()
+        await columnToggle.click({ force: true })
       }
     }
     await page.getByLabel('configure view').click()


### PR DESCRIPTION
- explorer v1 tests no longer work because even with test contracts they depend on being able to spin up explored and at least 1 hostd which is no longer possible on a v1 network.
- Fixed by removing the network option from cluster and replacing with a testContracts option. This means now the user may specify which test contracts are required v1 or v2 but the resulting network that tests run again is always mined into v2 before other daemons are spun up.
### Other changes
- Fixed other flaky tests relating to sending siacoin in walletd.