### PR TITLE
feat(indexd): account fields

### DIFF
--- a/.changeset/blue-hoops-unite.md
+++ b/.changeset/blue-hoops-unite.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/indexd-types': minor
+---
+
+The accounts response is now account objects with more fields.

--- a/.changeset/full-breads-listen.md
+++ b/.changeset/full-breads-listen.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+Added max pinned data to connect key detail panel.

--- a/.changeset/shy-maps-behave.md
+++ b/.changeset/shy-maps-behave.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+Added account fields: service account, max pinned data.

--- a/apps/indexd/components/Data/Accounts/SidePanelAccount.tsx
+++ b/apps/indexd/components/Data/Accounts/SidePanelAccount.tsx
@@ -5,6 +5,8 @@ import { useAccounts } from './useAccounts'
 import { useDialog } from '../../../contexts/dialog'
 import { TrashCan16 } from '@siafoundation/react-icons'
 import { useAccountsParams } from './useAccountsParams'
+import { InfoRow } from '../PanelInfoRow'
+import { SidePanelSection } from '../SidePanelSection'
 
 export function SidePanelAccount() {
   const { panelId, setPanelId } = useAccountsParams()
@@ -42,9 +44,18 @@ export function SidePanelAccount() {
         </Button>
       }
     >
-      <Text color="subtle" className="flex justify-center pt-[50px]">
-        No further information on accounts yet
-      </Text>
+      <SidePanelSection heading="Info">
+        <div className="flex flex-col gap-2">
+          <InfoRow
+            label="Service account"
+            value={account.serviceAccount ? 'Yes' : 'No'}
+          />
+          <InfoRow
+            label="Max pinned data"
+            value={account.displayFields.maxPinnedData}
+          />
+        </div>
+      </SidePanelSection>
     </SidePanel>
   )
 }

--- a/apps/indexd/components/Data/Accounts/accountsColumns.tsx
+++ b/apps/indexd/components/Data/Accounts/accountsColumns.tsx
@@ -1,9 +1,9 @@
 import { AccountData } from './types'
-import { ValueCopyable } from '@siafoundation/design-system'
+import { Text, ValueCopyable } from '@siafoundation/design-system'
 import { type ColumnDef } from '@tanstack/react-table'
 import { TableHeader } from '../ColumnHeader'
 import { selectColumn } from '../sharedColumns/select'
-import { hashColumnWidth } from '../sharedColumns/sizes'
+import { hashColumnWidth, smallColumnWidth } from '../sharedColumns/sizes'
 
 export const accountsColumns: ColumnDef<AccountData>[] = [
   selectColumn(),
@@ -23,5 +23,27 @@ export const accountsColumns: ColumnDef<AccountData>[] = [
       />
     ),
     meta: { className: 'justify-start', ...hashColumnWidth },
+  },
+  {
+    id: 'serviceAccount',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Service account
+      </TableHeader>
+    ),
+    cell: ({ row }) => (
+      <Text>{row.original.serviceAccount ? 'Yes' : 'No'}</Text>
+    ),
+    meta: { className: 'justify-end', ...smallColumnWidth },
+  },
+  {
+    id: 'maxPinnedData',
+    header: ({ table, column }) => (
+      <TableHeader table={table} column={column} className="justify-end">
+        Max pinned data
+      </TableHeader>
+    ),
+    cell: ({ row }) => <Text>{row.original.displayFields.maxPinnedData}</Text>,
+    meta: { className: 'justify-end', ...smallColumnWidth },
   },
 ]

--- a/apps/indexd/components/Data/Accounts/transform.ts
+++ b/apps/indexd/components/Data/Accounts/transform.ts
@@ -1,10 +1,16 @@
+import { Account } from '@siafoundation/indexd-types'
 import { AccountData } from './types'
-import { PublicKey } from '@siafoundation/types'
+import { humanBytes } from '@siafoundation/units'
 
-export function transformAccount(account: PublicKey): AccountData {
+export function transformAccount(account: Account): AccountData {
   const datum: AccountData = {
-    id: account,
-    publicKey: account,
+    id: account.accountKey,
+    publicKey: account.accountKey,
+    serviceAccount: account.serviceAccount,
+    maxPinnedData: account.maxPinnedData,
+    displayFields: {
+      maxPinnedData: humanBytes(account.maxPinnedData),
+    },
   }
   return datum
 }

--- a/apps/indexd/components/Data/Accounts/types.ts
+++ b/apps/indexd/components/Data/Accounts/types.ts
@@ -1,4 +1,9 @@
 export type AccountData = {
   id: string
   publicKey: string
+  serviceAccount: boolean
+  maxPinnedData: number
+  displayFields: {
+    maxPinnedData: string
+  }
 }

--- a/apps/indexd/components/Data/Accounts/useAccounts.tsx
+++ b/apps/indexd/components/Data/Accounts/useAccounts.tsx
@@ -13,8 +13,8 @@ export function useAccounts() {
   })
   const accounts = useMemo(
     () =>
-      rawAccounts.data?.map((publicKey) => {
-        return transformAccount(publicKey)
+      rawAccounts.data?.map((account) => {
+        return transformAccount(account)
       }) || [],
     [rawAccounts.data],
   )

--- a/apps/indexd/components/Data/Keys/SidePanelKey.tsx
+++ b/apps/indexd/components/Data/Keys/SidePanelKey.tsx
@@ -46,6 +46,10 @@ export function SidePanelKey() {
           <InfoRow label="Description" value={key.description} />
           <InfoRow label="Total uses" value={key.totalUses} />
           <InfoRow label="Remaining uses" value={key.remainingUses} />
+          <InfoRow
+            label="Max pinned data"
+            value={key.displayFields.maxPinnedData}
+          />
           <InfoRow label="Date created" value={key.displayFields.dateCreated} />
           <InfoRow label="Last updated" value={key.displayFields.lastUpdated} />
           <InfoRow label="Last used" value={key.displayFields.lastUsed} />

--- a/libs/indexd-types/src/admin/index.ts
+++ b/libs/indexd-types/src/admin/index.ts
@@ -15,6 +15,7 @@ import type {
   WalletBalance,
   ConnectKey,
   Alert,
+  Account,
 } from './types'
 import type { Host } from '../types'
 
@@ -61,7 +62,7 @@ export type AdminAccountsParams = {
   limit?: number
 }
 export type AdminAccountsPayload = void
-export type AdminAccountsResponse = PublicKey[]
+export type AdminAccountsResponse = Account[]
 
 export const adminAccountRoute = '/account/:accountkey'
 export type AdminAccountAddParams = {

--- a/libs/indexd-types/src/admin/types.ts
+++ b/libs/indexd-types/src/admin/types.ts
@@ -104,3 +104,9 @@ export type Alert = {
   data?: Record<string, unknown>
   timestamp: string
 }
+
+export type Account = {
+  accountKey: string
+  maxPinnedData: number
+  serviceAccount: boolean
+}


### PR DESCRIPTION
- The accounts response is now account objects with more fields.
- Added account fields: service account, max pinned data.
- Added max pinned data to connect key detail panel.

![Screenshot 2025-08-20 at 1.13.48 PM.png](https://app.graphite.dev/user-attachments/assets/77498eec-dc53-415b-8731-313240825255.png)

![Screenshot 2025-08-20 at 1.13.39 PM.png](https://app.graphite.dev/user-attachments/assets/45a67d08-687b-42ea-9ed4-5fc20c591948.png)

