### PR TITLE
feat(design-system): remote data

### DIFF
--- a/.changeset/soft-rockets-ring.md
+++ b/.changeset/soft-rockets-ring.md
@@ -1,0 +1,5 @@
+---
+'@siafoundation/design-system': minor
+---
+
+Added remote data and dataset hooks and components.

--- a/libs/design-system/src/components/EmptyState/StateError.tsx
+++ b/libs/design-system/src/components/EmptyState/StateError.tsx
@@ -1,19 +1,14 @@
 import { Text } from '../../core/Text'
 import { MisuseOutline32 } from '@siafoundation/react-icons'
-import { SWRError } from '@siafoundation/react-core'
 
-type Props = {
-  error?: SWRError
-}
-
-export function StateError({ error }: Props) {
+export function StateError({ message }: { message?: string }) {
   return (
     <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
       <Text>
         <MisuseOutline32 className="scale-[200%]" />
       </Text>
       <Text color="subtle" className="text-center max-w-[500px]">
-        Error loading data. Please try again later.
+        {message ?? 'Error loading data. Please try again later.'}
       </Text>
     </div>
   )

--- a/libs/design-system/src/components/EmptyState/StateNoData.tsx
+++ b/libs/design-system/src/components/EmptyState/StateNoData.tsx
@@ -1,14 +1,14 @@
 import { Text } from '../../core/Text'
 import { ChartArea32 } from '@siafoundation/react-icons'
 
-export function StateNoData() {
+export function StateNoData({ message }: { message?: string }) {
   return (
     <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
       <Text>
         <ChartArea32 className="scale-[200%]" />
       </Text>
       <Text color="subtle" className="text-center max-w-[500px]">
-        No data available.
+        {message ?? 'No data available.'}
       </Text>
     </div>
   )

--- a/libs/design-system/src/components/EmptyState/StateNoneMatching.tsx
+++ b/libs/design-system/src/components/EmptyState/StateNoneMatching.tsx
@@ -1,14 +1,14 @@
 import { Text } from '../../core/Text'
 import { Filter32 } from '@siafoundation/react-icons'
 
-export function StateNoneMatching() {
+export function StateNoneMatching({ message }: { message?: string }) {
   return (
     <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
       <Text>
         <Filter32 className="scale-[200%]" />
       </Text>
       <Text color="subtle" className="text-center max-w-[500px]">
-        No data matching filters.
+        {message ?? 'No data matching filters.'}
       </Text>
     </div>
   )

--- a/libs/design-system/src/components/EmptyState/StateNoneOnPage.tsx
+++ b/libs/design-system/src/components/EmptyState/StateNoneOnPage.tsx
@@ -6,7 +6,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Reset32 } from '@siafoundation/react-icons'
 import { useCallback } from 'react'
 
-export function StateNoneOnPage() {
+export function StateNoneOnPage({ message }: { message?: string }) {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -22,7 +22,7 @@ export function StateNoneOnPage() {
         <Reset32 className="scale-[200%]" />
       </Text>
       <Text color="subtle" className="text-center max-w-[500px]">
-        No data on this page, reset pagination to continue.
+        {message ?? 'No data on this page, reset pagination to continue.'}
       </Text>
       <Button onClick={back}>Back to first page</Button>
     </div>

--- a/libs/design-system/src/components/EmptyState/StateNoneYet.tsx
+++ b/libs/design-system/src/components/EmptyState/StateNoneYet.tsx
@@ -1,14 +1,14 @@
 import { Text } from '../../core/Text'
 import { DataBase32 } from '@siafoundation/react-icons'
 
-export function StateNoneYet() {
+export function StateNoneYet({ message }: { message?: string }) {
   return (
     <div className="flex flex-col gap-10 justify-center items-center h-[400px]">
       <Text>
         <DataBase32 className="scale-[200%]" />
       </Text>
       <Text color="subtle" className="text-center max-w-[500px]">
-        There is no data yet.
+        {message ?? 'There is no data yet.'}
       </Text>
     </div>
   )

--- a/libs/design-system/src/hooks/useStableCompare.ts
+++ b/libs/design-system/src/hooks/useStableCompare.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useRef } from 'react'
+
+// useStableBy is a stable version of useMemo that compares the previous
+// and current values using a custom equals function.
+export function useStableBy<T>(value: T, equals: (a: T, b: T) => boolean): T {
+  const ref = useRef<T>(value)
+  if (!equals(ref.current, value)) {
+    ref.current = value
+  }
+  return ref.current
+}
+
+// useStableArrayBy is a stable version of useMemo that compares the previous
+// and current values using a custom equals function.
+export function useStableArrayBy<T>(
+  arr: T[] | undefined,
+  equals: (a: T, b: T) => boolean = (a, b) => a === b,
+  key?: (item: T, index: number) => string | number,
+): T[] | undefined {
+  const ref = useRef<T[] | undefined>(arr)
+  const prev = ref.current
+  let same = true
+
+  if (!prev || !arr || prev.length !== arr.length) {
+    same = false
+  } else if (key) {
+    for (let i = 0; i < arr.length; i++) {
+      if (key(prev[i], i) !== key(arr[i], i) || !equals(prev[i], arr[i])) {
+        same = false
+        break
+      }
+    }
+  } else {
+    for (let i = 0; i < arr.length; i++) {
+      if (!equals(prev[i], arr[i])) {
+        same = false
+        break
+      }
+    }
+  }
+
+  if (!same) ref.current = arr
+  return ref.current
+}
+
+// useStableObjectBy is a stable version of useMemo that compares the previous
+// and current values using a custom equals function.
+export function useStableObjectBy<V extends Record<string, unknown>>(
+  obj: V,
+  equals: (a: V[keyof V], b: V[keyof V]) => boolean = (a, b) => Object.is(a, b),
+): V {
+  const ref = useRef<V>(obj)
+  const prev = ref.current
+  let same = true
+
+  if (!prev || !obj) {
+    same = prev === obj
+  } else {
+    const prevKeys = Object.keys(prev) as Array<keyof V>
+    const objKeys = Object.keys(obj) as Array<keyof V>
+    if (prevKeys.length !== objKeys.length) {
+      same = false
+    } else {
+      for (let i = 0; i < objKeys.length; i++) {
+        const k = objKeys[i]
+        if (!(k in prev) || !equals(prev[k], obj[k])) {
+          same = false
+          break
+        }
+      }
+    }
+  }
+
+  if (!same) ref.current = obj as V
+  return ref.current
+}
+
+export function useLatestRef<T>(value: T) {
+  const ref = useRef(value)
+  if (ref.current !== value) ref.current = value
+  return ref
+}

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -151,6 +151,12 @@ export * from './form/useFormInit'
 export * from './form/useFormSetField'
 export * from './form/useDialogFormHelpers'
 
+// remote data
+export * from './remoteData/useRemoteDataset'
+export * from './remoteData/useRemoteData'
+export * from './remoteData/RemoteDataStates'
+export * from './remoteData/RemoteDatasetStates'
+
 // hooks
 export * from './hooks/tooltip'
 export * from './hooks/useConnectivity'

--- a/libs/design-system/src/remoteData/RemoteDataStates.tsx
+++ b/libs/design-system/src/remoteData/RemoteDataStates.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import React from 'react'
+import { RemoteData } from './types'
+
+export type RemoteDataStatesProps<T> = {
+  data: RemoteData<T>
+  loaded: React.ReactNode | ((data: T) => React.ReactNode)
+  loading: React.ReactNode
+  notFound: React.ReactNode
+  error?: React.ReactNode
+}
+
+export function RemoteDataStates<T>({
+  loaded,
+  loading,
+  notFound,
+  data,
+  error,
+}: RemoteDataStatesProps<T>) {
+  if (data.state === 'loading') {
+    return loading
+  }
+
+  if (data.state === 'loaded') {
+    return typeof loaded === 'function' ? loaded(data.data) : loaded
+  }
+
+  if (data.state === 'error' && error) {
+    return error
+  }
+
+  return notFound
+}

--- a/libs/design-system/src/remoteData/RemoteDatasetStates.tsx
+++ b/libs/design-system/src/remoteData/RemoteDatasetStates.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import React from 'react'
+import { StateNoneOnPage } from '../components/EmptyState/StateNoneOnPage'
+import { StateNoneYet } from '../components/EmptyState/StateNoneYet'
+import { StateNoneMatching } from '../components/EmptyState/StateNoneMatching'
+import { StateError } from '../components/EmptyState/StateError'
+import { RemoteDataset } from './types'
+
+export type RemoteDatasetStatesProps<T> = {
+  dataset: RemoteDataset<T>
+  loaded: React.ReactNode | ((data: T) => React.ReactNode)
+  loading?: React.ReactNode
+  noneOnPage?: React.ReactNode
+  noneYet?: React.ReactNode
+  noneMatchingFilters?: React.ReactNode
+  error?: React.ReactNode
+}
+
+export function RemoteDatasetStates<T>({
+  loaded,
+  loading,
+  noneOnPage = <StateNoneOnPage />,
+  noneYet = <StateNoneYet />,
+  noneMatchingFilters = <StateNoneMatching />,
+  dataset,
+  error = <StateError />,
+}: RemoteDatasetStatesProps<T>) {
+  if (dataset.state === 'loading') {
+    return loading ?? null
+  }
+
+  if (dataset.state === 'loaded') {
+    return typeof loaded === 'function' ? loaded(dataset.data) : loaded
+  }
+
+  if (dataset.state === 'error') {
+    return error ?? null
+  }
+
+  if (dataset.state === 'noneOnPage') {
+    return noneOnPage ?? null
+  }
+
+  if (dataset.state === 'noneMatchingFilters') {
+    return noneMatchingFilters ?? null
+  }
+
+  if (dataset.state === 'noneYet') {
+    return noneYet ?? null
+  }
+
+  return null
+}

--- a/libs/design-system/src/remoteData/types.ts
+++ b/libs/design-system/src/remoteData/types.ts
@@ -1,0 +1,101 @@
+export type Remote<T> = {
+  isLoading?: boolean
+  data: T | undefined
+  isValidating: boolean
+  error?: Error
+}
+
+export type FetchingInfo = {
+  isLoading?: boolean
+  isValidating: boolean
+}
+
+export type DataLoaded<O> = {
+  state: 'loaded'
+  data: O
+} & FetchingInfo
+
+export type DataLoading = {
+  state: 'loading'
+  data: undefined
+} & FetchingInfo
+
+export type DataEmptyNotFound = {
+  state: 'notFound'
+  data: undefined
+} & FetchingInfo
+
+export type DataError = {
+  state: 'error'
+  data: undefined
+  error?: Error
+} & FetchingInfo
+
+export type DataEmptyNoneYet = {
+  state: 'noneYet'
+  data: undefined
+} & FetchingInfo
+
+export type DataEmptyNoneMatchingFilters = {
+  state: 'noneMatchingFilters'
+  data: undefined
+} & FetchingInfo
+
+export type DataEmptyNoneOnPage = {
+  state: 'noneOnPage'
+  data: undefined
+} & FetchingInfo
+
+export type RemoteData<O> =
+  | DataLoaded<O>
+  | DataLoading
+  | DataError
+  | DataEmptyNotFound
+
+export type RemoteDataset<O> =
+  | DataLoaded<O>
+  | DataLoading
+  | DataError
+  | DataEmptyNoneYet
+  | DataEmptyNoneMatchingFilters
+  | DataEmptyNoneOnPage
+
+export type ValuesOf<Remotes extends Record<string, Remote<unknown>>> = {
+  [K in keyof Remotes]: NonNullable<Remotes[K]['data']>
+}
+
+export function checkAllHaveData<
+  Remotes extends Record<string, Remote<unknown>>,
+>(
+  deps: Remotes,
+): deps is Remotes & {
+  [K in keyof Remotes]: Remote<NonNullable<Remotes[K]['data']>>
+} {
+  return Object.values(deps).every((d) => d.data !== undefined)
+}
+
+export function checkAnyHaveError<
+  Remotes extends Record<string, Remote<unknown>>,
+>(deps: Remotes): Error | undefined {
+  return Object.values(deps).find((d) => d.error !== undefined)?.error
+}
+
+export function checkAnyValidating<
+  Remotes extends Record<string, Remote<unknown>>,
+>(deps: Remotes): deps is Remotes & { [K in keyof Remotes]: Remote<boolean> } {
+  return Object.values(deps).some((d) => d.isValidating)
+}
+
+export function checkAnyLoading<
+  Remotes extends Record<string, Remote<unknown>>,
+>(deps: Remotes): deps is Remotes & { [K in keyof Remotes]: Remote<boolean> } {
+  return Object.values(deps).some((d) => d.isLoading)
+}
+
+export function getValues<Remotes extends Record<string, Remote<unknown>>>(
+  deps: Remotes,
+): ValuesOf<Remotes> {
+  return Object.fromEntries(
+    Object.entries(deps).map(([k, v]) => [k, v.data]),
+  ) as ValuesOf<Remotes>
+}

--- a/libs/design-system/src/remoteData/useRemoteData.spec.tsx
+++ b/libs/design-system/src/remoteData/useRemoteData.spec.tsx
@@ -1,0 +1,181 @@
+import { renderHook } from '@testing-library/react'
+import { type Remote } from './types'
+import { useRemoteData } from './useRemoteData'
+
+type Remotes = {
+  a: Remote<number>
+  b: Remote<string>
+}
+
+const transform = (values: { a: number; b: string }): string | undefined => {
+  if (values.b === 'empty') {
+    return undefined
+  }
+  return `${values.b}:${values.a}`
+}
+
+describe('useRemoteData', () => {
+  test('returns loading when any dependency is loading initially', () => {
+    const { result } = renderHook(() =>
+      useRemoteData(
+        {
+          a: { isLoading: true, data: 1, isValidating: true },
+          b: { data: 'x', isLoading: false, isValidating: false },
+        },
+        transform,
+      ),
+    )
+    expect(result.current.state).toBe('loading')
+  })
+
+  test('returns loaded when all dependencies have data with no errors', () => {
+    const { result } = renderHook(() =>
+      useRemoteData(
+        {
+          a: { data: 42, isValidating: false },
+          b: { data: 'ok', isValidating: false },
+        },
+        transform,
+      ),
+    )
+    expect(result.current.state).toBe('loaded')
+    expect(result.current.data).toBe('ok:42')
+    expect('error' in result.current).toBe(false)
+  })
+
+  test('returns loaded when revalidating with previous data present', () => {
+    const { result } = renderHook(() =>
+      useRemoteData(
+        {
+          a: { data: 1, isValidating: true },
+          b: { data: 'x', isValidating: true },
+        },
+        transform,
+      ),
+    )
+    expect(result.current.state).toBe('loaded')
+    expect(result.current.data).toBe('x:1')
+  })
+
+  test('returns error when any dependency has error', () => {
+    const err = new Error('fetch failed')
+    const { result } = renderHook(() =>
+      useRemoteData(
+        {
+          a: { data: 1, error: err, isValidating: false },
+          b: { data: 'x', isValidating: false },
+        },
+        transform,
+      ),
+    )
+    expect(result.current.state).toBe('error')
+    expect(result.current.data).toBeUndefined()
+    expect('error' in result.current && result.current.error).toBe(err)
+  })
+
+  test('returns loading when all fields are initial values (before initial loading starts)', () => {
+    const { result } = renderHook(() =>
+      useRemoteData(
+        {
+          a: { isLoading: false, isValidating: false, data: undefined },
+          b: { isLoading: false, isValidating: false, data: undefined },
+        },
+        transform,
+      ),
+    )
+    expect(result.current.state).toBe('loading')
+  })
+
+  test('state sequence', () => {
+    const { result, rerender } = renderHook(
+      ({ remotes }: { remotes: Remotes }) => useRemoteData(remotes, transform),
+      {
+        initialProps: {
+          remotes: {
+            a: { isLoading: true, isValidating: false, data: undefined },
+            b: { isLoading: false, isValidating: false, data: undefined },
+          } as Remotes,
+        },
+      },
+    )
+
+    // Pre initial loading.
+    expect(result.current.state).toBe('loading')
+
+    // Initial loading.
+    rerender({
+      remotes: {
+        a: { isLoading: true, isValidating: false, data: undefined },
+        b: { isLoading: false, isValidating: false, data: undefined },
+      },
+    })
+    expect(result.current.state).toBe('loading')
+
+    // Loaded.
+    rerender({
+      remotes: {
+        a: { isLoading: false, isValidating: false, data: 7 },
+        b: { isLoading: false, isValidating: false, data: 'ok' },
+      },
+    })
+    expect(result.current.state).toBe('loaded')
+    expect(result.current.data).toBe('ok:7')
+
+    // Revalidating.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: true },
+        b: { data: 'ok', isValidating: true },
+      },
+    })
+    expect(result.current.state).toBe('loaded')
+
+    // Errored.
+    const err = new Error('refresh failed')
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: false },
+        b: { data: undefined, isValidating: false, error: err },
+      },
+    })
+    expect(result.current.state).toBe('error')
+
+    // Error retained when revalidating.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: true },
+        b: { data: 'ok', isValidating: true },
+      },
+    })
+    expect(result.current.state).toBe('error')
+
+    // Loaded.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: false },
+        b: { data: 'ok', isValidating: false },
+      },
+    })
+    expect(result.current.state).toBe('loaded')
+
+    // Not found result.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: false },
+        b: { data: 'empty', isValidating: false },
+      },
+    })
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.state).toBe('notFound')
+
+    // Not found retained when revalidating.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: true },
+        b: { data: 'empty', isValidating: true },
+      },
+    })
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.state).toBe('notFound')
+  })
+})

--- a/libs/design-system/src/remoteData/useRemoteData.ts
+++ b/libs/design-system/src/remoteData/useRemoteData.ts
@@ -1,0 +1,133 @@
+'use client'
+
+import { useMemo, useRef } from 'react'
+import {
+  RemoteData,
+  Remote,
+  ValuesOf,
+  checkAnyLoading,
+  checkAnyValidating,
+  checkAnyHaveError,
+  checkAllHaveData,
+  getValues,
+} from './types'
+import { useStableRemotes } from './utils'
+
+export function useRemoteData<
+  Remotes extends Record<string, Remote<unknown>>,
+  O,
+>(
+  remotes: Remotes,
+  transform: (values: ValuesOf<Remotes>) => O,
+): RemoteData<O> {
+  const stableRemotes = useStableRemotes(remotes)
+  const currentState = useMemo(
+    () => deriveCurrentState(stableRemotes, transform),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [stableRemotes],
+  )
+  const prevBaseState = useRef<RemoteData<O> | undefined>(undefined)
+  return useMemo(() => {
+    if (prevBaseState.current?.state === currentState.state) {
+      return currentState
+    }
+    // If we are revalidating, and the previous state was an error or empty,
+    // continue to show the previous state until validation completes.
+    // This is to avoid a skeleton loader flickering between identical states.
+    if (currentState.isValidating && prevBaseState.current) {
+      if (prevBaseState.current.state === 'error') {
+        return {
+          state: 'error',
+          data: undefined,
+          error: prevBaseState.current.error,
+          isValidating: currentState.isValidating,
+          isLoading: currentState.isLoading,
+        }
+      }
+      if (prevBaseState.current.state === 'notFound') {
+        return {
+          state: 'notFound',
+          data: undefined,
+          isValidating: currentState.isValidating,
+          isLoading: currentState.isLoading,
+        }
+      }
+    }
+    prevBaseState.current = currentState
+    return currentState
+  }, [currentState])
+}
+
+function deriveCurrentState<Remotes extends Record<string, Remote<unknown>>, O>(
+  remotes: Remotes,
+  transform: (values: ValuesOf<Remotes>) => O,
+): RemoteData<O> {
+  const anyLoading = checkAnyLoading(remotes)
+  const anyRevalidating = checkAnyValidating(remotes)
+  const anyError = checkAnyHaveError(remotes)
+  const allData = checkAllHaveData(remotes)
+  const startState = !anyLoading && !anyRevalidating && !anyError && !allData
+
+  if (startState) {
+    return {
+      state: 'loading',
+      data: undefined,
+      isValidating: anyRevalidating,
+      isLoading: anyLoading,
+    }
+  }
+
+  if (anyLoading) {
+    return {
+      state: 'loading',
+      data: undefined,
+      isValidating: anyRevalidating,
+      isLoading: anyLoading,
+    }
+  }
+
+  if (anyError) {
+    return {
+      state: 'error',
+      data: undefined,
+      error: anyError,
+      isValidating: anyRevalidating,
+      isLoading: anyLoading,
+    }
+  }
+
+  if (allData) {
+    const data = transform(getValues(remotes))
+    if (data) {
+      return {
+        state: 'loaded',
+        data,
+        isValidating: anyRevalidating,
+        isLoading: anyLoading,
+      }
+    }
+    return {
+      state: 'notFound',
+      data: undefined,
+      isValidating: anyRevalidating,
+      isLoading: anyLoading,
+    }
+  }
+
+  if (anyRevalidating) {
+    return {
+      state: 'loading',
+      data: undefined,
+      isValidating: anyRevalidating,
+      isLoading: anyLoading,
+    }
+  }
+
+  // Should never reach here.
+  return {
+    state: 'error',
+    data: undefined,
+    isValidating: anyRevalidating,
+    isLoading: anyLoading,
+  }
+}

--- a/libs/design-system/src/remoteData/useRemoteDataset.spec.tsx
+++ b/libs/design-system/src/remoteData/useRemoteDataset.spec.tsx
@@ -1,0 +1,251 @@
+import { renderHook } from '@testing-library/react'
+import { type Remote } from './types'
+import { useRemoteDataset } from './useRemoteDataset'
+
+type Remotes = {
+  a: Remote<number>
+  b: Remote<number>
+}
+
+const transform = (values: { a: number; b: number }): number[] => {
+  if (values.a === 0 && values.b === 0) {
+    return []
+  }
+  return [values.a, values.b]
+}
+
+const defaultParams = {
+  offset: undefined,
+  filters: undefined,
+}
+
+describe('useRemoteDataset', () => {
+  test('returns loading when any dependency is loading initially', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { isLoading: true, data: 1, isValidating: true },
+          b: { data: 2, isLoading: false, isValidating: false },
+        },
+        transform,
+        defaultParams,
+      ),
+    )
+    expect(result.current.state).toBe('loading')
+  })
+
+  test('returns loaded when all dependencies have data with no errors', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 42, isValidating: false },
+          b: { data: 2, isValidating: false },
+        },
+        transform,
+        defaultParams,
+      ),
+    )
+    expect(result.current.state).toBe('loaded')
+    expect(result.current.data).toEqual([42, 2])
+    expect('error' in result.current).toBe(false)
+  })
+
+  test('returns loaded when revalidating with previous data present', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 1, isValidating: true },
+          b: { data: 2, isValidating: true },
+        },
+        transform,
+        defaultParams,
+      ),
+    )
+    expect(result.current.state).toBe('loaded')
+    expect(result.current.data).toEqual([1, 2])
+  })
+
+  test('returns error when any dependency has error', () => {
+    const err = new Error('fetch failed')
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 1, error: err, isValidating: false },
+          b: { data: 2, isValidating: false },
+        },
+        transform,
+        defaultParams,
+      ),
+    )
+    expect(result.current.state).toBe('error')
+    expect(result.current.data).toBeUndefined()
+    expect('error' in result.current && result.current.error).toBe(err)
+  })
+
+  test('returns loading when all fields are initial values (before initial loading starts)', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { isLoading: false, isValidating: false, data: undefined },
+          b: { isLoading: false, isValidating: false, data: undefined },
+        },
+        transform,
+        defaultParams,
+      ),
+    )
+    expect(result.current.state).toBe('loading')
+  })
+
+  test('empty result on the first page', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 0, isValidating: false },
+          b: { data: 0, isValidating: false },
+        },
+        transform,
+        defaultParams,
+      ),
+    )
+    expect(result.current.state).toBe('noneYet')
+  })
+
+  test('empty result on the first page with filters', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 0, isValidating: false },
+          b: { data: 0, isValidating: false },
+        },
+        transform,
+        {
+          offset: 0,
+          filters: [1],
+        },
+      ),
+    )
+    expect(result.current.state).toBe('noneMatchingFilters')
+  })
+
+  test('empty result not on the first page', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 0, isValidating: false },
+          b: { data: 0, isValidating: false },
+        },
+        transform,
+        { offset: 1 },
+      ),
+    )
+    expect(result.current.state).toBe('noneOnPage')
+  })
+
+  test('empty result not on the first page with filters', () => {
+    const { result } = renderHook(() =>
+      useRemoteDataset(
+        {
+          a: { data: 0, isValidating: false },
+          b: { data: 0, isValidating: false },
+        },
+        transform,
+        { offset: 1, filters: [1] },
+      ),
+    )
+    expect(result.current.state).toBe('noneOnPage')
+  })
+
+  test('state sequence', () => {
+    const { result, rerender } = renderHook(
+      ({ remotes }: { remotes: Remotes }) =>
+        useRemoteDataset(remotes, transform, defaultParams),
+      {
+        initialProps: {
+          remotes: {
+            a: { isLoading: true, isValidating: false, data: undefined },
+            b: { isLoading: false, isValidating: false, data: undefined },
+          } as Remotes,
+        },
+      },
+    )
+
+    // Pre initial loading.
+    expect(result.current.state).toBe('loading')
+
+    // Initial loading.
+    rerender({
+      remotes: {
+        a: { isLoading: true, isValidating: false, data: undefined },
+        b: { isLoading: false, isValidating: false, data: undefined },
+      },
+    })
+    expect(result.current.state).toBe('loading')
+
+    // Loaded.
+    rerender({
+      remotes: {
+        a: { isLoading: false, isValidating: false, data: 7 },
+        b: { isLoading: false, isValidating: false, data: 8 },
+      },
+    })
+    expect(result.current.state).toBe('loaded')
+    expect(result.current.data).toEqual([7, 8])
+
+    // Revalidating.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: true },
+        b: { data: 8, isValidating: true },
+      },
+    })
+    expect(result.current.state).toBe('loaded')
+
+    // Errored.
+    const err = new Error('refresh failed')
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: false },
+        b: { data: undefined, isValidating: false, error: err },
+      },
+    })
+    expect(result.current.state).toBe('error')
+
+    // Error retained when revalidating.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: true },
+        b: { data: 8, isValidating: true },
+      },
+    })
+    expect(result.current.state).toBe('error')
+
+    // Loaded.
+    rerender({
+      remotes: {
+        a: { data: 7, isValidating: false },
+        b: { data: 8, isValidating: false },
+      },
+    })
+    expect(result.current.state).toBe('loaded')
+
+    // None yet result.
+    rerender({
+      remotes: {
+        a: { data: 0, isValidating: false },
+        b: { data: 0, isValidating: false },
+      },
+    })
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.state).toBe('noneYet')
+
+    // None yet retained when revalidating.
+    rerender({
+      remotes: {
+        a: { data: 0, isValidating: true },
+        b: { data: 0, isValidating: true },
+      },
+    })
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.state).toBe('noneYet')
+  })
+})

--- a/libs/design-system/src/remoteData/useRemoteDataset.ts
+++ b/libs/design-system/src/remoteData/useRemoteDataset.ts
@@ -1,0 +1,208 @@
+'use client'
+
+import { useMemo, useRef } from 'react'
+import {
+  Remote,
+  ValuesOf,
+  checkAnyLoading,
+  checkAnyValidating,
+  checkAnyHaveError,
+  checkAllHaveData,
+  getValues,
+  RemoteDataset,
+} from './types'
+import { useStableFilters, useStableRemotes } from './utils'
+
+export function useRemoteDataset<
+  Remotes extends Record<string, Remote<unknown>>,
+  O,
+>(
+  remotes: Remotes,
+  transform: (values: ValuesOf<Remotes>) => O[],
+  {
+    marker,
+    offset,
+    filters,
+  }: {
+    marker?: string | null
+    offset?: number
+    filters?: unknown[]
+  },
+): RemoteDataset<O[]> {
+  const stableRemotes = useStableRemotes(remotes)
+  const stableFilters = useStableFilters(filters ?? [])
+  const currentState = useMemo(
+    () =>
+      deriveCurrentState(stableRemotes, transform, {
+        marker,
+        offset,
+        filters: stableFilters,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [stableRemotes, marker, offset, stableFilters],
+  )
+  const prevBaseState = useRef<RemoteDataset<O[]> | undefined>(undefined)
+  return useMemo(() => {
+    if (prevBaseState.current?.state === currentState.state) {
+      return currentState
+    }
+    // If we are revalidating, and the previous state was an error or empty,
+    // continue to show the previous state until validation completes.
+    // This is to avoid a skeleton loader flickering between identical states.
+    if (currentState.isValidating && prevBaseState.current) {
+      if (prevBaseState.current.state === 'error') {
+        return {
+          state: 'error',
+          data: undefined,
+          error: prevBaseState.current.error,
+          isValidating: currentState.isValidating,
+          isLoading: currentState.isLoading,
+        }
+      }
+      if (
+        prevBaseState.current.state === 'noneYet' ||
+        prevBaseState.current.state === 'noneMatchingFilters' ||
+        prevBaseState.current.state === 'noneOnPage'
+      ) {
+        return {
+          state: prevBaseState.current.state,
+          data: undefined,
+          isValidating: currentState.isValidating,
+          isLoading: currentState.isLoading,
+        }
+      }
+    }
+    prevBaseState.current = currentState
+    return currentState
+  }, [currentState])
+}
+
+function deriveCurrentState<Remotes extends Record<string, Remote<unknown>>, O>(
+  remotes: Remotes,
+  transform: (values: ValuesOf<Remotes>) => O[],
+  {
+    marker,
+    offset,
+    filters,
+  }: {
+    marker?: string | null
+    offset?: number
+    filters?: unknown[]
+  },
+): RemoteDataset<O[]> {
+  const anyLoading = checkAnyLoading(remotes)
+  const anyRevalidating = checkAnyValidating(remotes)
+  const anyError = checkAnyHaveError(remotes)
+  const allData = checkAllHaveData(remotes)
+  const startState = !anyLoading && !anyRevalidating && !anyError && !allData
+
+  if (startState) {
+    return {
+      state: 'loading',
+      data: undefined,
+      isLoading: anyLoading,
+      isValidating: anyRevalidating,
+    }
+  }
+
+  if (anyLoading) {
+    return {
+      state: 'loading',
+      data: undefined,
+      isLoading: anyLoading,
+      isValidating: anyRevalidating,
+    }
+  }
+
+  if (anyError) {
+    return {
+      state: 'error',
+      data: undefined,
+      error: anyError,
+      isLoading: anyLoading,
+      isValidating: anyRevalidating,
+    }
+  }
+
+  if (allData) {
+    const data = transform(getValues(remotes))
+    if (data.length > 0) {
+      return {
+        state: 'loaded',
+        data,
+        isLoading: anyLoading,
+        isValidating: anyRevalidating,
+      }
+    }
+    return {
+      state: getEmptyState({ offset, marker, filters }),
+      data: undefined,
+      isLoading: anyLoading,
+      isValidating: anyRevalidating,
+    }
+  }
+
+  if (anyRevalidating) {
+    return {
+      state: 'loading',
+      data: undefined,
+      isLoading: anyLoading,
+      isValidating: anyRevalidating,
+    }
+  }
+
+  // Should never reach here.
+  return {
+    state: 'error',
+    data: undefined,
+    isLoading: anyLoading,
+    isValidating: anyRevalidating,
+  }
+}
+
+function getIsOnFirstPage({
+  offset,
+  marker,
+}: {
+  offset?: number
+  marker?: string | null
+}): boolean {
+  // If marker is undefined it is not in use.
+  if (marker !== undefined) {
+    // Page marker.
+    if (marker) {
+      return false
+    }
+    // If marker is null, its the first page.
+    if (marker === null) {
+      return true
+    }
+  }
+  // If both marker and offset are undefined, there is no paging.
+  if (offset === undefined) {
+    return true
+  }
+  // Offset based pagination.
+  if (offset > 0) {
+    return false
+  }
+  return true
+}
+
+function getEmptyState({
+  offset,
+  marker,
+  filters,
+}: {
+  offset?: number
+  marker?: string | null
+  filters?: unknown[]
+}): 'noneOnPage' | 'noneYet' | 'noneMatchingFilters' {
+  if (!getIsOnFirstPage({ offset, marker })) {
+    return 'noneOnPage'
+  }
+  if (!filters || filters.length === 0) {
+    return 'noneYet'
+  }
+  return 'noneMatchingFilters'
+}

--- a/libs/design-system/src/remoteData/utils.ts
+++ b/libs/design-system/src/remoteData/utils.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useStableArrayBy, useStableObjectBy } from '../hooks/useStableCompare'
+
+// Stable compare remotes in case the caller is not memoizing the prop.
+export function useStableRemotes<
+  Remotes extends Record<
+    string,
+    { data: unknown; isLoading?: boolean; isValidating: boolean }
+  >,
+>(remotes: Remotes): Remotes {
+  return useStableObjectBy(remotes, (a, b) => {
+    const av = a as {
+      data: unknown
+      isLoading?: boolean
+      isValidating: boolean
+    }
+    const bv = b as {
+      data: unknown
+      isLoading?: boolean
+      isValidating: boolean
+    }
+    return (
+      av.data === bv.data &&
+      (av.isLoading ?? false) === (bv.isLoading ?? false) &&
+      av.isValidating === bv.isValidating
+    )
+  })
+}
+
+// Stable compare filters in case the caller is not memoizing the prop.
+export function useStableFilters(filters: unknown[]) {
+  return useStableArrayBy(filters)
+}


### PR DESCRIPTION
- Adds remote data and dataset hooks and components.
- These helpers allow fetching data from one or more sources and transforming it into one result.
- The result covers all loading states and factors in previous states when deciding which state the UI should display, eg: after an error or empty state revalidating the same data retains that state rather than flickering to a loading state.
- example usage:

```
const dataset = useRemoteDataset(
  {
    sourceA, // { isLoading, isValidating, data, error }
    sourceB, // { isLoading, isValidating, data, error }
  },
  ({ sourceA, sourceB }) => results, // transform successfully loaded remote sources
  {
    offset,
    filters,
  }
)  // DataLoaded<O> | DataLoading | DataError | DataEmptyNoneYet | DataEmptyNoneMatchingFilters | DataEmptyNoneOnPage

<RemoteDatasetStates
  dataset={dataset}
  loaded={...}
  error{...}
  noneYet={...}
  nonMatchingFilters={...}
  loading={...}
/>
```

