### PR TITLE
fix(renterd): config validates total shards <= num hosts

### DIFF
--- a/.changeset/lemon-words-drum.md
+++ b/.changeset/lemon-words-drum.md
@@ -1,0 +1,5 @@
+---
+'renterd': minor
+---
+
+Total shards field validation now checks that the value is less than or equal to the number of hosts / contracts. Closes https://github.com/SiaFoundation/renterd/issues/1625

--- a/apps/renterd/contexts/config/fields.tsx
+++ b/apps/renterd/contexts/config/fields.tsx
@@ -691,6 +691,12 @@ export function getFields({
               new BigNumber(value || 0).gte(values.minShards || 0) ||
               'must be at least equal to min shards',
           ),
+          lteNumHosts: requiredIfAdvanced(
+            validationContext,
+            (value: Maybe<BigNumber>, values) =>
+              new BigNumber(value || 0).lte(values.amountHosts || 0) ||
+              'must be less than or equal to number of hosts',
+          ),
           max: requiredIfAdvanced(
             validationContext,
             (value: Maybe<BigNumber>) =>


### PR DESCRIPTION
- Total shards field validation now checks that the value is less than or equal to the number of hosts / contracts. https://github.com/SiaFoundation/renterd/issues/1625