### PR TITLE
feat(design-system): data table

### DIFF
--- a/.changeset/metal-guests-find.md
+++ b/.changeset/metal-guests-find.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Added TanStack-based DataTable.

--- a/bun.lock
+++ b/bun.lock
@@ -264,6 +264,8 @@
         "@siafoundation/types": "^0.12.2",
         "@siafoundation/units": "^3.5.2",
         "@tailwindcss/container-queries": "^0.1.1",
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.13.12",
         "@technically/lodash": "^4.17.0",
         "@visx/axis": "^3.12.0",
         "@visx/brush": "^3.12.0",
@@ -1658,6 +1660,14 @@
     "@szmarczak/http-timer": ["@szmarczak/http-timer@5.0.1", "", { "dependencies": { "defer-to-connect": "^2.0.1" } }, "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw=="],
 
     "@tailwindcss/container-queries": ["@tailwindcss/container-queries@0.1.1", "", { "peerDependencies": { "tailwindcss": ">=3.2.0" } }, "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA=="],
+
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.12", "", { "dependencies": { "@tanstack/virtual-core": "3.13.12" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.12", "", {}, "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA=="],
 
     "@technically/lodash": ["@technically/lodash@4.17.0", "", { "dependencies": { "@types/lodash-es": "^4.17.0", "lodash": "^4.17.0", "lodash-es": "^4.17.0" } }, "sha512-x0dRMAZbdv7HOyaayrW0Tua9V0k8Sdr+NDgsNRRfPada2+MlCE6esmYoSL7KJeCh13O3up5dlq8VbcQBTW+wqg=="],
 

--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -29,6 +29,8 @@
     "@siafoundation/types": "^0.12.2",
     "@siafoundation/units": "^3.5.2",
     "@tailwindcss/container-queries": "^0.1.1",
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.12",
     "@technically/lodash": "^4.17.0",
     "@visx/axis": "^3.12.0",
     "@visx/brush": "^3.12.0",

--- a/libs/design-system/src/app/DataTable/ActiveFilters.tsx
+++ b/libs/design-system/src/app/DataTable/ActiveFilters.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { Button } from '../../core/Button'
+import { ControlGroup } from '../../core/ControlGroup'
+import { countryCodeEmoji, getCountryName } from '@siafoundation/units'
+import { truncate } from '../../lib/utils'
+import { Close16, Filter20 } from '@siafoundation/react-icons'
+import { ColumnFiltersState, type Table } from '@tanstack/react-table'
+
+interface ActiveFiltersProps<T> {
+  table: Table<T>
+  fixedFilters?: ColumnFiltersState
+  onClickFilterIcon?: () => void
+  heading?: React.ReactNode
+}
+
+export function ActiveFilters<T>({
+  table,
+  fixedFilters,
+  onClickFilterIcon,
+  heading,
+}: ActiveFiltersProps<T>) {
+  const columnFilters = table.getState().columnFilters
+
+  const getColumnDisplayName = (columnId: string): string => {
+    const column = table.getColumn(columnId)
+    if (!column) return columnId
+
+    // Try to extract a readable name from the column definition
+    const header = column.columnDef.header
+
+    // If header is a string, use it
+    if (typeof header === 'string') {
+      return header
+    }
+
+    // Otherwise, use a formatted version of the column ID
+    return columnId
+      .replace(/([A-Z])/g, ' $1') // Add spaces before capital letters
+      .replace(/^./, (str) => str.toUpperCase()) // Capitalize first letter
+      .trim()
+  }
+
+  const getValueDisplayName = (columnId: string, value: unknown): string => {
+    const column = table.getColumn(columnId)
+
+    // Check if column has meta information for custom formatting
+    const meta = column?.columnDef.meta as {
+      formatFilterValue?: (value: unknown) => string
+    }
+    if (meta?.formatFilterValue) {
+      return meta.formatFilterValue(value)
+    }
+
+    // Handle boolean values
+    if (typeof value === 'boolean') {
+      return value ? 'Yes' : 'No'
+    }
+
+    // Handle special known cases for better UX
+    if (columnId === 'country' || columnId === 'countryCode') {
+      const countryFlag = countryCodeEmoji(value as string)
+      const countryName = getCountryName(value as string)
+      return `${countryFlag} ${countryName}`
+    }
+
+    // Default: just stringify the value
+    return truncate(String(value), 20)
+  }
+
+  const clearFilter = (columnId: string) => {
+    const column = table.getColumn(columnId)
+    column?.setFilterValue(undefined)
+  }
+
+  const clearAllFilters = () => {
+    table.resetColumnFilters()
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="ghost" size="none" onClick={onClickFilterIcon}>
+        <Filter20 />
+      </Button>
+      {heading}
+      <div className="flex items-center gap-2 flex-wrap">
+        {columnFilters.map((filter) => (
+          <ControlGroup key={filter.id}>
+            <Button variant="gray" size="small">
+              {getColumnDisplayName(filter.id)}
+            </Button>
+            <Button variant="gray" size="small">
+              is
+            </Button>
+            <Button variant="gray" size="small">
+              {getValueDisplayName(filter.id, filter.value)}
+            </Button>
+            {fixedFilters?.find((f) => f.id === filter.id) ? null : (
+              <Button
+                variant="gray"
+                size="small"
+                onClick={() => clearFilter(filter.id)}
+                className="hover:bg-red-100 dark:hover:bg-red-900/30 hover:text-red-700 dark:hover:text-red-300"
+              >
+                <Close16 className="h-3 w-3" />
+              </Button>
+            )}
+          </ControlGroup>
+        ))}
+
+        {columnFilters.length > 1 &&
+          columnFilters.length > (fixedFilters?.length ?? 0) && (
+            <Button
+              variant="ghost"
+              size="small"
+              onClick={clearAllFilters}
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            >
+              Clear all
+            </Button>
+          )}
+      </div>
+    </div>
+  )
+}

--- a/libs/design-system/src/app/DataTable/DataTable.tsx
+++ b/libs/design-system/src/app/DataTable/DataTable.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { cx } from 'class-variance-authority'
+import {
+  ColumnFiltersState,
+  flexRender,
+  type Row,
+  type Table,
+} from '@tanstack/react-table'
+import { type VirtualItem, type Virtualizer } from '@tanstack/react-virtual'
+import { Label } from '../../core/Label'
+import { Panel } from '../../core/Panel'
+import { ScrollArea } from '../../core/ScrollArea'
+import { Select, Option } from '../../core/Select'
+import { DataTablePaginatorKnownTotal } from './DataTablePaginatorKnownTotal'
+import { ActiveFilters } from './ActiveFilters'
+
+interface DataTableProps<T extends { id: string }> {
+  fixedFilters?: ColumnFiltersState
+  table: Table<T>
+  virtualRows: VirtualItem[]
+  totalSize: number
+  tableContainerRef: React.RefObject<HTMLDivElement | null>
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>
+  rows: Row<T>[]
+  className?: string
+  selectedRowId?: string
+  onRowClick?: (id: string) => void
+  offset: number
+  limit: number
+  onClickFilterIcon?: () => void
+  /** Optional heading to render after the filter icon. */
+  heading?: React.ReactNode
+}
+
+const defaultWidth = 100
+
+export function DataTable<T extends { id: string }>({
+  fixedFilters,
+  table,
+  virtualRows,
+  totalSize,
+  tableContainerRef,
+  rowVirtualizer,
+  rows,
+  className,
+  selectedRowId,
+  onRowClick,
+  offset,
+  limit,
+  onClickFilterIcon,
+  heading,
+}: DataTableProps<T>) {
+  const filteredTotal = table.getFilteredRowModel().rows.length
+
+  return (
+    <Panel
+      className={cx(
+        '@container flex flex-col h-full w-full overflow-hidden',
+        className,
+      )}
+    >
+      <div className="z-10 flex items-center justify-between gap-4 bg-graydark-200 py-2 px-4 border-b border-gray-200 dark:border-graydark-400">
+        <ActiveFilters
+          fixedFilters={fixedFilters}
+          table={table}
+          onClickFilterIcon={onClickFilterIcon}
+          heading={heading}
+        />
+      </div>
+      <div className="flex-1 overflow-hidden relative">
+        <ScrollArea ref={tableContainerRef} className="relative">
+          <div className="min-w-fit">
+            <table className="text-sm" style={{ display: 'grid' }}>
+              <thead className="sticky top-0 z-10 bg-graydark-200 border-b border-gray-100/60 dark:border-graydark-300">
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr
+                    key={headerGroup.id}
+                    style={{ display: 'flex', width: '100%' }}
+                  >
+                    {headerGroup.headers.map((header) => {
+                      const { width = defaultWidth, className } = header.column
+                        .columnDef.meta as {
+                        width?: number
+                        className?: string
+                      }
+                      return (
+                        <th
+                          key={header.id}
+                          className={cx(
+                            'px-2 py-2 overflow-hidden border-r border-gray-100/60 dark:border-graydark-300/20',
+                            className,
+                          )}
+                          style={{
+                            width,
+                          }}
+                        >
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                        </th>
+                      )
+                    })}
+                  </tr>
+                ))}
+              </thead>
+              <tbody
+                style={{
+                  display: 'grid',
+                  height: `${totalSize}px`,
+                  position: 'relative',
+                }}
+              >
+                {virtualRows.map((virtualRow) => {
+                  const row = rows[virtualRow.index]
+                  return (
+                    <tr
+                      key={row.id}
+                      data-index={virtualRow.index}
+                      ref={(node) => rowVirtualizer.measureElement(node)}
+                      style={{
+                        display: 'flex',
+                        position: 'absolute',
+                        transform: `translateY(${virtualRow.start}px)`,
+                        willChange: 'transform',
+                        width: '100%',
+                      }}
+                      className={cx(
+                        'cursor-pointer transition-colors',
+                        selectedRowId === row.original.id
+                          ? 'bg-blue-50 dark:bg-blue-900/30'
+                          : 'hover:bg-blue-100 dark:hover:bg-blue-900/40',
+                        'border-b border-gray-100 dark:border-graydark-300',
+                      )}
+                      onClick={() => onRowClick?.(row.original.id)}
+                    >
+                      {row.getVisibleCells().map((cell) => {
+                        const { width = defaultWidth, className } = cell.column
+                          .columnDef.meta as {
+                          width?: number
+                          className?: string
+                        }
+                        return (
+                          <td
+                            key={cell.id}
+                            className={cx(
+                              'relative overflow-hidden whitespace-nowrap text-ellipsis px-2 py-1',
+                              'flex items-center',
+                              'border-r border-gray-100 dark:border-graydark-300/20',
+                              className,
+                            )}
+                            style={{
+                              width,
+                            }}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )}
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </ScrollArea>
+      </div>
+      <div className="z-10 flex items-center justify-end gap-4 bg-graydark-200 py-2 px-4 border-t border-gray-200 dark:border-graydark-400">
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2">
+            <Label
+              htmlFor="page-size"
+              className="text-xs text-neutral-500 hidden @md:block"
+            >
+              Rows per page
+            </Label>
+            <Select
+              id="page-size"
+              className="border rounded px-2 py-1 text-xs"
+              value={table.getState().pagination.pageSize.toString()}
+              onChange={(e) => table.setPageSize(Number(e.target.value))}
+            >
+              {[25, 50, 100, 1000, 10000].map((size) => (
+                <Option key={size} value={size.toString()}>
+                  {size.toLocaleString()}
+                </Option>
+              ))}
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <DataTablePaginatorKnownTotal
+              offset={offset}
+              limit={limit}
+              total={filteredTotal}
+              isLoading={false}
+              firstPage={() => table.firstPage()}
+              previousPage={() => table.previousPage()}
+              nextPage={() => table.nextPage()}
+              lastPage={() => table.lastPage()}
+            />
+          </div>
+        </div>
+      </div>
+    </Panel>
+  )
+}

--- a/libs/design-system/src/app/DataTable/DataTablePaginatorKnownTotal.tsx
+++ b/libs/design-system/src/app/DataTable/DataTablePaginatorKnownTotal.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { Button } from '../../core/Button'
+import { ControlGroup } from '../../core/ControlGroup'
+import {
+  CaretLeft16,
+  CaretRight16,
+  PageFirst16,
+  PageLast16,
+} from '@siafoundation/react-icons'
+import { LoadingDots } from '../../components/LoadingDots'
+
+type Props = {
+  offset: number
+  limit: number
+  isLoading: boolean
+  total: number
+  firstPage: () => void
+  previousPage: () => void
+  nextPage: () => void
+  lastPage: () => void
+}
+
+export function DataTablePaginatorKnownTotal({
+  offset,
+  limit,
+  total,
+  isLoading,
+  firstPage,
+  previousPage,
+  nextPage,
+  lastPage,
+}: Props) {
+  return (
+    <ControlGroup>
+      <Button
+        aria-label="go to first page"
+        icon="contrast"
+        disabled={offset <= 0}
+        size="small"
+        variant="gray"
+        className="rounded-r-none"
+        onClick={() => {
+          firstPage()
+        }}
+      >
+        <div className="flex scale-[0.65]">
+          <PageFirst16 />
+        </div>
+      </Button>
+      <Button
+        aria-label="go to previous page"
+        icon="contrast"
+        disabled={offset <= 0}
+        size="small"
+        variant="gray"
+        className="rounded-none"
+        onClick={() => {
+          previousPage()
+        }}
+      >
+        <CaretLeft16 />
+      </Button>
+      <Button state="waiting" className="rounded-none px-3">
+        {total > 0 ? (
+          `${offset + 1} - ${Math.min(offset + limit, total)} of ${
+            total ? total.toLocaleString() : ''
+          }`
+        ) : isLoading ? (
+          <LoadingDots className="px-2" />
+        ) : (
+          'No results'
+        )}
+      </Button>
+      <Button
+        aria-label="go to next page"
+        icon="contrast"
+        disabled={offset + limit >= total}
+        size="small"
+        variant="gray"
+        className="rounded-none"
+        onClick={() => {
+          nextPage()
+        }}
+      >
+        <CaretRight16 />
+      </Button>
+      <Button
+        aria-label="go to last page"
+        icon="contrast"
+        disabled={offset + limit >= total}
+        size="small"
+        variant="gray"
+        className="rounded-l-none"
+        onClick={() => {
+          lastPage()
+        }}
+      >
+        <div className="flex" style={{ transform: 'scale(0.65)' }}>
+          <PageLast16 />
+        </div>
+      </Button>
+    </ControlGroup>
+  )
+}

--- a/libs/design-system/src/app/DataTable/useDataTable.tsx
+++ b/libs/design-system/src/app/DataTable/useDataTable.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import {
+  useReactTable,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getFilteredRowModel,
+  type ColumnDef,
+  type PaginationState,
+  type OnChangeFn,
+  type ColumnFiltersState,
+  getFacetedMinMaxValues,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
+  SortingState,
+  getSortedRowModel,
+} from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { useCallback, useMemo, useRef } from 'react'
+
+interface DataTableProps<T extends { id: string }> {
+  columns: ColumnDef<T>[]
+  data: T[]
+  fixedFilters?: ColumnFiltersState
+  columnFilters: ColumnFiltersState
+  columnSorts: SortingState
+  setColumnFilters?: OnChangeFn<ColumnFiltersState>
+  setColumnSorts?: OnChangeFn<SortingState>
+  offset: number
+  limit: number
+  setOffset: (offset: number) => void
+  setLimit: (limit: number) => void
+  onRowClick?: (id: string) => void
+}
+
+export function useDataTable<T extends { id: string }>({
+  columns,
+  data,
+  columnFilters,
+  fixedFilters,
+  columnSorts,
+  setColumnFilters,
+  setColumnSorts,
+  offset,
+  limit,
+  setOffset,
+  setLimit,
+  onRowClick,
+}: DataTableProps<T>) {
+  const tableContainerRef = useRef<HTMLDivElement>(null)
+
+  // Convert URL offset/limit to TanStack pageIndex/pageSize
+  const pagination = useMemo(() => {
+    const pageIndex = Math.floor(offset / limit)
+    const pageSize = limit
+    return {
+      pageIndex,
+      pageSize,
+    }
+  }, [offset, limit])
+
+  // Handle pagination changes from TanStack and sync to URL
+  const handlePaginationChange = useCallback<OnChangeFn<PaginationState>>(
+    (updater) => {
+      const newPagination =
+        typeof updater === 'function' ? updater(pagination) : updater
+      const newOffset = newPagination.pageIndex * newPagination.pageSize
+
+      // Update URL params
+      if (newOffset !== offset) {
+        setOffset(newOffset)
+      }
+      if (newPagination.pageSize !== limit) {
+        setLimit(newPagination.pageSize)
+      }
+    },
+    [pagination, setOffset, setLimit, limit, offset],
+  )
+
+  const table = useReactTable({
+    data,
+    columns,
+    defaultColumn: {
+      size: 200,
+      minSize: 50,
+      maxSize: 500,
+    },
+    state: {
+      pagination,
+      columnFilters,
+      sorting: columnSorts,
+    },
+    onPaginationChange: handlePaginationChange,
+    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setColumnSorts,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getFacetedMinMaxValues: getFacetedMinMaxValues(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    manualPagination: false,
+    debugTable: false,
+  })
+
+  const rows = table.getRowModel().rows
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => tableContainerRef.current,
+    estimateSize: () => 36,
+    overscan: 36,
+  })
+
+  const virtualRows = rowVirtualizer.getVirtualItems()
+  const totalSize = rowVirtualizer.getTotalSize()
+
+  return {
+    tableContainerRef,
+    table,
+    rowVirtualizer,
+    rows,
+    virtualRows,
+    totalSize,
+    pagination,
+    handlePaginationChange,
+    columnFilters,
+    fixedFilters,
+    setColumnFilters,
+    columnSorts,
+    setColumnSorts,
+    offset,
+    limit,
+    setOffset,
+    setLimit,
+    datasetTotal: data.length,
+    onRowClick,
+  }
+}

--- a/libs/design-system/src/app/DataTable/useDataTableParams.tsx
+++ b/libs/design-system/src/app/DataTable/useDataTableParams.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import {
+  ColumnFiltersState,
+  OnChangeFn,
+  SortingState,
+} from '@tanstack/react-table'
+
+export function useDataTableParams(scope: string) {
+  const params = useSearchParams()
+  const pathname = usePathname()
+  const router = useRouter()
+  const limit = parseInt(params.get(`${scope}Limit`) || '1000', 10) || 1000
+  const offset = parseInt(params.get(`${scope}Offset`) || '0', 10) || 0
+  const selectedId = params.get(`${scope}Id`) as string | undefined
+
+  const setPage = useCallback(
+    (offset: number) => {
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      paramsObj.set(`${scope}Offset`, String(offset))
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, scope, pathname],
+  )
+
+  const setPageSize = useCallback(
+    (size: number) => {
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      paramsObj.set(`${scope}Limit`, String(size))
+      paramsObj.set(`${scope}Offset`, '0') // reset to first page
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, scope, pathname],
+  )
+
+  const setSelectedId = useCallback(
+    (id: string | undefined) => {
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      if (id) {
+        paramsObj.set(`${scope}Id`, id)
+      } else {
+        paramsObj.delete(`${scope}Id`)
+      }
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, pathname, scope],
+  )
+
+  const setOffset = useCallback(
+    (offset: number) => {
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      paramsObj.set(`${scope}Offset`, String(offset))
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, pathname, scope],
+  )
+
+  const setLimit = useCallback(
+    (limit: number) => {
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      paramsObj.set(`${scope}Limit`, String(limit))
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, pathname, scope],
+  )
+
+  const columnFiltersParams = params.get(`${scope}Filters`)
+  const columnFilters = useMemo(() => {
+    return columnFiltersParams
+      ? (JSON.parse(columnFiltersParams) as ColumnFiltersState)
+      : []
+  }, [columnFiltersParams])
+
+  const setColumnFilters: OnChangeFn<ColumnFiltersState> = useCallback(
+    (filtersFn) => {
+      const filters =
+        typeof filtersFn === 'function' ? filtersFn(columnFilters) : filtersFn
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      paramsObj.set(`${scope}Filters`, JSON.stringify(filters))
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, pathname, scope, columnFilters],
+  )
+
+  const columnSortsParams = params.get(`${scope}Sorts`)
+  const columnSorts = useMemo(() => {
+    return columnSortsParams
+      ? (JSON.parse(columnSortsParams) as SortingState)
+      : []
+  }, [columnSortsParams])
+
+  const setColumnSorts: OnChangeFn<SortingState> = useCallback(
+    (sortsFn) => {
+      const sorts =
+        typeof sortsFn === 'function' ? sortsFn(columnSorts) : sortsFn
+      const paramsObj = new URLSearchParams(Array.from(params.entries()))
+      paramsObj.set(`${scope}Sorts`, JSON.stringify(sorts))
+      router.push(`${pathname}?${paramsObj.toString()}`)
+    },
+    [router, params, pathname, scope, columnSorts],
+  )
+
+  return {
+    offset,
+    limit,
+    setPage,
+    setPageSize,
+    selectedId,
+    setSelectedId,
+    setOffset,
+    setLimit,
+    columnFilters,
+    setColumnFilters,
+    columnSorts,
+    setColumnSorts,
+  }
+}

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -120,6 +120,9 @@ export * from './app/TestnetWarningBanner'
 export * from './app/NextAppSsrAppRouter'
 export * from './app/NextAppCsr'
 export * from './app/HostMap'
+export * from './app/DataTable/DataTable'
+export * from './app/DataTable/useDataTable'
+export * from './app/DataTable/useDataTableParams'
 
 // form
 export * from './form/ConfigurationPanel'


### PR DESCRIPTION
- Added TanStack-based DataTable and supporting hooks.
  - Initial pass at a TanStack table for use in indexd and eventually it can replace our homegrown table API in all apps.
  - Subject to change as we build out indexd and figure out what we need.
  - Currently configured to support virtualization, and client-side pagination, faceting, filtering, sorting by default.
  - Table data parameters are URL driven and uniquely scoped.
  - Table goes for more density than those in our existing apps, also aims to support displaying and manipulating thousands of rows.
  - Reason for introducing this is that it will provide solid foundation with strong ecosystem of plugins for column filtering, faceting, ordering, etc and especially virtualization - users have asked for many of these features and they will be easier to implement and maintain with this library. Also interestingly the table's API is pretty much the same as our homegrown ones.
  
### screenshot from next PR which uses it in indexd
<img width="1461" height="795" alt="Screenshot 2025-08-01 at 12 06 37 PM" src="https://github.com/user-attachments/assets/8306f635-20a8-48b9-942d-489334ab336e" />