### PR TITLE
fix(hostd): suggested max collateral

### DIFF
--- a/.changeset/wild-geckos-beam.md
+++ b/.changeset/wild-geckos-beam.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+The suggested max collateral value has been updated to configured storage price * collateral multiplier * 10.

--- a/apps/hostd-e2e/src/specs/config.spec.ts
+++ b/apps/hostd-e2e/src/specs/config.spec.ts
@@ -85,7 +85,7 @@ test('dynamic max collateral suggestion', async ({ page }) => {
     page
       .getByTestId('maxCollateralGroup')
       .getByLabel('Suggestion')
-      .getByText('60 SC'),
+      .getByText('600 SC'),
   ).toBeVisible()
 
   // Set all values that affect the max collateral calculation.
@@ -95,6 +95,6 @@ test('dynamic max collateral suggestion', async ({ page }) => {
     page
       .getByTestId('maxCollateralGroup')
       .getByLabel('Suggestion')
-      .getByText('300 SC'),
+      .getByText('3,000 SC'),
   ).toBeVisible()
 })

--- a/apps/hostd/contexts/config/fields.tsx
+++ b/apps/hostd/contexts/config/fields.tsx
@@ -332,7 +332,8 @@ export function getFields({
         <>
           The host's maximum collateral. Choose whether to set your max
           collateral price in siacoin or to pin the max collateral to a fixed
-          fiat value.
+          fiat value. The suggested value for max collateral is the configured
+          storage price * collateral multiplier * 10.
         </>
       ),
       type: 'siacoin',
@@ -340,10 +341,10 @@ export function getFields({
       decimalsLimitSc: scDecimalPlaces,
       suggestion:
         storageTBMonth && collateralMultiplier
-          ? calculateMaxCollateral(storageTBMonth, collateralMultiplier)
+          ? calculateMaxCollateral(storageTBMonth, collateralMultiplier, 10)
           : undefined,
       suggestionTip:
-        'The suggested maximum collateral, calculated based on the configured storage price and collateral multiplier.',
+        'The suggested maximum collateral, which is the configured storage price * collateral multiplier * 10.',
       validation: {
         required: 'required',
       },

--- a/apps/hostd/contexts/config/transform.spec.ts
+++ b/apps/hostd/contexts/config/transform.spec.ts
@@ -268,7 +268,7 @@ describe('data transforms', () => {
 
   it('max collateral', () => {
     expect(
-      calculateMaxCollateral(new BigNumber('400'), new BigNumber(2)),
-    ).toEqual(new BigNumber('2400'))
+      calculateMaxCollateral(new BigNumber('400'), new BigNumber(2), 10),
+    ).toEqual(new BigNumber('24000'))
   })
 })

--- a/apps/hostd/contexts/config/transform.ts
+++ b/apps/hostd/contexts/config/transform.ts
@@ -281,9 +281,17 @@ export function transformDown({
   }
 }
 
+/**
+ * Calculates the max collateral based on the storage price, collateral multiplier, and factor.
+ * @param storage - The storage price.
+ * @param collateralMultiplier - The collateral multiplier.
+ * @param factor - The factor which defaults to 10. The suggested value can be found in the documentation: https://docs.sia.tech/provide-storage/configuring-your-host#pricing.
+ * @returns The max collateral.
+ */
 export function calculateMaxCollateral(
   storage: BigNumber,
   collateralMultiplier: BigNumber,
+  factor = 10,
 ) {
   if (!storage || !collateralMultiplier) {
     return new BigNumber(0)
@@ -295,4 +303,5 @@ export function calculateMaxCollateral(
     .times(storage)
     .div(monthsToBlocks(1))
     .times(collateralMultiplier)
+    .times(factor)
 }

--- a/apps/hostd/next-env.d.ts
+++ b/apps/hostd/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
- The suggested max collateral value has been updated to configured storage price * collateral multiplier * 10. This aligns the UI with the docs: https://docs.sia.tech/provide-storage/configuring-your-host#pricing