### PR TITLE
feat(indexd): sector and account stats

### DIFF
--- a/.changeset/honest-monkeys-find.md
+++ b/.changeset/honest-monkeys-find.md
@@ -1,0 +1,5 @@
+---
+'indexd': minor
+---
+
+The metrics page now includes more sector and account stats.

--- a/.changeset/stupid-geese-strive.md
+++ b/.changeset/stupid-geese-strive.md
@@ -1,0 +1,7 @@
+---
+'@siafoundation/indexd-react': minor
+'@siafoundation/indexd-types': minor
+'@siafoundation/indexd-js': minor
+---
+
+Added new sector and account stats APIs.

--- a/apps/indexd/components/Metrics/index.tsx
+++ b/apps/indexd/components/Metrics/index.tsx
@@ -1,26 +1,91 @@
-import { Warning32 } from '@siafoundation/react-icons'
-import { DatumCard, Text } from '@siafoundation/design-system'
-import { useAdminStatsSectors } from '@siafoundation/indexd-react'
+import {
+  DatumCard,
+  RemoteDataStates,
+  StateError,
+  StateNoneYet,
+  useRemoteData,
+  Skeleton,
+} from '@siafoundation/design-system'
+import {
+  useAdminStatsSectors,
+  useAdminStatsAccounts,
+} from '@siafoundation/indexd-react'
 
 export function Metrics() {
-  const state = useAdminStatsSectors()
+  const sectors = useAdminStatsSectors()
+  const accounts = useAdminStatsAccounts()
+  const stats = useRemoteData(
+    {
+      sectors,
+      accounts,
+    },
+    (data) => ({
+      ...data.sectors,
+      ...data.accounts,
+    }),
+  )
   return (
     <div className="flex flex-col gap-5 p-5">
-      {state.error ? (
-        <div className="flex flex-col gap-6 items-center justify-center pt-[100px]">
-          <Warning32 className="scale-150" />
-          <Text size="20" color="subtle">
-            Error loading stats
-          </Text>
-        </div>
-      ) : (
-        <div className="flex flex-wrap gap-7">
-          <DatumCard
-            label="Slabs"
-            value={state.data?.numSlabs?.toLocaleString()}
-          />
-        </div>
-      )}
+      <RemoteDataStates
+        data={stats}
+        error={
+          <StateError message="Error loading metrics. Please try again later." />
+        }
+        loading={
+          <div className="flex flex-wrap gap-7">
+            <DatumCard
+              label="Slabs"
+              value={<Skeleton className="h-12 w-[150px]" />}
+            />
+            <DatumCard
+              label="Migrated Sectors"
+              value={<Skeleton className="h-12 w-[150px]" />}
+            />
+            <DatumCard
+              label="Pinned Sectors"
+              value={<Skeleton className="h-12 w-[150px]" />}
+            />
+            <DatumCard
+              label="Unpinnable Sectors"
+              value={<Skeleton className="h-12 w-[150px]" />}
+            />
+            <DatumCard
+              label="Unpinned Sectors"
+              value={<Skeleton className="h-12 w-[150px]" />}
+            />
+            <DatumCard
+              label="Registered Accounts"
+              value={<Skeleton className="h-12 w-[150px]" />}
+            />
+          </div>
+        }
+        notFound={<StateNoneYet message="No metrics found." />}
+        loaded={(stats) => (
+          <div className="flex flex-wrap gap-7">
+            <DatumCard label="Slabs" value={stats.numSlabs.toLocaleString()} />
+            <DatumCard
+              label="Migrated Sectors"
+              value={stats.numMigratedSectors.toLocaleString()}
+            />
+            <DatumCard
+              label="Pinned Sectors"
+              value={stats.numPinnedSectors.toLocaleString()}
+            />
+            <DatumCard
+              label="Unpinnable Sectors"
+              value={stats.numUnpinnableSectors.toLocaleString()}
+            />
+            <DatumCard
+              label="Unpinned Sectors"
+              value={stats.numUnpinnedSectors.toLocaleString()}
+            />
+            <DatumCard
+              label="Registered Accounts"
+              value={stats.registered.toLocaleString()}
+            />
+          </div>
+        )}
+      />
     </div>
   )
 }

--- a/libs/indexd-js/src/admin.ts
+++ b/libs/indexd-js/src/admin.ts
@@ -133,6 +133,10 @@ import {
   AdminConnectKeyPayload,
   AdminConnectKeyResponse,
   adminConnectKeyRoute,
+  adminStatsAccountsRoute,
+  AdminStatsAccountsResponse,
+  AdminStatsAccountsPayload,
+  AdminStatsAccountsParams,
 } from '@siafoundation/indexd-types'
 import { buildRequestHandler, initAxios } from '@siafoundation/request'
 
@@ -310,5 +314,10 @@ export function Admin({ api, password }: { api: string; password?: string }) {
       AdminStatsSectorsPayload,
       AdminStatsSectorsResponse
     >(axios, 'get', adminStatsSectorsRoute),
+    statsAccounts: buildRequestHandler<
+      AdminStatsAccountsParams,
+      AdminStatsAccountsPayload,
+      AdminStatsAccountsResponse
+    >(axios, 'get', adminStatsAccountsRoute),
   }
 }

--- a/libs/indexd-react/src/admin.ts
+++ b/libs/indexd-react/src/admin.ts
@@ -122,6 +122,9 @@ import {
   AdminConnectKeyParams,
   AdminConnectKeyResponse,
   adminConnectKeyRoute,
+  adminStatsAccountsRoute,
+  AdminStatsAccountsParams,
+  AdminStatsAccountsResponse,
 } from '@siafoundation/indexd-types'
 import useSWR from 'swr'
 import {
@@ -550,5 +553,14 @@ export function useAdminStatsSectors(
   return useGetSwr({
     ...args,
     route: adminStatsSectorsRoute,
+  })
+}
+
+export function useAdminStatsAccounts(
+  args?: HookArgsSwr<AdminStatsAccountsParams, AdminStatsAccountsResponse>,
+) {
+  return useGetSwr({
+    ...args,
+    route: adminStatsAccountsRoute,
   })
 }

--- a/libs/indexd-types/src/admin/index.ts
+++ b/libs/indexd-types/src/admin/index.ts
@@ -283,4 +283,15 @@ export type AdminStatsSectorsParams = void
 export type AdminStatsSectorsPayload = void
 export type AdminStatsSectorsResponse = {
   numSlabs: number
+  numMigratedSectors: number
+  numPinnedSectors: number
+  numUnpinnableSectors: number
+  numUnpinnedSectors: number
+}
+
+export const adminStatsAccountsRoute = '/stats/accounts'
+export type AdminStatsAccountsParams = void
+export type AdminStatsAccountsPayload = void
+export type AdminStatsAccountsResponse = {
+  registered: number
 }


### PR DESCRIPTION
- The metrics page now includes more sector and account stats.
<img width="1469" height="550" alt="Screenshot 2025-09-23 at 11 00 32 AM" src="https://github.com/user-attachments/assets/b4cbe2fc-c5f3-4326-9126-b6456b72d79a" />
<img width="1286" height="519" alt="Screenshot 2025-09-23 at 10 59 37 AM" src="https://github.com/user-attachments/assets/b56fc3f2-85f9-4ab5-9282-303fd7ffc9fe" />
<img width="1468" height="572" alt="Screenshot 2025-09-23 at 10 59 56 AM" src="https://github.com/user-attachments/assets/b9d63760-50f4-451e-942d-f8e8243c587d" />
