### PR TITLE
fix(hostd): metrics y-axis labels decimal

### DIFF
--- a/.changeset/proud-rivers-sneeze.md
+++ b/.changeset/proud-rivers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+Y-axis numeric labels on metrics charts now show 1 decimal place. Closes https://github.com/SiaFoundation/hostd/issues/811

--- a/.changeset/wild-goats-fetch.md
+++ b/.changeset/wild-goats-fetch.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': patch
+---
+
+Increased the ChartXY y axis label width.

--- a/apps/hostd/contexts/metrics/index.tsx
+++ b/apps/hostd/contexts/metrics/index.tsx
@@ -250,7 +250,7 @@ function useMetricsMain() {
         },
         formatTickY: (v) =>
           humanSiacoin(v, {
-            fixed: 0,
+            fixed: 1,
             dynamicUnits: true,
           }),
         formatTimestamp,
@@ -292,7 +292,7 @@ function useMetricsMain() {
         formatTimestamp,
         formatTickY: (v) =>
           humanSiacoin(v, {
-            fixed: 0,
+            fixed: 1,
             dynamicUnits: true,
           }),
         disableAnimations,
@@ -364,7 +364,7 @@ function useMetricsMain() {
         formatTimestamp,
         formatTickY: (v) =>
           humanSiacoin(v, {
-            fixed: 0,
+            fixed: 1,
             dynamicUnits: true,
           }),
         disableAnimations,
@@ -491,7 +491,7 @@ function useMetricsMain() {
         },
         format: (v) => humanBytes(v),
         formatTimestamp,
-        formatTickY: (v) => humanBytes(v, { fixed: 0 }),
+        formatTickY: (v) => humanBytes(v, { fixed: 1 }),
         disableAnimations,
         chartType: 'line',
         curveType: 'linear',
@@ -557,7 +557,7 @@ function useMetricsMain() {
         formatTimestamp,
         formatTickY: (v) =>
           humanBytes(v, {
-            fixed: 0,
+            fixed: 1,
           }),
         disableAnimations,
         chartType: 'line',

--- a/libs/design-system/src/components/ChartXY/ChartXYGraph.tsx
+++ b/libs/design-system/src/components/ChartXY/ChartXYGraph.tsx
@@ -237,6 +237,7 @@ export function ChartXYGraph<Key extends string, Cat extends string>({
         // tickFormat={stackOffset === 'wiggle' ? () => '' : undefined}
         tickFormat={config.formatTickY}
         tickLabelProps={(p) => ({
+          width: 70,
           ...p,
           fill: theme.labels.color,
           fontFamily: theme.labels.fontFamily,


### PR DESCRIPTION
- Y-axis numeric labels on metrics charts now show 1 decimal place.  https://github.com/SiaFoundation/hostd/issues/811
- Increased the ChartXY y axis label width.

![Screenshot 2025-08-20 at 1.22.26 PM.png](https://app.graphite.dev/user-attachments/assets/051da8d3-f447-4898-9af2-a634d453c13c.png)![Screenshot 2025-08-20 at 1.18.45 PM.png](https://app.graphite.dev/user-attachments/assets/a1adcf6a-ec4c-446e-bb1d-a3979ae54ce1.png)