### PR TITLE
feat(indexd): responsive column widths

### DIFF
--- a/.changeset/bumpy-comics-yawn.md
+++ b/.changeset/bumpy-comics-yawn.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+Data explorer columns now expand when more space is available.

--- a/.changeset/major-emus-pay.md
+++ b/.changeset/major-emus-pay.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+DataTable now supports responsive min max column sizing.

--- a/.changeset/purple-papers-stay.md
+++ b/.changeset/purple-papers-stay.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+Full IDs and public keys are now displayed in the data explorer cells.

--- a/apps/indexd/components/Data/Contracts/contractsColumns.tsx
+++ b/apps/indexd/components/Data/Contracts/contractsColumns.tsx
@@ -11,6 +11,13 @@ import { TableHeader } from '../columns'
 import { UsabilityBadges } from '../UsabilityBadges'
 import { CheckmarkFilled16, CloseFilled16 } from '@siafoundation/react-icons'
 import { selectColumn } from '../sharedColumns/select'
+import {
+  hostUsableColumnWidth,
+  smallColumnWidth,
+  timestampColumnWidth,
+  hashColumnWidth,
+  hostBlockedColumnWidth,
+} from '../sharedColumns/sizes'
 
 export const contractsColumns: ColumnDef<ContractData>[] = [
   selectColumn(),
@@ -23,9 +30,13 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'id',
     cell: ({ getValue }) => (
-      <ValueCopyable value={getValue<string>()} type="contract" />
+      <ValueCopyable
+        maxLength={100}
+        value={getValue<string>()}
+        type="contract"
+      />
     ),
-    meta: { className: 'justify-start', width: 160 },
+    meta: { className: 'justify-start', ...hashColumnWidth },
   },
   {
     id: 'status',
@@ -38,7 +49,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ getValue }) => (
       <StatusBadge variant={getValue<boolean>() ? 'good' : 'bad'} />
     ),
-    meta: { className: 'justify-end', width: 80 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'state',
@@ -49,20 +60,24 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'state',
     cell: ({ getValue }) => <StateBadge value={getValue<string>()} />,
-    meta: { className: 'justify-end', width: 80 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'hostPublicKey',
     header: ({ table, column }) => (
-      <TableHeader table={table} column={column}>
+      <TableHeader table={table} column={column} className="justify-start">
         Host Public Key
       </TableHeader>
     ),
     accessorKey: 'hostKey',
     cell: ({ getValue }) => (
-      <ValueCopyable value={getValue<string>()} type="hostPublicKey" />
+      <ValueCopyable
+        maxLength={100}
+        value={getValue<string>()}
+        type="hostPublicKey"
+      />
     ),
-    meta: { className: 'justify-end', width: 160 },
+    meta: { className: 'justify-start', ...hashColumnWidth },
   },
   {
     id: 'location',
@@ -89,7 +104,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
         </span>
       )
     },
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'hostUsable',
@@ -120,7 +135,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
         </div>
       )
     },
-    meta: { className: 'justify-start', width: 160 },
+    meta: { className: 'justify-start', ...hostUsableColumnWidth },
   },
   {
     id: 'hostBlocked',
@@ -146,7 +161,10 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
         </div>
       )
     },
-    meta: { className: 'justify-end' },
+    meta: {
+      className: 'justify-end',
+      ...hostBlockedColumnWidth,
+    },
   },
   {
     id: 'formation',
@@ -157,7 +175,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'formation',
     cell: ({ row }) => <Text>{row.original.displayFields.formation}</Text>,
-    meta: { className: 'justify-end', width: 140 },
+    meta: { className: 'justify-end', ...timestampColumnWidth },
   },
   {
     id: 'proofHeight',
@@ -168,7 +186,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'proofHeight',
     cell: ({ row }) => <Text>{row.original.displayFields.proofHeight}</Text>,
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'expirationHeight',
@@ -181,7 +199,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <Text>{row.original.displayFields.expirationHeight}</Text>
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...timestampColumnWidth },
   },
   {
     id: 'nextPrune',
@@ -192,7 +210,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'nextPrune',
     cell: ({ row }) => <Text>{row.original.displayFields.nextPrune}</Text>,
-    meta: { className: 'justify-end', width: 140 },
+    meta: { className: 'justify-end', ...timestampColumnWidth },
   },
   {
     id: 'lastBroadcastAttempt',
@@ -205,7 +223,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <Text>{row.original.displayFields.lastBroadcastAttempt}</Text>
     ),
-    meta: { className: 'justify-end', width: 140 },
+    meta: { className: 'justify-end', ...timestampColumnWidth },
   },
   {
     id: 'capacity',
@@ -216,7 +234,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'size',
     cell: ({ row }) => <Text>{row.original.displayFields.capacity}</Text>,
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'dataSize',
@@ -227,7 +245,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'capacity',
     cell: ({ row }) => <Text>{row.original.displayFields.dataSize}</Text>,
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'spendingSectorRoots',
@@ -240,7 +258,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.spendSectorRoots} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.spending.sectorRoots
       const b = rowB.original.sortingFields.spending.sectorRoots
@@ -258,7 +276,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.spendAppendSector} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.spending.appendSector
       const b = rowB.original.sortingFields.spending.appendSector
@@ -276,7 +294,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.spendFreeSector} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.spending.freeSector
       const b = rowB.original.sortingFields.spending.freeSector
@@ -294,7 +312,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.spendFundAccount} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.spending.fundAccount
       const b = rowB.original.sortingFields.spending.fundAccount
@@ -312,7 +330,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.initialAllowance} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.spending.sectorRoots
       const b = rowB.original.sortingFields.spending.sectorRoots
@@ -330,7 +348,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.remainingAllowance} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.remainingAllowance
       const b = rowB.original.sortingFields.remainingAllowance
@@ -348,7 +366,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.totalCollateral} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.totalCollateral
       const b = rowB.original.sortingFields.totalCollateral
@@ -366,7 +384,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.usedCollateral} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.usedCollateral
       const b = rowB.original.sortingFields.usedCollateral
@@ -384,7 +402,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.contractPrice} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.contractPrice
       const b = rowB.original.sortingFields.contractPrice
@@ -402,7 +420,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     cell: ({ row }) => (
       <ValueWithTooltip {...row.original.displayFields.minerFee} />
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       const a = rowA.original.sortingFields.minerFee
       const b = rowB.original.sortingFields.minerFee
@@ -418,7 +436,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
     ),
     accessorKey: 'revisionNumber',
     cell: ({ row }) => <Text>{row.original.displayFields.revisionNumber}</Text>,
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'renewedFrom',
@@ -435,7 +453,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       }
       return <Text>{value}</Text>
     },
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...hashColumnWidth },
   },
   {
     id: 'renewedTo',
@@ -452,7 +470,7 @@ export const contractsColumns: ColumnDef<ContractData>[] = [
       }
       return <Text>{value}</Text>
     },
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...hashColumnWidth },
   },
 ]
 

--- a/apps/indexd/components/Data/Hosts/SidePanelHost.tsx
+++ b/apps/indexd/components/Data/Hosts/SidePanelHost.tsx
@@ -46,7 +46,7 @@ export function SidePanelHost() {
     <SidePanel
       onClose={() => setSelectedId(undefined)}
       heading={
-        <Text size="18" weight="medium">
+        <Text size="18" weight="medium" ellipsis>
           {host?.location?.countryCode ? (
             <span className="pr-1">
               <CountryFlag countryCode={host?.location?.countryCode} />

--- a/apps/indexd/components/Data/Hosts/hostsColumns.tsx
+++ b/apps/indexd/components/Data/Hosts/hostsColumns.tsx
@@ -14,6 +14,13 @@ import { CountryFilter } from './filters/CountryFilter'
 import { UsableFilter } from './filters/UsableFilter'
 import { BlockedFilter } from './filters/BlockedFilter'
 import { selectColumn } from '../sharedColumns/select'
+import {
+  hostUsableColumnWidth,
+  smallColumnWidth,
+  timestampColumnWidth,
+  hashColumnWidth,
+  hostBlockedColumnWidth,
+} from '../sharedColumns/sizes'
 
 export const columns: ColumnDef<HostData>[] = [
   selectColumn(),
@@ -26,9 +33,13 @@ export const columns: ColumnDef<HostData>[] = [
     ),
     accessorKey: 'id',
     cell: ({ getValue }) => (
-      <ValueCopyable value={getValue<string>()} type="hostPublicKey" />
+      <ValueCopyable
+        maxLength={100}
+        value={getValue<string>()}
+        type="hostPublicKey"
+      />
     ),
-    meta: { width: 150 },
+    meta: { ...hashColumnWidth },
   },
   {
     id: 'usable',
@@ -65,7 +76,7 @@ export const columns: ColumnDef<HostData>[] = [
       )
     },
     meta: {
-      width: 200,
+      ...hostUsableColumnWidth,
     },
   },
   {
@@ -104,6 +115,7 @@ export const columns: ColumnDef<HostData>[] = [
     },
     meta: {
       className: 'justify-start',
+      ...hostBlockedColumnWidth,
     },
   },
   {
@@ -124,7 +136,7 @@ export const columns: ColumnDef<HostData>[] = [
         />
       </div>
     ),
-    meta: { className: 'justify-end', width: 80 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'uptime',
@@ -143,7 +155,7 @@ export const columns: ColumnDef<HostData>[] = [
         <Text>{row.original.displayFields.uptime}</Text>
       </div>
     ),
-    meta: { className: 'justify-end', width: 100 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'location',
@@ -174,7 +186,7 @@ export const columns: ColumnDef<HostData>[] = [
         </div>
       )
     },
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'totalStorage',
@@ -185,7 +197,7 @@ export const columns: ColumnDef<HostData>[] = [
     ),
     accessorKey: 'settings.totalStorage',
     cell: ({ row }) => <Text>{row.original.displayFields.totalStorage}</Text>,
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'remainingStorage',
@@ -206,7 +218,7 @@ export const columns: ColumnDef<HostData>[] = [
         </div>
       )
     },
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'storagePrice',
@@ -227,6 +239,7 @@ export const columns: ColumnDef<HostData>[] = [
     ),
     meta: {
       className: 'justify-end',
+      ...smallColumnWidth,
     },
     sortingFn: (rowA, rowB) => {
       return rowA.original.sortFields.storagePrice
@@ -253,7 +266,7 @@ export const columns: ColumnDef<HostData>[] = [
         </div>
       )
     },
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       return rowA.original.sortFields.ingressPrice
         .minus(rowB.original.sortFields.ingressPrice)
@@ -277,7 +290,7 @@ export const columns: ColumnDef<HostData>[] = [
         <ValueWithTooltip {...row.original.displayFields.egressPrice} />
       </div>
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       return rowA.original.sortFields.egressPrice
         .minus(rowB.original.sortFields.egressPrice)
@@ -303,7 +316,7 @@ export const columns: ColumnDef<HostData>[] = [
         <ValueWithTooltip {...row.original.displayFields.freeSectorPrice} />
       </div>
     ),
-    meta: { className: 'justify-end' },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       return rowA.original.sortFields.freeSectorPrice
         .minus(rowB.original.sortFields.freeSectorPrice)
@@ -329,7 +342,7 @@ export const columns: ColumnDef<HostData>[] = [
         <Text>{row.original.displayFields.maxContractDuration}</Text>
       </div>
     ),
-    meta: { className: 'justify-end', width: 120 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'maxCollateral',
@@ -348,7 +361,7 @@ export const columns: ColumnDef<HostData>[] = [
         <ValueWithTooltip {...row.original.displayFields.maxCollateral} />
       </div>
     ),
-    meta: { className: 'justify-end', width: 120 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
     sortingFn: (rowA, rowB) => {
       return rowA.original.sortFields.maxCollateral
         .minus(rowB.original.sortFields.maxCollateral)
@@ -374,7 +387,7 @@ export const columns: ColumnDef<HostData>[] = [
         <Text>{row.original.displayFields.protocolVersion}</Text>
       </div>
     ),
-    meta: { className: 'justify-end', width: 120 },
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
   {
     id: 'priceValidity',
@@ -393,7 +406,7 @@ export const columns: ColumnDef<HostData>[] = [
         <Text>{row.original.displayFields.priceValidity}</Text>
       </div>
     ),
-    meta: { className: 'justify-end', width: 220 },
+    meta: { className: 'justify-end', ...timestampColumnWidth },
   },
   {
     id: 'release',
@@ -404,6 +417,6 @@ export const columns: ColumnDef<HostData>[] = [
     ),
     accessorKey: 'settings.release',
     cell: ({ row }) => <Text>{row.original.displayFields.release}</Text>,
-    meta: { className: 'justify-end', width: 120 },
+    meta: { className: 'justify-end', minWidth: 160, maxWidth: 160 },
   },
 ]

--- a/apps/indexd/components/Data/SidePanel.tsx
+++ b/apps/indexd/components/Data/SidePanel.tsx
@@ -24,7 +24,7 @@ export function SidePanel({
         {customCloseAction ||
           (onClose ? (
             <Button
-              className="absolute top-1.5 right-2 p-2 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-blue-500 z-10"
+              className="p-2 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-blue-500 z-10"
               onClick={onClose}
               aria-label="Close drawer"
               variant="ghost"

--- a/apps/indexd/components/Data/sharedColumns/sizes.ts
+++ b/apps/indexd/components/Data/sharedColumns/sizes.ts
@@ -1,0 +1,24 @@
+export const smallColumnWidth = {
+  minWidth: 100,
+  maxWidth: 100,
+}
+
+export const timestampColumnWidth = {
+  minWidth: 200,
+  maxWidth: 220,
+}
+
+export const hostUsableColumnWidth = {
+  minWidth: 200,
+  maxWidth: 1500,
+}
+
+export const hashColumnWidth = {
+  minWidth: 140,
+  maxWidth: 650,
+}
+
+export const hostBlockedColumnWidth = {
+  minWidth: 140,
+  maxWidth: 160,
+}


### PR DESCRIPTION
- Data explorer columns now expand when more space is available.
- DataTable now supports responsive min max column sizing.
- Full IDs and public keys are now displayed in the data explorer cells.

<img width="1314" height="610" alt="Screenshot 2025-08-08 at 11 27 23 AM" src="https://github.com/user-attachments/assets/ceb8716e-b205-4629-8e35-4efdaa3e0561" />
