### PR TITLE
fix(indexd): update mincollateral units

### DIFF
--- a/.changeset/soft-doors-visit.md
+++ b/.changeset/soft-doors-visit.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+Update min collateral units. Closes https://github.com/SiaFoundation/indexd/issues/310

--- a/apps/indexd/contexts/config/transform.spec.ts
+++ b/apps/indexd/contexts/config/transform.spec.ts
@@ -41,7 +41,7 @@ describe('tansforms', () => {
         maxIngressPriceTBPinned: new BigNumber(200),
         maxStoragePriceTBMonth: new BigNumber(864),
         maxStoragePriceTBMonthPinned: new BigNumber(300),
-        minCollateral: new BigNumber(50000),
+        minCollateral: new BigNumber(100),
         minCollateralPinned: new BigNumber(400),
         minProtocolVersion: '1.7.0',
         pinnedCurrency: 'usd' as CurrencyId,
@@ -105,7 +105,7 @@ describe('tansforms', () => {
               maxEgressPriceTB: new BigNumber(200),
               maxIngressPriceTB: new BigNumber(300),
               maxStoragePriceTBMonth: new BigNumber(400),
-              minCollateral: new BigNumber(500),
+              minCollateral: new BigNumber(100),
               minProtocolVersion: '1.7.0',
             } as ValuesHosts,
             {
@@ -119,7 +119,7 @@ describe('tansforms', () => {
           maxEgressPrice: '200000000000000',
           maxIngressPrice: '300000000000000',
           maxStoragePrice: '92592592593',
-          minCollateral: '500000000000000000000000000',
+          minCollateral: '23148148148',
           minProtocolVersion: 'v1.7.0',
         })
       })
@@ -247,7 +247,7 @@ function buildAllResponses() {
       maxEgressPrice: '1000000000000000',
       maxIngressPrice: '1000000000000000',
       maxStoragePrice: '200000000000',
-      minCollateral: toHastings(50_000).toString(),
+      minCollateral: '23148148148',
     } as UsabilitySettings,
     pricePinning: {
       currency: 'usd',

--- a/apps/indexd/contexts/config/transformDown.ts
+++ b/apps/indexd/contexts/config/transformDown.ts
@@ -53,7 +53,7 @@ export function transformDownHosts(
       scDecimalPlaces,
     ),
     minCollateral: toSiacoins(
-      new BigNumber(config.minCollateral),
+      valuePerBytePerBlockToPerTBPerMonth(new BigNumber(config.minCollateral)),
       scDecimalPlaces,
     ),
     minProtocolVersion: config.minProtocolVersion.slice(

--- a/apps/indexd/contexts/config/transformUp.ts
+++ b/apps/indexd/contexts/config/transformUp.ts
@@ -45,7 +45,9 @@ export function transformUpHosts(
     maxEgressPrice: toHastings(
       valuePerTBToPerByte(values.maxEgressPriceTB),
     ).toString(),
-    minCollateral: toHastings(values.minCollateral).toString(),
+    minCollateral: toHastings(
+      valuePerTBPerMonthToPerBytePerBlock(values.minCollateral),
+    ).toString(),
     minProtocolVersion: `v${values.minProtocolVersion}`,
   }
 }


### PR DESCRIPTION
- The daemon units are hastings/byte/block, this converts and displays in sc/tb/month. https://github.com/SiaFoundation/indexd/issues/310