### PR TITLE
fix(indexd): min collateral units label

### DIFF
--- a/.changeset/stupid-brooms-cut.md
+++ b/.changeset/stupid-brooms-cut.md
@@ -1,0 +1,5 @@
+---
+'indexd': patch
+---
+
+The min collateral inputs now show the /TB/month label.

--- a/apps/indexd/contexts/config/fields.tsx
+++ b/apps/indexd/contexts/config/fields.tsx
@@ -266,12 +266,14 @@ export function getFields(): ConfigFields<InputValues, Categories> {
       title: 'Min collateral',
       description: (
         <>
-          The min allowed collateral a contract must have. Choose whether to set
-          the collateral in siacoin or to pin the collateral to a fixed fiat
-          value.
+          The minimum amount of collateral indexd expects a host to lock up per
+          TB per month. Additionally, we expect hosts to lock up at least 2x
+          their storage price. Whichever value is higher is the absolute
+          minimum. Choose whether to set the minimum collateral in siacoin or to
+          pin the minimum collateral to a fixed fiat value.
         </>
       ),
-      units: 'SC',
+      units: 'SC/TB/month',
       decimalsLimitSc: scDecimalPlaces,
       validation: {
         required: 'required',
@@ -282,6 +284,7 @@ export function getFields(): ConfigFields<InputValues, Categories> {
       description: '',
       type: 'fiat',
       category: 'pricing',
+      units: '/TB/month',
       validation: {
         validate: {
           required: requiredIfPinningEnabled(


### PR DESCRIPTION
- The min collateral inputs now show the /TB/month label.

<img width="1237" height="232" alt="Screenshot 2025-08-12 at 10 14 47 AM" src="https://github.com/user-attachments/assets/cfc3f4d5-b960-40e9-8b24-4423bec29448" />
<img width="438" height="142" alt="Screenshot 2025-08-12 at 10 14 54 AM" src="https://github.com/user-attachments/assets/c7bac367-2e9f-42cc-956c-9c384bf52259" />
