### PR TITLE
fix(libs): estimated block height uses dynamic genesis

### DIFF
--- a/.changeset/cute-badgers-fly.md
+++ b/.changeset/cute-badgers-fly.md
@@ -1,0 +1,8 @@
+---
+'@siafoundation/renterd-react': minor
+'@siafoundation/walletd-react': minor
+'@siafoundation/hostd-react': minor
+'@siafoundation/units': minor
+---
+
+Estimated block height now uses dynamic genesis timestamp. Closes https://github.com/SiaFoundation/walletd/issues/238

--- a/libs/hostd-react/src/api.ts
+++ b/libs/hostd-react/src/api.ts
@@ -127,10 +127,7 @@ import {
   V2ContractsResponse,
   v2ContractsRoute,
 } from '@siafoundation/hostd-types'
-import {
-  getMainnetBlockHeight,
-  getTestnetZenBlockHeight,
-} from '@siafoundation/units'
+import { getBlockHeightFromGenesis } from '@siafoundation/units'
 
 // state
 
@@ -189,12 +186,7 @@ export function useEstimatedNetworkBlockHeight(): number {
   })
   const res = useSWR(
     state,
-    () => {
-      if (state.data?.name === 'zen') {
-        return getTestnetZenBlockHeight()
-      }
-      return getMainnetBlockHeight()
-    },
+    () => getBlockHeightFromGenesis(state.data?.hardforkOak.genesisTimestamp),
     {
       refreshInterval: 60_000,
       keepPreviousData: true,

--- a/libs/indexd-react/src/admin.ts
+++ b/libs/indexd-react/src/admin.ts
@@ -141,10 +141,7 @@ import {
   AdminConsensusNetworkResponse,
 } from '@siafoundation/indexd-types'
 import useSWR from 'swr'
-import {
-  getMainnetBlockHeight,
-  getTestnetZenBlockHeight,
-} from '@siafoundation/units'
+import { getBlockHeightFromGenesis } from '@siafoundation/units'
 
 // state
 
@@ -158,7 +155,7 @@ export function useAdminState(
 }
 
 export function useAdminEstimatedNetworkBlockHeight(): number {
-  const state = useAdminState({
+  const network = useAdminConsensusNetwork({
     config: {
       swr: {
         revalidateOnFocus: false,
@@ -166,13 +163,8 @@ export function useAdminEstimatedNetworkBlockHeight(): number {
     },
   })
   const res = useSWR(
-    state,
-    () => {
-      if (state.data?.network === 'zen') {
-        return getTestnetZenBlockHeight()
-      }
-      return getMainnetBlockHeight()
-    },
+    network,
+    () => getBlockHeightFromGenesis(network.data?.hardforkOak.genesisTimestamp),
     {
       refreshInterval: 60_000,
       keepPreviousData: true,

--- a/libs/renterd-react/src/bus.ts
+++ b/libs/renterd-react/src/bus.ts
@@ -11,10 +11,7 @@ import {
   delay,
   throttle,
 } from '@siafoundation/react-core'
-import {
-  getMainnetBlockHeight,
-  getTestnetZenBlockHeight,
-} from '@siafoundation/units'
+import { getBlockHeightFromGenesis } from '@siafoundation/units'
 import {
   AlertsDismissParams,
   AlertsDismissPayload,
@@ -294,7 +291,7 @@ export function useConsensusNetwork(
 }
 
 export function useEstimatedNetworkBlockHeight(): number {
-  const state = useBusState({
+  const state = useConsensusNetwork({
     config: {
       swr: {
         revalidateOnFocus: false,
@@ -303,12 +300,7 @@ export function useEstimatedNetworkBlockHeight(): number {
   })
   const res = useSWR(
     state,
-    () => {
-      if (state.data?.network === 'zen') {
-        return getTestnetZenBlockHeight()
-      }
-      return getMainnetBlockHeight()
-    },
+    () => getBlockHeightFromGenesis(state.data?.hardforkOak.genesisTimestamp),
     {
       refreshInterval: 60_000,
       keepPreviousData: true,

--- a/libs/units/src/blockHeight.ts
+++ b/libs/units/src/blockHeight.ts
@@ -1,13 +1,8 @@
-const genesis = 1433600000
-export function getMainnetBlockHeight() {
+export function getBlockHeightFromGenesis(genesisTimestamp?: string) {
+  if (!genesisTimestamp) {
+    return 0
+  }
   // (now - genesis) / 10min = est block height
-  return Math.round((new Date().getTime() - genesis * 1000) / (1000 * 60 * 10))
-}
-
-const zenGenesis = 1673600000
-export function getTestnetZenBlockHeight() {
-  // (now - genesis) / 10min = est block height
-  return Math.round(
-    (new Date().getTime() - zenGenesis * 1000) / (1000 * 60 * 10),
-  )
+  const genesis = new Date(genesisTimestamp).getTime()
+  return Math.round((new Date().getTime() - genesis) / (1000 * 60 * 10))
 }

--- a/libs/walletd-react/src/api.ts
+++ b/libs/walletd-react/src/api.ts
@@ -8,10 +8,7 @@ import {
   delay,
   useDeleteFunc,
 } from '@siafoundation/react-core'
-import {
-  getMainnetBlockHeight,
-  getTestnetZenBlockHeight,
-} from '@siafoundation/units'
+import { getBlockHeightFromGenesis } from '@siafoundation/units'
 import {
   WalletAddressOutputsSiacoinParams,
   WalletAddressOutputsSiacoinResponse,
@@ -166,12 +163,7 @@ export function useEstimatedNetworkBlockHeight(): number {
   })
   const res = useSWR(
     network,
-    () => {
-      if (network.data?.name === 'zen') {
-        return getTestnetZenBlockHeight()
-      }
-      return getMainnetBlockHeight()
-    },
+    () => getBlockHeightFromGenesis(network.data?.hardforkOak.genesisTimestamp),
     {
       refreshInterval: 60_000,
       keepPreviousData: true,


### PR DESCRIPTION
- Estimated block height now uses dynamic genesis timestamp. https://github.com/SiaFoundation/walletd/issues/238