### PR TITLE
fix(explorer): use selected currency for exchange rate fallback

### DIFF
--- a/.changeset/olive-poems-shake.md
+++ b/.changeset/olive-poems-shake.md
@@ -1,0 +1,5 @@
+---
+'explorer': patch
+---
+
+Fixed the server-rendered exchange rate showing a USD value when a different currency was selected.

--- a/apps/explorer/lib/fallback.ts
+++ b/apps/explorer/lib/fallback.ts
@@ -10,7 +10,7 @@ import { getExplored } from './explored'
 export async function buildFallbackDataExchangeRate(currency: CurrencyID) {
   const explored = await getExplored()
   const { data: rate } = await explored.exchangeRate({
-    params: { currency: 'usd' },
+    params: { currency },
   })
   return {
     // Hooks build with react-core have keys of the form:


### PR DESCRIPTION
I think this is just an oversight on the "fallback" language. A user preferring EUR would see the USD exchange rate number next to the pound icon until it resolved. I believe this cleans that up but would appreciate a good eye towards whether I'm categorizing the issue correctly.