### PR TITLE
feat(indexd): connect keys

### DIFF
--- a/.changeset/fresh-books-sell.md
+++ b/.changeset/fresh-books-sell.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+Connect keys can now be deleted from the detail panel.

--- a/.changeset/mean-heads-ask.md
+++ b/.changeset/mean-heads-ask.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+The data explorer now includes connect keys.

--- a/apps/indexd/components/Data/Accounts/useAccounts.tsx
+++ b/apps/indexd/components/Data/Accounts/useAccounts.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react'
-import { useAdminAccounts as useIndexAccounts } from '@siafoundation/indexd-react'
+import { useAdminAccounts } from '@siafoundation/indexd-react'
 import { transformAccount } from './transform'
 import { useAccountsParams } from './useAccountsParams'
 
 export function useAccounts() {
   const { limit, offset } = useAccountsParams()
-  const rawAccounts = useIndexAccounts({
+  const rawAccounts = useAdminAccounts({
     params: {
       limit,
       offset,

--- a/apps/indexd/components/Data/Contracts/useContracts.tsx
+++ b/apps/indexd/components/Data/Contracts/useContracts.tsx
@@ -1,6 +1,6 @@
 import { useActiveSiascanExchangeRate } from '@siafoundation/design-system'
 import { useMemo } from 'react'
-import { useAdminContracts as useIndexContracts } from '@siafoundation/indexd-react'
+import { useAdminContracts } from '@siafoundation/indexd-react'
 import { ContractData } from './types'
 import { useAppSettings } from '@siafoundation/react-core'
 import { transformContract } from './transform'
@@ -22,7 +22,7 @@ export function useContracts() {
     }
     return filters
   }, [columnFilters, offset, limit])
-  const rawContracts = useIndexContracts({
+  const rawContracts = useAdminContracts({
     params,
   })
   const geo = useSiascanHosts()

--- a/apps/indexd/components/Data/Hosts/useHosts.tsx
+++ b/apps/indexd/components/Data/Hosts/useHosts.tsx
@@ -1,6 +1,6 @@
 import { useActiveSiascanExchangeRate } from '@siafoundation/design-system'
 import { useMemo } from 'react'
-import { useAdminHosts as useIndexHosts } from '@siafoundation/indexd-react'
+import { useAdminHosts } from '@siafoundation/indexd-react'
 import { transformHost } from './transform'
 import { useAppSettings } from '@siafoundation/react-core'
 import { AdminHostsParams } from '@siafoundation/indexd-types'
@@ -28,7 +28,7 @@ export function useHosts() {
     }
     return filters
   }, [columnFilters, offset, limit])
-  const rawHosts = useIndexHosts({
+  const rawHosts = useAdminHosts({
     params,
   })
   const exchangeRate = useActiveSiascanExchangeRate()

--- a/apps/indexd/components/Data/Keys/KeysTab.tsx
+++ b/apps/indexd/components/Data/Keys/KeysTab.tsx
@@ -1,0 +1,68 @@
+import { DataTable, useDataTable } from '@siafoundation/design-system'
+import { useCallback } from 'react'
+import { keysColumns } from './keysColumns'
+import { DataViewSelect, type DataView } from '../Views'
+import { SidePanelKeyList } from './SidePanelKeyList'
+import { SidePanelKey } from './SidePanelKey'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { KeyData } from './types'
+import { useKeys } from './useKeys'
+import { Layout } from '../Layout'
+import { useKeysParams } from './useKeysParams'
+
+export function KeysTab() {
+  const params = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const view = params.get('view') as DataView
+  const setView = (view: DataView) => {
+    const paramsObj = new URLSearchParams(Array.from(params.entries()))
+    paramsObj.set('view', view)
+    router.push(`${pathname}?${paramsObj.toString()}`)
+  }
+  const {
+    offset,
+    limit,
+    setOffset,
+    setLimit,
+    panelId,
+    setPanelId,
+    columnFilters,
+    setColumnFilters,
+    columnSorts,
+    setColumnSorts,
+  } = useKeysParams()
+  const onRowClick = useCallback(
+    (id: string) => {
+      setPanelId(id)
+    },
+    [setPanelId],
+  )
+
+  const keys = useKeys()
+  const table = useDataTable<KeyData>({
+    data: keys,
+    columns: keysColumns,
+    columnFilters,
+    setColumnFilters,
+    columnSorts,
+    setColumnSorts,
+    offset,
+    limit,
+    onRowClick,
+    setOffset,
+    setLimit,
+  })
+
+  return (
+    <Layout
+      table={
+        <DataTable
+          {...table}
+          heading={<DataViewSelect value={view} onValueChange={setView} />}
+        />
+      }
+      panel={panelId ? <SidePanelKey /> : <SidePanelKeyList table={table} />}
+    />
+  )
+}

--- a/apps/indexd/components/Data/Keys/SidePanelKey.tsx
+++ b/apps/indexd/components/Data/Keys/SidePanelKey.tsx
@@ -1,0 +1,56 @@
+import { Button, Text, truncate } from '@siafoundation/design-system'
+import { useMemo } from 'react'
+import { SidePanel } from '../SidePanel'
+import { useKeys } from './useKeys'
+import { useDialog } from '../../../contexts/dialog'
+import { TrashCan16 } from '@siafoundation/react-icons'
+import { useKeysParams } from './useKeysParams'
+import { SidePanelSection } from '../SidePanelSection'
+import { InfoRow } from '../PanelInfoRow'
+
+export function SidePanelKey() {
+  const { panelId, setPanelId } = useKeysParams()
+  const { openDialog } = useDialog()
+  // TODO: Temporary until a key detail endpoint is added.
+  const keys = useKeys()
+  const key = useMemo(() => keys.find((k) => k.id === panelId), [panelId, keys])
+  if (!key) {
+    return (
+      <SidePanel heading={null}>
+        <div className="flex justify-center pt-[50px]">
+          <Text color="subtle">Key not found</Text>
+        </div>
+      </SidePanel>
+    )
+  }
+  return (
+    <SidePanel
+      onClose={() => setPanelId(undefined)}
+      heading={
+        <Text size="18" weight="medium" ellipsis>
+          Key: {truncate(key?.key, 24)}
+        </Text>
+      }
+      actions={
+        <Button
+          onClick={() => openDialog('connectKeyDelete', key.id)}
+          variant="red"
+        >
+          <TrashCan16 />
+          Delete key
+        </Button>
+      }
+    >
+      <SidePanelSection heading="Info">
+        <div className="flex flex-col gap-2">
+          <InfoRow label="Description" value={key.description} />
+          <InfoRow label="Total uses" value={key.totalUses} />
+          <InfoRow label="Remaining uses" value={key.remainingUses} />
+          <InfoRow label="Date created" value={key.displayFields.dateCreated} />
+          <InfoRow label="Last updated" value={key.displayFields.lastUpdated} />
+          <InfoRow label="Last used" value={key.displayFields.lastUsed} />
+        </div>
+      </SidePanelSection>
+    </SidePanel>
+  )
+}

--- a/apps/indexd/components/Data/Keys/SidePanelKeyList.tsx
+++ b/apps/indexd/components/Data/Keys/SidePanelKeyList.tsx
@@ -1,0 +1,38 @@
+import { Text, Button, DataTableState } from '@siafoundation/design-system'
+import { KeyData } from './types'
+import { SidePanel } from '../SidePanel'
+import { useMemo } from 'react'
+
+export function SidePanelKeyList({
+  table,
+}: {
+  table: DataTableState<KeyData>
+}) {
+  const keys = useMemo(() => {
+    return table.isSelection ? table.selectedRows : table.rows
+  }, [table.isSelection, table.selectedRows, table.rows])
+  return (
+    <SidePanel
+      heading={
+        <Text size="18" weight="medium">
+          {table.isSelection
+            ? `Selected keys (${keys.length})`
+            : table.isFiltered
+              ? `Filtered keys (${keys.length})`
+              : 'All keys'}
+        </Text>
+      }
+      customCloseAction={
+        table.isSelection ? (
+          <Button onClick={() => table.setRowSelection({})}>
+            Clear selection
+          </Button>
+        ) : null
+      }
+    >
+      <Text color="subtle" className="flex justify-center pt-[50px]">
+        No information on keys yet
+      </Text>
+    </SidePanel>
+  )
+}

--- a/apps/indexd/components/Data/Keys/keysColumns.tsx
+++ b/apps/indexd/components/Data/Keys/keysColumns.tsx
@@ -1,0 +1,100 @@
+import { KeyData } from './types'
+import { Text, ValueCopyable } from '@siafoundation/design-system'
+import { type ColumnDef } from '@tanstack/react-table'
+import { TableHeader } from '../ColumnHeader'
+import { selectColumn } from '../sharedColumns/select'
+import {
+  hashColumnWidth,
+  smallColumnWidth,
+  timestampColumnWidth,
+} from '../sharedColumns/sizes'
+
+export const keysColumns: ColumnDef<KeyData>[] = [
+  selectColumn(),
+  {
+    id: 'key',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-start">
+        Key
+      </TableHeader>
+    ),
+    accessorKey: 'key',
+    cell: ({ getValue }) => (
+      <ValueCopyable maxLength={100} value={getValue<string>()} label="key" />
+    ),
+    meta: { className: 'justify-start', ...hashColumnWidth },
+  },
+  {
+    id: 'description',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-start">
+        Description
+      </TableHeader>
+    ),
+    cell: ({ row }) => <Text>{row.original.description}</Text>,
+    meta: { className: 'justify-start', ...hashColumnWidth },
+  },
+  {
+    id: 'totalUses',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Total uses
+      </TableHeader>
+    ),
+    cell: ({ row }) => <Text>{row.original.totalUses}</Text>,
+    meta: { className: 'justify-end', ...smallColumnWidth },
+  },
+  {
+    id: 'remainingUses',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Remaining uses
+      </TableHeader>
+    ),
+    cell: ({ row }) => <Text>{row.original.remainingUses}</Text>,
+    meta: { className: 'justify-end', ...smallColumnWidth },
+  },
+  {
+    id: 'maxPinnedData',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Max pinned data
+      </TableHeader>
+    ),
+    cell: ({ row }) => <Text>{row.original.displayFields.maxPinnedData}</Text>,
+    meta: { className: 'justify-end', ...smallColumnWidth },
+  },
+  {
+    id: 'dateCreated',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Date created
+      </TableHeader>
+    ),
+    accessorKey: 'dateCreated',
+    cell: ({ row }) => <Text>{row.original.displayFields.dateCreated}</Text>,
+    meta: { className: 'justify-end', ...timestampColumnWidth },
+  },
+  {
+    id: 'lastUpdated',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Last updated
+      </TableHeader>
+    ),
+    accessorKey: 'lastUpdated',
+    cell: ({ row }) => <Text>{row.original.displayFields.lastUpdated}</Text>,
+    meta: { className: 'justify-end', ...timestampColumnWidth },
+  },
+  {
+    id: 'lastUsed',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Last used
+      </TableHeader>
+    ),
+    accessorKey: 'lastUsed',
+    cell: ({ row }) => <Text>{row.original.displayFields.lastUsed}</Text>,
+    meta: { className: 'justify-end', ...timestampColumnWidth },
+  },
+]

--- a/apps/indexd/components/Data/Keys/transform.ts
+++ b/apps/indexd/components/Data/Keys/transform.ts
@@ -1,0 +1,35 @@
+import { ConnectKey } from '@siafoundation/indexd-types'
+import { KeyData } from './types'
+import { humanBytes } from '@siafoundation/units'
+
+export function transformKey(key: ConnectKey): KeyData {
+  const datum: KeyData = {
+    id: key.key,
+    key: key.key,
+    description: key.description,
+    maxPinnedData: key.maxPinnedData,
+    totalUses: key.totalUses,
+    remainingUses: key.remainingUses,
+    dateCreated: key.dateCreated,
+    lastUpdated: key.lastUpdated,
+    lastUsed: key.lastUsed,
+    displayFields: {
+      maxPinnedData: humanBytes(key.maxPinnedData),
+      dateCreated: Intl.DateTimeFormat('en-US', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      }).format(new Date(key.dateCreated)),
+      lastUpdated: Intl.DateTimeFormat('en-US', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      }).format(new Date(key.lastUpdated)),
+      lastUsed: key.lastUsed
+        ? Intl.DateTimeFormat('en-US', {
+            dateStyle: 'short',
+            timeStyle: 'short',
+          }).format(new Date(key.lastUsed))
+        : undefined,
+    },
+  }
+  return datum
+}

--- a/apps/indexd/components/Data/Keys/types.ts
+++ b/apps/indexd/components/Data/Keys/types.ts
@@ -1,0 +1,17 @@
+export type KeyData = {
+  id: string
+  key: string
+  description: string
+  maxPinnedData: number
+  totalUses: number
+  remainingUses: number
+  dateCreated: string
+  lastUpdated: string
+  lastUsed: string
+  displayFields: {
+    maxPinnedData: string
+    dateCreated: string
+    lastUpdated: string
+    lastUsed?: string
+  }
+}

--- a/apps/indexd/components/Data/Keys/useKeys.tsx
+++ b/apps/indexd/components/Data/Keys/useKeys.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import { useAdminConnectKeys } from '@siafoundation/indexd-react'
+import { transformKey } from './transform'
+import { useKeysParams } from './useKeysParams'
+
+export function useKeys() {
+  const { limit, offset } = useKeysParams()
+  const rawKeys = useAdminConnectKeys({
+    params: {
+      limit,
+      offset,
+    },
+  })
+  const keys = useMemo(
+    () =>
+      rawKeys.data?.map((key) => {
+        return transformKey(key)
+      }) || [],
+    [rawKeys.data],
+  )
+
+  return keys
+}

--- a/apps/indexd/components/Data/Keys/useKeysParams.ts
+++ b/apps/indexd/components/Data/Keys/useKeysParams.ts
@@ -1,0 +1,11 @@
+import { useDataTableParams, useParamStr } from '@siafoundation/design-system'
+
+export function useKeysParams() {
+  const tableParams = useDataTableParams('keyList')
+  const [panelId, setPanelId] = useParamStr('keysPanelId')
+  return {
+    ...tableParams,
+    panelId,
+    setPanelId,
+  }
+}

--- a/apps/indexd/components/Data/Views.tsx
+++ b/apps/indexd/components/Data/Views.tsx
@@ -4,6 +4,7 @@ const VIEWS = [
   { value: 'hosts', label: 'Hosts' },
   { value: 'contracts', label: 'Contracts' },
   { value: 'accounts', label: 'Accounts' },
+  { value: 'keys', label: 'Connect Keys' },
 ] as const
 
 export type DataView = (typeof VIEWS)[number]['value']

--- a/apps/indexd/components/Data/index.tsx
+++ b/apps/indexd/components/Data/index.tsx
@@ -4,6 +4,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import { ContractsTab } from './Contracts/ContractsTab'
 import { AccountsTab } from './Accounts/AccountsTab'
+import { KeysTab } from './Keys/KeysTab'
 
 export function DataExplorer() {
   const params = useSearchParams()
@@ -24,6 +25,7 @@ export function DataExplorer() {
       {view === 'hosts' && <HostsTab />}
       {view === 'contracts' && <ContractsTab />}
       {view === 'accounts' && <AccountsTab />}
+      {view === 'keys' && <KeysTab />}
     </div>
   )
 }

--- a/apps/indexd/components/Data/sharedColumns/sizes.ts
+++ b/apps/indexd/components/Data/sharedColumns/sizes.ts
@@ -8,6 +8,11 @@ export const mediumColumnWidth = {
   maxWidth: 150,
 }
 
+export const largeColumnWidth = {
+  minWidth: 150,
+  maxWidth: 600,
+}
+
 export const timestampColumnWidth = {
   minWidth: 200,
   maxWidth: 220,

--- a/apps/indexd/contexts/dialog.tsx
+++ b/apps/indexd/contexts/dialog.tsx
@@ -16,6 +16,7 @@ import { IndexdSendSiacoinDialog } from '../dialogs/IndexdSendSiacoinDialog'
 import { IndexdTransactionDetailsDialog } from '../dialogs/IndexdTransactionDetailsDialog'
 import { DebugDialog } from '../dialogs/DebugDialog'
 import { AccountDeleteDialog } from '../dialogs/AccountDeleteDialog'
+import { ConnectKeyDeleteDialog } from '../dialogs/ConnectKeyDeleteDialog'
 
 export type DialogType =
   | 'cmdk'
@@ -27,6 +28,7 @@ export type DialogType =
   | 'bugReport'
   | 'confirm'
   | 'accountDelete'
+  | 'connectKeyDelete'
 
 type ConfirmProps = {
   title: React.ReactNode
@@ -159,6 +161,11 @@ export function Dialogs() {
       <AccountDeleteDialog
         id={id}
         open={dialog === 'accountDelete'}
+        onOpenChange={onOpenChange}
+      />
+      <ConnectKeyDeleteDialog
+        id={id}
+        open={dialog === 'connectKeyDelete'}
         onOpenChange={onOpenChange}
       />
     </>

--- a/apps/indexd/dialogs/ConnectKeyDeleteDialog.tsx
+++ b/apps/indexd/dialogs/ConnectKeyDeleteDialog.tsx
@@ -1,0 +1,124 @@
+import {
+  Paragraph,
+  Dialog,
+  triggerSuccessToast,
+  ConfigFields,
+  useOnInvalid,
+  FormSubmitButton,
+  FieldText,
+  Code,
+  triggerErrorToast,
+} from '@siafoundation/design-system'
+import { useAdminConnectKeyDelete } from '@siafoundation/indexd-react'
+import { useCallback, useMemo } from 'react'
+import { useForm } from 'react-hook-form'
+import { useDialog } from '../contexts/dialog'
+import { useKeysParams } from '../components/Data/Keys/useKeysParams'
+import { useMutate } from '@siafoundation/react-core'
+import { adminConnectKeysRoute } from '@siafoundation/indexd-types'
+
+const defaultValues = {
+  name: '',
+}
+
+function getFields(): ConfigFields<typeof defaultValues, never> {
+  return {
+    name: {
+      type: 'text',
+      title: 'Confirmation',
+      placeholder: 'delete the key',
+      validation: {
+        required: 'required',
+        validate: {
+          equals: (value) => value === 'delete the key' || 'does not match',
+        },
+      },
+    },
+  }
+}
+
+type Props = {
+  id: string | undefined
+  trigger?: React.ReactNode
+  open: boolean
+  onOpenChange: (val: boolean) => void
+}
+
+export function ConnectKeyDeleteDialog({
+  id,
+  trigger,
+  open,
+  onOpenChange,
+}: Props) {
+  const { closeDialog } = useDialog()
+  const { panelId, setPanelId } = useKeysParams()
+  const keyDelete = useAdminConnectKeyDelete()
+
+  const form = useForm({
+    mode: 'all',
+    defaultValues,
+  })
+
+  const mutate = useMutate()
+  const onSubmit = useCallback(async () => {
+    if (!id) {
+      return
+    }
+    const response = await keyDelete.delete({
+      params: {
+        key: id,
+      },
+    })
+    if (response.error) {
+      triggerErrorToast({
+        title: 'Error deleting connect key',
+        body: response.error,
+      })
+    } else {
+      triggerSuccessToast({ title: 'Connect key permanently deleted' })
+      mutate((key) => key.startsWith(adminConnectKeysRoute))
+      form.reset()
+      closeDialog()
+      if (panelId === id) {
+        setPanelId(undefined)
+      }
+    }
+  }, [form, id, keyDelete, closeDialog, panelId, setPanelId, mutate])
+
+  const fields = useMemo(() => getFields(), [])
+
+  const onInvalid = useOnInvalid(fields)
+
+  return (
+    <Dialog
+      title="Delete connect key"
+      trigger={trigger}
+      open={open}
+      onOpenChange={(val) => {
+        if (!val) {
+          form.reset(defaultValues)
+        }
+        onOpenChange(val)
+      }}
+      contentVariants={{
+        className: 'w-[400px]',
+      }}
+      onSubmit={form.handleSubmit(onSubmit, onInvalid)}
+    >
+      <div className="flex flex-col gap-4">
+        <Paragraph size="14">
+          Are you sure you would like to permanently delete the following
+          connect key?
+        </Paragraph>
+        <Code className="overflow-hidden">{id}</Code>
+        <Paragraph size="14">
+          {'Enter "delete the key" to confirm the removal.'}
+        </Paragraph>
+        <FieldText name="name" form={form} fields={fields} />
+        <FormSubmitButton variant="red" form={form}>
+          Delete connect key
+        </FormSubmitButton>
+      </div>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
- The data explorer now includes connect keys.
- Connect keys can now be deleted from the detail panel.

<img width="1465" height="451" alt="Screenshot 2025-08-15 at 10 27 46 AM" src="https://github.com/user-attachments/assets/19305fa9-cdc8-460e-afed-6e5e3574694f" />
<img width="397" height="312" alt="Screenshot 2025-08-15 at 10 27 23 AM" src="https://github.com/user-attachments/assets/b8a2d833-e9d4-411b-940d-f7d97221e5a3" />
