### PR TITLE
ci: pin GitHub Actions to SHA-256 commits

### DIFF
--- a/.github/workflows/e2e-merge-reports.yml
+++ b/.github/workflows/e2e-merge-reports.yml
@@ -15,12 +15,12 @@ jobs:
   merge-reports:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.2.18
       - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ inputs.project }}-blob-reports
           pattern: ${{ inputs.project }}-blob-report-*
@@ -38,7 +38,7 @@ jobs:
           fi
       - name: Upload HTML report
         if: ${{ steps.merge.outputs.continue == 'true' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ inputs.project }}-html-report--attempt-${{ github.run_attempt }}
           path: playwright-report

--- a/.github/workflows/e2e-shard-tests.yml
+++ b/.github/workflows/e2e-shard-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       # Full setup required since building the JS SDK requires Go.
@@ -52,7 +52,7 @@ jobs:
         run: nx run ${{ inputs.project }}:e2e --shard=${{ inputs.shardIndex }}/${{ inputs.shardTotal }}
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ steps.check.outputs.continue == 'true' && !cancelled() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ inputs.project }}-blob-report-${{ inputs.shardIndex }}
           path: blob-report

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       # Full setup required since building the JS SDK requires Go
@@ -60,7 +60,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Setup Git
@@ -71,12 +71,12 @@ jobs:
         with:
           go_version: 1.24.3
       - name: Lint Go
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
         with:
           working-directory: ${{ matrix.module }}
           skip-cache: true
       - name: Test Go
-        uses: n8maninger/action-golang-test@v2
+        uses: n8maninger/action-golang-test@aa292dc81b16d34406a9551e629e0cdca00d9418 # v2.2.1
         with:
           args: '-race'
           working-directory: ${{ matrix.module }}

--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -13,5 +13,5 @@ on:
 
 jobs:
   add-to-project:
-    uses: SiaFoundation/workflows/.github/workflows/project-add.yml@master
+    uses: SiaFoundation/workflows/.github/workflows/project-add.yml@22e56c0750c0febb09784caa01c60021e0b5f111 # master
     secrets: inherit

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Overwrite .npmrc with NPM token
@@ -50,7 +50,7 @@ jobs:
         run: ./scripts/replace-src-with-dists-for-publishing.sh
       - name: Publish beta prerelease to NPM and GitHub
         if: steps.check_pre.outputs.run == 'true'
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: bunx changeset publish
         env:

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Setup
@@ -40,7 +40,7 @@ jobs:
       # this step will be skipped because no publish script is specified.
       - name: Update release pull request
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           commit: 'chore: release packages'
           version: bun run version
@@ -54,7 +54,7 @@ jobs:
       - name: Publish to NPM and create GitHub releases
         id: changesets_release
         if: steps.changesets.outputs.hasChangesets == 'false'
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: bun run release
         env:
@@ -62,7 +62,7 @@ jobs:
       - name: Release Go modules
         # If a release was published, release the Go modules
         if: steps.changesets_release.outputs.published == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}
           repository: siafoundation/web
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Setup
@@ -79,8 +79,8 @@ jobs:
         with:
           bun_version: 1.2.18
           go_version: 1.24.3
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Setup
@@ -137,7 +137,7 @@ jobs:
         module: [./renterd, ./hostd, ./walletd, ./indexd]
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Setup Git
@@ -148,12 +148,12 @@ jobs:
         with:
           go_version: 1.24.3
       - name: Lint Go
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
         with:
           working-directory: ${{ matrix.module }}
           skip-cache: true
       - name: Test Go
-        uses: n8maninger/action-golang-test@v2
+        uses: n8maninger/action-golang-test@aa292dc81b16d34406a9551e629e0cdca00d9418 # v2.2.1
         with:
           args: '-race'
           working-directory: ${{ matrix.module }}

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Overwrite .npmrc with NPM token
@@ -44,7 +44,7 @@ jobs:
       # Check for and publish any new versions to NPM.
       - name: Publish to NPM and create GitHub releases
         id: changesets_release
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           publish: bun run release
         env:
@@ -53,7 +53,7 @@ jobs:
       - name: Release Go modules
         # If a release was published, release the Go modules
         if: steps.changesets_release.outputs.published == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.PAT_REPOSITORY_DISPATCH }}
           repository: siafoundation/web
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout all commits
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Setup
@@ -70,8 +70,8 @@ jobs:
         with:
           bun_version: 1.2.18
           go_version: 1.24.3
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary
- Pin every `uses:` reference in workflows to a specific commit SHA
- Each pin is annotated with the corresponding version tag in a trailing comment
- Versions stay within the existing major (e.g. `@v4` → latest v4.x.y SHA) to avoid breaking changes

## Why
Mitigates supply-chain attacks where a tag could be retargeted to malicious code. Pinning to a SHA is the [recommended hardening practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Notes for reviewers
- Annotated tags resolve to the underlying commit SHA (not the tag object)
- For `SiaFoundation/workflows@master` and `dtolnay/rust-toolchain@stable|nightly` (which use a branch ref intentionally), the pin uses the current branch tip SHA — future updates will require a follow-up PR
- This PR was generated by tooling; please skim each workflow diff
