### PR TITLE
feat(indexd): siascan explorer data

### DIFF
--- a/apps/indexd/app/layout.tsx
+++ b/apps/indexd/app/layout.tsx
@@ -2,7 +2,6 @@ import '../config/style.css'
 import { NextAppCsr } from '@siafoundation/design-system'
 import { rootFontClasses } from '@siafoundation/fonts'
 import { routes } from '../config/routes'
-import { stateRoute } from '@siafoundation/indexd-types'
 import { Providers } from '../config/providers'
 
 export const metadata = {
@@ -18,11 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={rootFontClasses}>
       <body>
-        <NextAppCsr
-          daemonExplorerInfoRoute={stateRoute}
-          passwordProtectRequestHooks
-          lockRoutes={routes}
-        >
+        <NextAppCsr passwordProtectRequestHooks lockRoutes={routes}>
           <Providers>{children}</Providers>
         </NextAppCsr>
       </body>

--- a/apps/indexd/components/Config/index.tsx
+++ b/apps/indexd/components/Config/index.tsx
@@ -5,7 +5,7 @@ import {
   ConfigurationSiacoin,
   PanelMenuSection,
   PanelMenuSetting,
-  useDaemonExplorerExchangeRate,
+  useSiascanExchangeRate,
 } from '@siafoundation/design-system'
 import { useConfig } from '../../contexts/config'
 import { StateConnError } from './StateConnError'
@@ -21,7 +21,7 @@ export function Config() {
   const shouldPinMaxEgressPrice = form.watch('shouldPinMaxEgressPrice')
   const shouldPinMinCollateral = form.watch('shouldPinMinCollateral')
 
-  const { rate } = useDaemonExplorerExchangeRate({
+  const { rate } = useSiascanExchangeRate({
     currency: pinnedCurrency || undefined,
   })
   const canUseExchangeRates = !!rate

--- a/apps/indexd/contexts/config/useFormExchangeRate.tsx
+++ b/apps/indexd/contexts/config/useFormExchangeRate.tsx
@@ -1,10 +1,10 @@
 import { UseFormReturn } from 'react-hook-form'
 import { InputValues } from './types'
-import { useDaemonExplorerExchangeRate } from '@siafoundation/design-system'
+import { useSiascanExchangeRate } from '@siafoundation/design-system'
 
 export function useFormExchangeRate(form: UseFormReturn<InputValues>) {
   const pinnedCurrency = form.watch('pinnedCurrency')
-  const { rate } = useDaemonExplorerExchangeRate({
+  const { rate } = useSiascanExchangeRate({
     currency: pinnedCurrency || undefined,
   })
   return {

--- a/apps/indexd/hooks/useMedianPrices.tsx
+++ b/apps/indexd/hooks/useMedianPrices.tsx
@@ -5,10 +5,10 @@ import {
   toSiacoins,
   valuePerByteToPerTB,
 } from '@siafoundation/units'
-import { useDaemonExplorerHostMetrics } from '@siafoundation/design-system'
+import { useSiascanHostMetrics } from '@siafoundation/design-system'
 
 export function useMedianPrices() {
-  const explorerMedians = useDaemonExplorerHostMetrics({
+  const explorerMedians = useSiascanHostMetrics({
     config: {
       swr: {
         revalidateOnFocus: false,

--- a/libs/design-system/src/app/SettingsDialog.tsx
+++ b/libs/design-system/src/app/SettingsDialog.tsx
@@ -228,9 +228,6 @@ export function SettingsDialog({
                         size="medium"
                         disabled
                         checked={daemonExplorer.enabled}
-                        onCheckedChange={(val) =>
-                          setExternalDataSettings({ siascan: val })
-                        }
                       />
                     </div>
                   </div>


### PR DESCRIPTION
- Configure indexd to use siascan explorer APIs directly for now.
  - Once the desired featureset is more clear we will likely move the explorer url to a daemon configuration, right now indexd has a single exchange rate route and does not follow the standard state explorer config like the other daemons.