### PR TITLE
refactor(indexd): improve data table rendering

### DIFF
--- a/.changeset/major-owls-lick.md
+++ b/.changeset/major-owls-lick.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+The data explorer table rendering performance has been improved.

--- a/apps/indexd/components/Data/Contracts/SidePanelContract.tsx
+++ b/apps/indexd/components/Data/Contracts/SidePanelContract.tsx
@@ -32,9 +32,11 @@ export function SidePanelContract() {
   }, [contract])
   if (!contract) {
     return (
-      <div className="flex flex-col items-center justify-center overflow-hidden">
-        <Text>Contract not found</Text>
-      </div>
+      <SidePanel heading={null}>
+        <div className="flex justify-center pt-[50px]">
+          <Text color="subtle">Contract not found</Text>
+        </div>
+      </SidePanel>
     )
   }
   return (

--- a/apps/indexd/components/Data/Contracts/contractsColumns.tsx
+++ b/apps/indexd/components/Data/Contracts/contractsColumns.tsx
@@ -2,15 +2,12 @@ import { type ContractData } from './types'
 import {
   Badge,
   Text,
-  CountryFlag,
-  ValueCurrency,
   ValueCopyable,
   Tooltip,
+  ValueWithTooltip,
 } from '@siafoundation/design-system'
 import { type ColumnDef } from '@tanstack/react-table'
 import { TableHeader } from '../columns'
-import { humanBytes } from '@siafoundation/units'
-import BigNumber from 'bignumber.js'
 import { UsabilityBadges } from '../UsabilityBadges'
 import { CheckmarkFilled16, CloseFilled16 } from '@siafoundation/react-icons'
 import { selectColumn } from '../sharedColumns/select'
@@ -75,13 +72,20 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'host.location.countryCode',
-    cell: ({ getValue }) => {
-      const code = getValue<string>()
-      if (code === 'unknown') return <Text color="verySubtle">-</Text>
+    cell: ({ row, getValue }) => {
+      if (row.original.host?.location?.countryCode === 'unknown') {
+        return (
+          <div className="py-1">
+            <Text color="verySubtle">-</Text>
+          </div>
+        )
+      }
       return (
         <span className="flex items-center gap-1">
-          <CountryFlag countryCode={code} />
-          <Text>{code}</Text>
+          <span role="img" aria-label={row.original.displayFields.countryName}>
+            {row.original.displayFields.countryFlag}
+          </span>
+          <Text>{row.original.host?.location.countryCode}</Text>
         </span>
       )
     },
@@ -152,14 +156,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'formation',
-    cell: ({ getValue }) => (
-      <Text>
-        {Intl.DateTimeFormat('en-US', {
-          dateStyle: 'short',
-          timeStyle: 'short',
-        }).format(new Date(getValue<string>()))}
-      </Text>
-    ),
+    cell: ({ row }) => <Text>{row.original.displayFields.formation}</Text>,
     meta: { className: 'justify-end', width: 140 },
   },
   {
@@ -170,7 +167,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'proofHeight',
-    cell: ({ getValue }) => <Text>{getValue<number>().toLocaleString()}</Text>,
+    cell: ({ row }) => <Text>{row.original.displayFields.proofHeight}</Text>,
     meta: { className: 'justify-end' },
   },
   {
@@ -181,7 +178,9 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'expirationHeight',
-    cell: ({ getValue }) => <Text>{getValue<number>().toLocaleString()}</Text>,
+    cell: ({ row }) => (
+      <Text>{row.original.displayFields.expirationHeight}</Text>
+    ),
     meta: { className: 'justify-end' },
   },
   {
@@ -192,14 +191,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'nextPrune',
-    cell: ({ getValue }) => (
-      <Text>
-        {Intl.DateTimeFormat('en-US', {
-          dateStyle: 'short',
-          timeStyle: 'short',
-        }).format(new Date(getValue<string>()))}
-      </Text>
-    ),
+    cell: ({ row }) => <Text>{row.original.displayFields.nextPrune}</Text>,
     meta: { className: 'justify-end', width: 140 },
   },
   {
@@ -210,13 +202,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'lastBroadcastAttempt',
-    cell: ({ getValue }) => (
-      <Text>
-        {Intl.DateTimeFormat('en-US', {
-          dateStyle: 'short',
-          timeStyle: 'short',
-        }).format(new Date(getValue<string>()))}
-      </Text>
+    cell: ({ row }) => (
+      <Text>{row.original.displayFields.lastBroadcastAttempt}</Text>
     ),
     meta: { className: 'justify-end', width: 140 },
   },
@@ -228,7 +215,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'size',
-    cell: ({ getValue }) => <Text>{humanBytes(getValue<number>())}</Text>,
+    cell: ({ row }) => <Text>{row.original.displayFields.capacity}</Text>,
     meta: { className: 'justify-end' },
   },
   {
@@ -239,7 +226,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'capacity',
-    cell: ({ getValue }) => <Text>{humanBytes(getValue<number>())}</Text>,
+    cell: ({ row }) => <Text>{row.original.displayFields.dataSize}</Text>,
     meta: { className: 'justify-end' },
   },
   {
@@ -250,12 +237,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'spending.sectorRoots',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.spendSectorRoots} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -272,12 +255,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'spending.appendSector',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.spendAppendSector} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -294,12 +273,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'spending.freeSector',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.spendFreeSector} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -316,12 +291,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'spending.fundAccount',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.spendFundAccount} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -338,12 +309,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'initialAllowance',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.initialAllowance} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -360,12 +327,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'remainingAllowance',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.remainingAllowance} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -382,12 +345,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'totalCollateral',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.totalCollateral} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -404,12 +363,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'usedCollateral',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.usedCollateral} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -426,12 +381,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'contractPrice',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.contractPrice} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -448,12 +399,8 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'minerFee',
-    cell: ({ getValue }) => (
-      <ValueCurrency
-        variant="value"
-        font="sans"
-        value={new BigNumber(getValue<string>())}
-      />
+    cell: ({ row }) => (
+      <ValueWithTooltip {...row.original.displayFields.minerFee} />
     ),
     meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
@@ -470,7 +417,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'revisionNumber',
-    cell: ({ getValue }) => <Text>{getValue<number>()?.toLocaleString()}</Text>,
+    cell: ({ row }) => <Text>{row.original.displayFields.revisionNumber}</Text>,
     meta: { className: 'justify-end' },
   },
   {
@@ -481,13 +428,11 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'renewedFrom',
-    cell: ({ getValue }) => {
-      const value = getValue<string>()
-      if (
-        value ===
-        '0000000000000000000000000000000000000000000000000000000000000000'
-      )
+    cell: ({ row }) => {
+      const value = row.original.displayFields.renewedFrom
+      if (value === '-') {
         return <Text color="verySubtle">-</Text>
+      }
       return <Text>{value}</Text>
     },
     meta: { className: 'justify-end' },
@@ -500,13 +445,11 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       </TableHeader>
     ),
     accessorKey: 'renewedTo',
-    cell: ({ getValue }) => {
-      const value = getValue<string>()
-      if (
-        value ===
-        '0000000000000000000000000000000000000000000000000000000000000000'
-      )
+    cell: ({ row }) => {
+      const value = row.original.displayFields.renewedTo
+      if (value === '-') {
         return <Text color="verySubtle">-</Text>
+      }
       return <Text>{value}</Text>
     },
     meta: { className: 'justify-end' },

--- a/apps/indexd/components/Data/Contracts/transform.ts
+++ b/apps/indexd/components/Data/Contracts/transform.ts
@@ -1,28 +1,38 @@
 import { ContractData } from './types'
 import { BigNumber } from 'bignumber.js'
 import { transformHost } from '../Hosts/transform'
-import { CurrencyOption } from '@siafoundation/react-core'
+import {
+  CurrencyDisplayPreference,
+  CurrencyOption,
+} from '@siafoundation/react-core'
 import { Contract, Host } from '@siafoundation/indexd-types'
+import {
+  countryCodeEmoji,
+  getCountryName,
+  humanBytes,
+} from '@siafoundation/units'
+import { getCurrencyDisplayPropsPreferred } from '@siafoundation/design-system'
 
 export function transformContract(
   contract: Contract,
   {
-    geo,
+    location,
     host,
     exchange,
+    currencyDisplay,
   }: {
     host?: Host
-    geo?: {
-      publicKey: string
-      location: { countryCode: string; latitude: number; longitude: number }
-    }[]
-    exchange: { currency: CurrencyOption; rate: BigNumber }
+    location?: { countryCode: string; latitude: number; longitude: number }
+    currencyDisplay: CurrencyDisplayPreference
+    exchange: { currency: CurrencyOption; rate: BigNumber } | undefined
   },
 ): ContractData {
   const datum: ContractData = {
     ...contract,
     id: contract.id,
-    host: host ? transformHost(host, { geo, exchange }) : undefined,
+    host: host
+      ? transformHost(host, { location, exchange, currencyDisplay })
+      : undefined,
     exchange,
     sortingFields: {
       spending: {
@@ -38,6 +48,103 @@ export function transformContract(
       usedCollateral: new BigNumber(contract.usedCollateral),
       initialAllowance: new BigNumber(contract.initialAllowance),
     },
+    displayFields: transformContractDisplayFields(
+      contract,
+      location,
+      currencyDisplay,
+      exchange,
+    ),
   }
   return datum
+}
+
+function transformContractDisplayFields(
+  contract: Contract,
+  location:
+    | { countryCode: string; latitude: number; longitude: number }
+    | undefined,
+  currencyDisplay: CurrencyDisplayPreference,
+  exchange: { currency: CurrencyOption; rate: BigNumber } | undefined,
+) {
+  return {
+    contractPrice: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.contractPrice),
+      currencyDisplay,
+      exchange,
+    }),
+    minerFee: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.minerFee),
+      currencyDisplay,
+      exchange,
+    }),
+    usedCollateral: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.usedCollateral),
+      currencyDisplay,
+      exchange,
+    }),
+    initialAllowance: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.initialAllowance),
+      currencyDisplay,
+      exchange,
+    }),
+    remainingAllowance: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.remainingAllowance),
+      currencyDisplay,
+      exchange,
+    }),
+    totalCollateral: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.totalCollateral),
+      currencyDisplay,
+      exchange,
+    }),
+    spendSectorRoots: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.spending.sectorRoots),
+      currencyDisplay,
+      exchange,
+    }),
+    spendAppendSector: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.spending.appendSector),
+      currencyDisplay,
+      exchange,
+    }),
+    spendFreeSector: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.spending.freeSector),
+      currencyDisplay,
+      exchange,
+    }),
+    spendFundAccount: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(contract.spending.fundAccount),
+      currencyDisplay,
+      exchange,
+    }),
+    countryFlag: countryCodeEmoji(location?.countryCode),
+    countryName: getCountryName(location?.countryCode),
+    formation: Intl.DateTimeFormat('en-US', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(contract.formation)),
+    proofHeight: contract.proofHeight.toLocaleString(),
+    expirationHeight: contract.expirationHeight.toLocaleString(),
+    nextPrune: Intl.DateTimeFormat('en-US', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(contract.nextPrune)),
+    lastBroadcastAttempt: Intl.DateTimeFormat('en-US', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date(contract.lastBroadcastAttempt)),
+    capacity: humanBytes(contract.size),
+    dataSize: humanBytes(contract.capacity),
+    renewedFrom:
+      contract.renewedFrom ===
+      '0000000000000000000000000000000000000000000000000000000000000000'
+        ? '-'
+        : contract.renewedFrom,
+    renewedTo:
+      contract.renewedTo ===
+      '0000000000000000000000000000000000000000000000000000000000000000'
+        ? '-'
+        : contract.renewedTo,
+    revisionNumber: contract.revisionNumber.toLocaleString(),
+  }
 }

--- a/apps/indexd/components/Data/Contracts/types.ts
+++ b/apps/indexd/components/Data/Contracts/types.ts
@@ -2,6 +2,7 @@ import { Contract } from '@siafoundation/indexd-types'
 import { HostData } from '../Hosts/types'
 import { CurrencyOption } from '@siafoundation/react-core'
 import BigNumber from 'bignumber.js'
+import { CurrencyDisplayProps } from '@siafoundation/design-system'
 
 export type ContractData = Contract & {
   id: string
@@ -23,5 +24,29 @@ export type ContractData = Contract & {
     minerFee: BigNumber
     usedCollateral: BigNumber
     initialAllowance: BigNumber
+  }
+  displayFields: {
+    contractPrice: CurrencyDisplayProps
+    minerFee: CurrencyDisplayProps
+    usedCollateral: CurrencyDisplayProps
+    initialAllowance: CurrencyDisplayProps
+    remainingAllowance: CurrencyDisplayProps
+    totalCollateral: CurrencyDisplayProps
+    spendSectorRoots: CurrencyDisplayProps
+    spendAppendSector: CurrencyDisplayProps
+    spendFreeSector: CurrencyDisplayProps
+    spendFundAccount: CurrencyDisplayProps
+    countryFlag: string
+    countryName: string
+    formation: string
+    proofHeight: string
+    expirationHeight: string
+    nextPrune: string
+    lastBroadcastAttempt: string
+    capacity: string
+    dataSize: string
+    renewedFrom: string
+    renewedTo: string
+    revisionNumber: string
   }
 }

--- a/apps/indexd/components/Data/Hosts/SidePanelHost.tsx
+++ b/apps/indexd/components/Data/Hosts/SidePanelHost.tsx
@@ -35,9 +35,11 @@ export function SidePanelHost() {
   }, [host])
   if (!host) {
     return (
-      <div className="flex flex-col items-center justify-center overflow-hidden">
-        <Text>Host not found</Text>
-      </div>
+      <SidePanel heading={null}>
+        <div className="flex justify-center pt-[50px]">
+          <Text color="subtle">Host not found</Text>
+        </div>
+      </SidePanel>
     )
   }
   return (
@@ -73,15 +75,9 @@ export function SidePanelHost() {
         <div className="flex flex-col gap-2">
           {host.addresses.map((address) => (
             <InfoRow
-              key={address.address}
+              key={address.address + address.protocol}
               label={address.protocol}
-              value={
-                <ValueCopyable
-                  className="justify-end"
-                  value={address.address}
-                  maxLength={24}
-                />
-              }
+              value={<ValueCopyable value={address.address} maxLength={24} />}
             />
           ))}
         </div>

--- a/apps/indexd/components/Data/Hosts/hostsColumns.tsx
+++ b/apps/indexd/components/Data/Hosts/hostsColumns.tsx
@@ -3,23 +3,12 @@ import {
   Text,
   Tooltip,
   ValueCopyable,
-  CountryFlag,
-  ValueCurrency,
   Badge,
+  ValueWithTooltip,
 } from '@siafoundation/design-system'
 import { CheckmarkFilled16, CloseFilled16 } from '@siafoundation/react-icons'
 import { HostData } from './types'
 import { TableHeader } from '../columns'
-import {
-  sectorsToBytes,
-  humanBytes,
-  blocksToWeeks,
-  GBToBytes,
-  storagePriceInHastingsPerTBPerMonth,
-  egressPriceInHastingsPerTBPerMonth,
-  ingressPriceInHastingsPerTBPerMonth,
-} from '@siafoundation/units'
-import { BigNumber } from 'bignumber.js'
 import { UsabilityBadges, UsabilityIndicator } from '../UsabilityBadges'
 import { CountryFilter } from './filters/CountryFilter'
 import { UsableFilter } from './filters/UsableFilter'
@@ -151,7 +140,7 @@ export const columns: ColumnDef<HostData>[] = [
           status={row.original.usability.uptime ? 'usable' : 'unusable'}
           name="recent uptime"
         />
-        <Text>{(row.original.recentUptime * 100).toFixed(1)}%</Text>
+        <Text>{row.original.displayFields.uptime}</Text>
       </div>
     ),
     meta: { className: 'justify-end', width: 100 },
@@ -178,8 +167,10 @@ export const columns: ColumnDef<HostData>[] = [
       }
       return (
         <div className="py-1">
-          <CountryFlag countryCode={row.original.location?.countryCode} />
-          <Text className="ml-1">{row.original.location?.countryCode}</Text>
+          <span role="img" aria-label={row.original.displayFields.countryName}>
+            {row.original.displayFields.countryFlag}
+          </span>
+          <Text className="ml-1">{row.original.location.countryCode}</Text>
         </div>
       )
     },
@@ -193,9 +184,7 @@ export const columns: ColumnDef<HostData>[] = [
       </TableHeader>
     ),
     accessorKey: 'settings.totalStorage',
-    cell: ({ getValue }) => (
-      <Text>{humanBytes(sectorsToBytes(getValue<number>()))}</Text>
-    ),
+    cell: ({ row }) => <Text>{row.original.displayFields.totalStorage}</Text>,
     meta: { className: 'justify-end' },
   },
   {
@@ -206,22 +195,14 @@ export const columns: ColumnDef<HostData>[] = [
       </TableHeader>
     ),
     accessorKey: 'settings.remainingStorage',
-    cell: ({ getValue }) => {
-      const value = sectorsToBytes(getValue<number>())
-      const lowStorageThreshold = GBToBytes(10)
+    cell: ({ row }) => {
       return (
         <div className="flex items-center justify-end gap-1">
           <UsabilityIndicator
-            status={
-              value.eq(0)
-                ? 'unusable'
-                : value.lt(lowStorageThreshold)
-                  ? 'warning'
-                  : 'usable'
-            }
+            status={row.original.displayFields.remainingStorageUsability}
             name="storage"
           />
-          <Text>{humanBytes(value)}</Text>
+          <Text>{row.original.displayFields.remainingStorage}</Text>
         </div>
       )
     },
@@ -241,13 +222,7 @@ export const columns: ColumnDef<HostData>[] = [
           status={row.original.usability.storagePrice ? 'usable' : 'unusable'}
           name="storage price"
         />
-        <ValueCurrency
-          variant="value"
-          font="sans"
-          value={storagePriceInHastingsPerTBPerMonth({
-            price: row.original.settings.prices.storagePrice,
-          })}
-        />
+        <ValueWithTooltip {...row.original.displayFields.storagePrice} />
       </div>
     ),
     meta: {
@@ -274,13 +249,7 @@ export const columns: ColumnDef<HostData>[] = [
             status={row.original.usability.ingressPrice ? 'usable' : 'unusable'}
             name="ingress price"
           />
-          <ValueCurrency
-            variant="value"
-            font="sans"
-            value={ingressPriceInHastingsPerTBPerMonth({
-              price: row.original.settings.prices.ingressPrice,
-            })}
-          />
+          <ValueWithTooltip {...row.original.displayFields.ingressPrice} />
         </div>
       )
     },
@@ -305,13 +274,7 @@ export const columns: ColumnDef<HostData>[] = [
           status={row.original.usability.egressPrice ? 'usable' : 'unusable'}
           name="egress price"
         />
-        <ValueCurrency
-          variant="value"
-          font="sans"
-          value={egressPriceInHastingsPerTBPerMonth({
-            price: row.original.settings.prices.egressPrice,
-          })}
-        />
+        <ValueWithTooltip {...row.original.displayFields.egressPrice} />
       </div>
     ),
     meta: { className: 'justify-end' },
@@ -337,15 +300,10 @@ export const columns: ColumnDef<HostData>[] = [
           }
           name="free sector price"
         />
-        <ValueCurrency
-          variant="value"
-          font="sans"
-          fixed={10}
-          value={new BigNumber(getValue<number>())}
-        />
+        <ValueWithTooltip {...row.original.displayFields.freeSectorPrice} />
       </div>
     ),
-    meta: { className: 'justify-end', width: 160 },
+    meta: { className: 'justify-end' },
     sortingFn: (rowA, rowB) => {
       return rowA.original.sortFields.freeSectorPrice
         .minus(rowB.original.sortFields.freeSectorPrice)
@@ -368,7 +326,7 @@ export const columns: ColumnDef<HostData>[] = [
           }
           name="max contract duration"
         />
-        <Text>{blocksToWeeks(getValue<number>()).toFixed(1)} weeks</Text>
+        <Text>{row.original.displayFields.maxContractDuration}</Text>
       </div>
     ),
     meta: { className: 'justify-end', width: 120 },
@@ -387,11 +345,7 @@ export const columns: ColumnDef<HostData>[] = [
           status={row.original.usability.maxCollateral ? 'usable' : 'unusable'}
           name="max collateral"
         />
-        <ValueCurrency
-          variant="value"
-          font="sans"
-          value={new BigNumber(getValue<string>())}
-        />
+        <ValueWithTooltip {...row.original.displayFields.maxCollateral} />
       </div>
     ),
     meta: { className: 'justify-end', width: 120 },
@@ -417,7 +371,7 @@ export const columns: ColumnDef<HostData>[] = [
           }
           name="protocol version"
         />
-        <Text>{getValue<[number, number, number]>().join('.')}</Text>
+        <Text>{row.original.displayFields.protocolVersion}</Text>
       </div>
     ),
     meta: { className: 'justify-end', width: 120 },
@@ -430,13 +384,13 @@ export const columns: ColumnDef<HostData>[] = [
       </TableHeader>
     ),
     accessorKey: 'settings.prices.validUntil',
-    cell: ({ row, getValue }) => (
+    cell: ({ row }) => (
       <div className="flex items-center justify-end gap-1">
         <UsabilityIndicator
           status={row.original.usability.priceValidity ? 'usable' : 'unusable'}
           name="price validity"
         />
-        <Text>{new Date(getValue<string>()).toLocaleString()}</Text>
+        <Text>{row.original.displayFields.priceValidity}</Text>
       </div>
     ),
     meta: { className: 'justify-end', width: 220 },
@@ -449,7 +403,7 @@ export const columns: ColumnDef<HostData>[] = [
       </TableHeader>
     ),
     accessorKey: 'settings.release',
-    cell: ({ getValue }) => <Text>{getValue<string>()}</Text>,
+    cell: ({ row }) => <Text>{row.original.displayFields.release}</Text>,
     meta: { className: 'justify-end', width: 120 },
   },
 ]

--- a/apps/indexd/components/Data/Hosts/transform.ts
+++ b/apps/indexd/components/Data/Hosts/transform.ts
@@ -1,18 +1,33 @@
 import { HostData } from './types'
 import { BigNumber } from 'bignumber.js'
 import { Host } from '@siafoundation/indexd-types'
-import { CurrencyOption } from '@siafoundation/react-core'
+import {
+  CurrencyDisplayPreference,
+  CurrencyOption,
+} from '@siafoundation/react-core'
+import {
+  egressPriceInHastingsPerTBPerMonth,
+  GBToBytes,
+  countryCodeEmoji,
+  getCountryName,
+  humanBytes,
+  ingressPriceInHastingsPerTBPerMonth,
+  storagePriceInHastingsPerTBPerMonth,
+  sectorsToBytes,
+  blocksToWeeks,
+} from '@siafoundation/units'
+import { getCurrencyDisplayPropsPreferred } from '@siafoundation/design-system'
+import { getV2HostSettingsProtcolVersion } from '@siafoundation/types'
 
 export function transformHost(
   host: Host,
   {
-    geo,
+    location,
+    currencyDisplay,
     exchange,
   }: {
-    geo?: {
-      publicKey: string
-      location: { countryCode: string; latitude: number; longitude: number }
-    }[]
+    location?: { countryCode: string; latitude: number; longitude: number }
+    currencyDisplay: CurrencyDisplayPreference
     exchange?: { currency: CurrencyOption; rate: BigNumber }
   },
 ): HostData {
@@ -20,7 +35,7 @@ export function transformHost(
     ...host,
     id: host.publicKey,
     usable: Object.values(host.usability).every((value) => value),
-    location: geo?.find((h) => h.publicKey === host.publicKey)?.location || {
+    location: location || {
       countryCode: 'unknown',
       latitude: 0,
       longitude: 0,
@@ -33,6 +48,73 @@ export function transformHost(
       freeSectorPrice: new BigNumber(host.settings.prices.freeSectorPrice),
       maxCollateral: new BigNumber(host.settings.prices.collateral),
     },
+    displayFields: transformHostDisplayFields(
+      host,
+      location,
+      currencyDisplay,
+      exchange,
+    ),
   }
   return datum
+}
+
+function transformHostDisplayFields(
+  host: Host,
+  location:
+    | { countryCode: string; latitude: number; longitude: number }
+    | undefined,
+  currencyDisplay: CurrencyDisplayPreference,
+  exchange?: { currency: CurrencyOption; rate: BigNumber },
+) {
+  const remainingStorageBytes = sectorsToBytes(host.settings.remainingStorage)
+  const lowStorageThresholdBytes = GBToBytes(10)
+  const remainingStorageUsability: 'usable' | 'warning' | 'unusable' =
+    remainingStorageBytes.eq(0)
+      ? 'unusable'
+      : remainingStorageBytes.lt(lowStorageThresholdBytes)
+        ? 'warning'
+        : 'usable'
+  return {
+    uptime: `${(host.recentUptime * 100).toFixed(1)}%`,
+    totalStorage: humanBytes(sectorsToBytes(host.settings.totalStorage)),
+    remainingStorage: humanBytes(remainingStorageBytes),
+    remainingStorageUsability,
+    storagePrice: getCurrencyDisplayPropsPreferred({
+      sc: storagePriceInHastingsPerTBPerMonth({
+        price: host.settings.prices.storagePrice,
+      }),
+      currencyDisplay,
+      exchange,
+    }),
+    ingressPrice: getCurrencyDisplayPropsPreferred({
+      sc: ingressPriceInHastingsPerTBPerMonth({
+        price: host.settings.prices.ingressPrice,
+      }),
+      currencyDisplay,
+      exchange,
+    }),
+    egressPrice: getCurrencyDisplayPropsPreferred({
+      sc: egressPriceInHastingsPerTBPerMonth({
+        price: host.settings.prices.egressPrice,
+      }),
+      currencyDisplay,
+      exchange,
+    }),
+    freeSectorPrice: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(host.settings.prices.freeSectorPrice),
+      currencyDisplay,
+      exchange,
+    }),
+    maxCollateral: getCurrencyDisplayPropsPreferred({
+      sc: new BigNumber(host.settings.prices.collateral),
+      currencyDisplay,
+      exchange,
+    }),
+    maxContractDuration: `${blocksToWeeks(host.settings.maxContractDuration).toFixed(1)} weeks`,
+    protocolVersion: getV2HostSettingsProtcolVersion(host.settings),
+    priceValidity: new Date(host.settings.prices.validUntil).toLocaleString(),
+    release: host.settings.release,
+    countryName: getCountryName(location?.countryCode),
+    countryFlag: countryCodeEmoji(location?.countryCode),
+  }
 }

--- a/apps/indexd/components/Data/Hosts/types.ts
+++ b/apps/indexd/components/Data/Hosts/types.ts
@@ -1,6 +1,7 @@
 import { Host } from '@siafoundation/indexd-types'
 import { CurrencyOption } from '@siafoundation/react-core'
 import BigNumber from 'bignumber.js'
+import { CurrencyDisplayProps } from '@siafoundation/design-system'
 
 export type HostLocation =
   | {
@@ -28,5 +29,22 @@ export type HostData = Host & {
     egressPrice: BigNumber
     freeSectorPrice: BigNumber
     maxCollateral: BigNumber
+  }
+  displayFields: {
+    uptime: string
+    totalStorage: string
+    remainingStorage: string
+    remainingStorageUsability: 'usable' | 'warning' | 'unusable'
+    storagePrice: CurrencyDisplayProps
+    ingressPrice: CurrencyDisplayProps
+    egressPrice: CurrencyDisplayProps
+    freeSectorPrice: CurrencyDisplayProps
+    maxCollateral: CurrencyDisplayProps
+    maxContractDuration: string
+    protocolVersion: string
+    priceValidity: string
+    release: string
+    countryName: string
+    countryFlag: string
   }
 }

--- a/apps/indexd/components/Data/Hosts/useHosts.tsx
+++ b/apps/indexd/components/Data/Hosts/useHosts.tsx
@@ -8,6 +8,7 @@ import {
   useHosts as useIndexHosts,
 } from '@siafoundation/indexd-react'
 import { transformHost } from './transform'
+import { useAppSettings } from '@siafoundation/react-core'
 
 export function useHosts() {
   const state = useIndexdState()
@@ -25,7 +26,11 @@ export function useHosts() {
       online: true,
     },
   })
-  const rawHosts = useIndexHosts()
+  const rawHosts = useIndexHosts({
+    params: {
+      limit: 500,
+    },
+  })
   const exchangeRate = useActiveSiascanExchangeRate()
   const exchange = useMemo(
     () =>
@@ -36,16 +41,21 @@ export function useHosts() {
       },
     [exchangeRate.currency, exchangeRate.rate],
   )
+  const { settings } = useAppSettings()
   const hosts = useMemo(
     () =>
       rawHosts.data?.map((host) => {
+        const location = geo.data?.find(
+          (h) => h.publicKey === host.publicKey,
+        )?.location
         const datum = transformHost(host, {
-          geo: geo.data,
+          location,
+          currencyDisplay: settings.currencyDisplay,
           exchange,
         })
         return datum
       }) || [],
-    [rawHosts.data, geo.data, exchange],
+    [rawHosts.data, geo.data, exchange, settings.currencyDisplay],
   )
 
   return hosts

--- a/apps/indexd/components/Data/SidePanel.tsx
+++ b/apps/indexd/components/Data/SidePanel.tsx
@@ -40,7 +40,7 @@ export function SidePanel({
           {actions}
         </div>
       )}
-      <div className="p-4">{children}</div>
+      <div className="p-4 h-full w-full">{children}</div>
     </Panel>
   )
 }

--- a/apps/indexd/tsconfig.json
+++ b/apps/indexd/tsconfig.json
@@ -11,7 +11,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "incremental": true,
-    "types": ["jest", "node"],
+    "types": [
+      "jest",
+      "node"
+    ],
     "plugins": [
       {
         "name": "next"
@@ -23,8 +26,12 @@
     "**/*.jsx",
     "**/*.ts",
     "**/*.tsx",
+    ".next/types/**/*.ts",
     "next-env.d.ts",
-    ".next/types/**/*.ts"
+    "../../dist/apps/indexd/.next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "jest.config.ts"]
+  "exclude": [
+    "node_modules",
+    "jest.config.ts"
+  ]
 }

--- a/libs/design-system/src/app/DataTable/DataTable.tsx
+++ b/libs/design-system/src/app/DataTable/DataTable.tsx
@@ -10,7 +10,6 @@ import {
 import { type VirtualItem, type Virtualizer } from '@tanstack/react-virtual'
 import { Label } from '../../core/Label'
 import { Panel } from '../../core/Panel'
-import { ScrollArea } from '../../core/ScrollArea'
 import { Select, Option } from '../../core/Select'
 import { DataTablePaginatorKnownTotal } from './DataTablePaginatorKnownTotal'
 import { ActiveFilters } from './ActiveFilters'
@@ -20,6 +19,7 @@ interface DataTableProps<T extends { id: string }> {
   table: Table<T>
   virtualRows: VirtualItem[]
   totalSize: number
+  rowHeight: number
   tableContainerRef: React.RefObject<HTMLDivElement | null>
   rowVirtualizer: Virtualizer<HTMLDivElement, Element>
   rows: Row<T>[]
@@ -40,6 +40,7 @@ export function DataTable<T extends { id: string }>({
   table,
   virtualRows,
   totalSize,
+  rowHeight,
   tableContainerRef,
   rowVirtualizer,
   rows,
@@ -69,7 +70,10 @@ export function DataTable<T extends { id: string }>({
         />
       </div>
       <div className="flex-1 overflow-hidden relative">
-        <ScrollArea ref={tableContainerRef} className="relative">
+        <div
+          ref={tableContainerRef}
+          className="relative w-full h-full overflow-auto"
+        >
           <div className="min-w-fit">
             <table className="text-sm" style={{ display: 'grid' }}>
               <thead className="sticky top-0 z-10 bg-white dark:bg-graydark-200 border-b border-gray-100 dark:border-graydark-300">
@@ -124,7 +128,7 @@ export function DataTable<T extends { id: string }>({
                         display: 'flex',
                         position: 'absolute',
                         transform: `translateY(${virtualRow.start}px)`,
-                        willChange: 'transform',
+                        height: `${rowHeight}px`,
                         width: '100%',
                       }}
                       className={cx(
@@ -178,7 +182,7 @@ export function DataTable<T extends { id: string }>({
               </tbody>
             </table>
           </div>
-        </ScrollArea>
+        </div>
       </div>
       <div className="z-10 flex items-center justify-end gap-4 bg-white dark:bg-graydark-200 py-2 px-4 border-t border-gray-200 dark:border-graydark-400">
         <div className="flex items-center gap-2">

--- a/libs/design-system/src/app/DataTable/useDataTable.tsx
+++ b/libs/design-system/src/app/DataTable/useDataTable.tsx
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 type DataTableProps<T extends { id: string }> = {
   columns: ColumnDef<T>[]
   data: T[]
+  rowHeight?: number
   fixedFilters?: ColumnFiltersState
   columnFilters: ColumnFiltersState
   columnSorts: SortingState
@@ -42,6 +43,7 @@ export type DataTableState<T extends { id: string }> = ReturnType<
 export function useDataTable<T extends { id: string }>({
   columns,
   data,
+  rowHeight = 36,
   columnFilters,
   fixedFilters,
   columnSorts,
@@ -120,8 +122,8 @@ export function useDataTable<T extends { id: string }>({
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableContainerRef.current,
-    estimateSize: () => 36,
-    overscan: 36,
+    estimateSize: () => rowHeight,
+    overscan: 30,
   })
 
   const virtualRows = rowVirtualizer.getVirtualItems()
@@ -144,6 +146,7 @@ export function useDataTable<T extends { id: string }>({
   return {
     data,
     tableContainerRef,
+    rowHeight,
     table,
     rowVirtualizer,
     rows,


### PR DESCRIPTION
- The data explorer table rendering performance has been improved.
  - These changes should be apparent on the Safari browser which was having some issues.
  
### overview
- The host and contract datasets now pre-calculates display data for most columns so that this code does not run as the user scrolls.
- Switch to native scrollbars on the data table (for now) because the radix ones were not playing well with the virtualized scroll, I'll see if I can fix them.
- Added a fixed height to table rows to make virtualized scroll values fully accurate.

### other
  - Added max limit of 500 for host and contract data. (This is temporary fix to play with more of the available data, need to discuss removing the cap or adding server side filter and sorts).