### PR TITLE
fix(indexd): daemon explorer info route

### DIFF
--- a/.changeset/eighty-keys-enjoy.md
+++ b/.changeset/eighty-keys-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/react-core': minor
+---
+
+Daemon explorer info route now supports paths.

--- a/apps/indexd/app/layout.tsx
+++ b/apps/indexd/app/layout.tsx
@@ -3,6 +3,7 @@ import { NextAppCsr } from '@siafoundation/design-system'
 import { rootFontClasses } from '@siafoundation/fonts'
 import { routes } from '../config/routes'
 import { Providers } from '../config/providers'
+import { adminStateRoute } from '@siafoundation/indexd-types'
 
 export const metadata = {
   title: 'indexd',
@@ -17,7 +18,11 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={rootFontClasses}>
       <body>
-        <NextAppCsr passwordProtectRequestHooks lockRoutes={routes}>
+        <NextAppCsr
+          passwordProtectRequestHooks
+          lockRoutes={routes}
+          daemonExplorerInfoRoute={adminStateRoute}
+        >
           <Providers>{children}</Providers>
         </NextAppCsr>
       </body>

--- a/libs/react-core/src/appSettings/useExternalData/useDaemonExplorerMetadata.ts
+++ b/libs/react-core/src/appSettings/useExternalData/useDaemonExplorerMetadata.ts
@@ -41,8 +41,12 @@ export function useDaemonExplorerMetadata({
   const api = useMemo(() => {
     if (url) {
       try {
-        const { origin } = new URL(url)
-        return origin
+        const { origin, pathname } = new URL(url)
+        const api = `${origin}${pathname}`
+        if (api.endsWith('/')) {
+          return api.slice(0, -1)
+        }
+        return api
       } catch (e) {
         console.error(e)
       }


### PR DESCRIPTION
- Added missing info route which tells the provider where it can find the daemon explorer info.
- Added support for explorer APIs with a path eg: <https://api.siascan.com/zen>.