### PR TITLE
feat(indexd): account explorer

### DIFF
--- a/.changeset/tough-goats-relax.md
+++ b/.changeset/tough-goats-relax.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+The data explorer now has an Accounts mode.

--- a/apps/indexd/components/Data/Accounts/AccountsTab.tsx
+++ b/apps/indexd/components/Data/Accounts/AccountsTab.tsx
@@ -1,0 +1,77 @@
+import {
+  DataTable,
+  useDataTable,
+  useDataTableParams,
+} from '@siafoundation/design-system'
+import { useCallback } from 'react'
+import { accountsColumns } from './accountsColumns'
+import { DataViewSelect, type DataView } from '../Views'
+import { SidePanelAccountList } from './SidePanelAccountList'
+import { SidePanelAccount } from './SidePanelAccount'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { AccountData } from './types'
+import { useAccounts } from './useAccounts'
+import { Layout } from '../Layout'
+
+export function AccountsTab() {
+  const params = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const view = params.get('view') as DataView
+  const setView = (view: DataView) => {
+    const paramsObj = new URLSearchParams(Array.from(params.entries()))
+    paramsObj.set('view', view)
+    router.push(`${pathname}?${paramsObj.toString()}`)
+  }
+  const {
+    offset,
+    limit,
+    setOffset,
+    setLimit,
+    selectedId,
+    setSelectedId,
+    columnFilters,
+    setColumnFilters,
+    columnSorts,
+    setColumnSorts,
+  } = useDataTableParams('accountList')
+  const onRowClick = useCallback(
+    (id: string) => {
+      setSelectedId(id)
+    },
+    [setSelectedId],
+  )
+
+  const accounts = useAccounts()
+  const table = useDataTable<AccountData>({
+    data: accounts,
+    columns: accountsColumns,
+    columnFilters,
+    setColumnFilters,
+    columnSorts,
+    setColumnSorts,
+    offset,
+    limit,
+    onRowClick,
+    setOffset,
+    setLimit,
+  })
+
+  return (
+    <Layout
+      table={
+        <DataTable
+          {...table}
+          heading={<DataViewSelect value={view} onValueChange={setView} />}
+        />
+      }
+      panel={
+        selectedId ? (
+          <SidePanelAccount />
+        ) : (
+          <SidePanelAccountList table={table} />
+        )
+      }
+    />
+  )
+}

--- a/apps/indexd/components/Data/Accounts/SidePanelAccount.tsx
+++ b/apps/indexd/components/Data/Accounts/SidePanelAccount.tsx
@@ -1,0 +1,38 @@
+import { Text, truncate } from '@siafoundation/design-system'
+import { useDataTableParams } from '@siafoundation/design-system'
+import { useMemo } from 'react'
+import { SidePanel } from '../SidePanel'
+import { useAccounts } from './useAccounts'
+
+export function SidePanelAccount() {
+  const { selectedId, setSelectedId } = useDataTableParams('accountList')
+  // TODO: Temporary until an account detail endpoint is added.
+  const accounts = useAccounts()
+  const account = useMemo(
+    () => accounts.find((a) => a.id === selectedId),
+    [selectedId, accounts],
+  )
+  if (!account) {
+    return (
+      <SidePanel heading={null}>
+        <div className="flex justify-center pt-[50px]">
+          <Text color="subtle">Account not found</Text>
+        </div>
+      </SidePanel>
+    )
+  }
+  return (
+    <SidePanel
+      onClose={() => setSelectedId(undefined)}
+      heading={
+        <Text size="18" weight="medium" ellipsis>
+          Account: {truncate(account?.publicKey, 24)}
+        </Text>
+      }
+    >
+      <Text color="subtle" className="flex justify-center pt-[50px]">
+        No further information on accounts yet
+      </Text>
+    </SidePanel>
+  )
+}

--- a/apps/indexd/components/Data/Accounts/SidePanelAccountList.tsx
+++ b/apps/indexd/components/Data/Accounts/SidePanelAccountList.tsx
@@ -1,0 +1,38 @@
+import { Text, Button, DataTableState } from '@siafoundation/design-system'
+import { AccountData } from './types'
+import { SidePanel } from '../SidePanel'
+import { useMemo } from 'react'
+
+export function SidePanelAccountList({
+  table,
+}: {
+  table: DataTableState<AccountData>
+}) {
+  const accounts = useMemo(() => {
+    return table.isSelection ? table.selectedRows : table.rows
+  }, [table.isSelection, table.selectedRows, table.rows])
+  return (
+    <SidePanel
+      heading={
+        <Text size="18" weight="medium">
+          {table.isSelection
+            ? `Selected accounts (${accounts.length})`
+            : table.isFiltered
+              ? `Filtered accounts (${accounts.length})`
+              : 'All accounts'}
+        </Text>
+      }
+      customCloseAction={
+        table.isSelection ? (
+          <Button onClick={() => table.setRowSelection({})}>
+            Clear selection
+          </Button>
+        ) : null
+      }
+    >
+      <Text color="subtle" className="flex justify-center pt-[50px]">
+        No information on accounts yet
+      </Text>
+    </SidePanel>
+  )
+}

--- a/apps/indexd/components/Data/Accounts/accountsColumns.tsx
+++ b/apps/indexd/components/Data/Accounts/accountsColumns.tsx
@@ -1,0 +1,27 @@
+import { AccountData } from './types'
+import { ValueCopyable } from '@siafoundation/design-system'
+import { type ColumnDef } from '@tanstack/react-table'
+import { TableHeader } from '../columns'
+import { selectColumn } from '../sharedColumns/select'
+import { hashColumnWidth } from '../sharedColumns/sizes'
+
+export const accountsColumns: ColumnDef<AccountData>[] = [
+  selectColumn(),
+  {
+    id: 'publicKey',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-start">
+        Public key
+      </TableHeader>
+    ),
+    accessorKey: 'publicKey',
+    cell: ({ getValue }) => (
+      <ValueCopyable
+        maxLength={100}
+        value={getValue<string>()}
+        label="account"
+      />
+    ),
+    meta: { className: 'justify-start', ...hashColumnWidth },
+  },
+]

--- a/apps/indexd/components/Data/Accounts/transform.ts
+++ b/apps/indexd/components/Data/Accounts/transform.ts
@@ -1,0 +1,10 @@
+import { AccountData } from './types'
+import { PublicKey } from '@siafoundation/types'
+
+export function transformAccount(account: PublicKey): AccountData {
+  const datum: AccountData = {
+    id: account,
+    publicKey: account,
+  }
+  return datum
+}

--- a/apps/indexd/components/Data/Accounts/types.ts
+++ b/apps/indexd/components/Data/Accounts/types.ts
@@ -1,0 +1,4 @@
+export type AccountData = {
+  id: string
+  publicKey: string
+}

--- a/apps/indexd/components/Data/Accounts/useAccounts.tsx
+++ b/apps/indexd/components/Data/Accounts/useAccounts.tsx
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+import { useAccounts as useIndexAccounts } from '@siafoundation/indexd-react'
+import { transformAccount } from './transform'
+
+export function useAccounts() {
+  const rawAccounts = useIndexAccounts({
+    params: {
+      limit: 500,
+    },
+  })
+  const accounts = useMemo(
+    () =>
+      rawAccounts.data?.map((publicKey) => {
+        return transformAccount(publicKey)
+      }) || [],
+    [rawAccounts.data],
+  )
+
+  return accounts
+}

--- a/apps/indexd/components/Data/Views.tsx
+++ b/apps/indexd/components/Data/Views.tsx
@@ -1,9 +1,9 @@
 import { Select, Option } from '@siafoundation/design-system'
 
-// TODO: add contracts and accounts
 const VIEWS = [
   { value: 'hosts', label: 'Hosts' },
   { value: 'contracts', label: 'Contracts' },
+  { value: 'accounts', label: 'Accounts' },
 ] as const
 
 export type DataView = (typeof VIEWS)[number]['value']

--- a/apps/indexd/components/Data/index.tsx
+++ b/apps/indexd/components/Data/index.tsx
@@ -3,6 +3,7 @@ import { HostsTab } from './Hosts/HostsTab'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import { ContractsTab } from './Contracts/ContractsTab'
+import { AccountsTab } from './Accounts/AccountsTab'
 
 export function DataExplorer() {
   const params = useSearchParams()
@@ -22,6 +23,7 @@ export function DataExplorer() {
     <div className="w-full h-full overflow-hidden flex flex-col">
       {view === 'hosts' && <HostsTab />}
       {view === 'contracts' && <ContractsTab />}
+      {view === 'accounts' && <AccountsTab />}
     </div>
   )
 }

--- a/libs/indexd-types/src/admin.ts
+++ b/libs/indexd-types/src/admin.ts
@@ -54,9 +54,7 @@ export type AccountsParams = {
   limit?: number
 }
 export type AccountsPayload = void
-export type AccountsResponse = {
-  accounts: PublicKey[]
-}
+export type AccountsResponse = PublicKey[]
 
 export const accountRoute = '/account/:accountkey'
 export type AccountAddParams = {


### PR DESCRIPTION
- The data explorer now has an Accounts mode.
  - The accounts list response currently returns no data beyond public keys so this is bare bones for now.
  

<img width="1384" height="367" alt="Screenshot 2025-08-08 at 2 07 39 PM" src="https://github.com/user-attachments/assets/e0d7cee3-a204-4f19-adf9-e0cca12145ec" />
<img width="1386" height="397" alt="Screenshot 2025-08-08 at 2 09 16 PM" src="https://github.com/user-attachments/assets/841f1030-49a2-4bf6-986d-8153edf45621" />
<img width="1389" height="342" alt="Screenshot 2025-08-08 at 2 09 25 PM" src="https://github.com/user-attachments/assets/1dd3c432-5639-497e-84c5-e2e3ec2620bc" />
